### PR TITLE
Remove old UTM references (including ws_pricing)

### DIFF
--- a/src/app/(website)/blog/(sub-pages)/layout.tsx
+++ b/src/app/(website)/blog/(sub-pages)/layout.tsx
@@ -65,7 +65,7 @@ export default async function BlogPagesLayout({
           {
             kind: "primary-button",
             label: "Get started",
-            href: `${ROUTE.dashboard}?utm_campaign=gs-website-inbox`,
+            href: ROUTE.dashboard,
           },
           {
             kind: "secondary-button",

--- a/src/app/(website)/blog/[slug]/page.tsx
+++ b/src/app/(website)/blog/[slug]/page.tsx
@@ -82,7 +82,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
           {
             kind: "primary-button",
             label: "Get started",
-            href: `${ROUTE.dashboard}?utm_campaign=gs-website-inbox`,
+            href: ROUTE.dashboard,
           },
           {
             kind: "secondary-button",

--- a/src/app/(website)/blog/page.tsx
+++ b/src/app/(website)/blog/page.tsx
@@ -133,7 +133,7 @@ export default async function BlogPage() {
           {
             kind: "primary-button",
             label: "Get started",
-            href: `${ROUTE.dashboard}?utm_campaign=gs-website-inbox`,
+            href: ROUTE.dashboard,
           },
           {
             kind: "secondary-button",

--- a/src/app/(website)/changelog/page.tsx
+++ b/src/app/(website)/changelog/page.tsx
@@ -84,7 +84,7 @@ export default async function ChangelogPage({
           {
             kind: "primary-button",
             label: "Get started",
-            href: `${ROUTE.dashboard}?utm_campaign=gs-website-inbox`,
+            href: ROUTE.dashboard,
           },
           {
             kind: "secondary-button",

--- a/src/app/(website)/customers/[slug]/page.tsx
+++ b/src/app/(website)/customers/[slug]/page.tsx
@@ -203,7 +203,7 @@ export default async function CustomerStoryPage({
           {
             kind: "primary-button",
             label: "Get started",
-            href: `${ROUTE.dashboard}?utm_campaign=gs-website-inbox`,
+            href: ROUTE.dashboard,
           },
           {
             kind: "secondary-button",

--- a/src/app/(website)/customers/page.tsx
+++ b/src/app/(website)/customers/page.tsx
@@ -98,7 +98,7 @@ export default async function CustomersPage() {
           {
             kind: "primary-button",
             label: "Get started",
-            href: `${ROUTE.dashboard}?utm_campaign=gs-website-inbox`,
+            href: ROUTE.dashboard,
           },
           {
             kind: "secondary-button",

--- a/src/data/pages/pricing/index.tsx
+++ b/src/data/pages/pricing/index.tsx
@@ -35,7 +35,10 @@ import logoUnops from "@/images/pages/pricing/logos/unops.svg"
 import logoWaltonEnterprises from "@/images/pages/pricing/logos/walton-enterprises.svg"
 import logoWhoppah from "@/images/pages/pricing/logos/whoppah.svg"
 
+import { ROUTE } from "@/constants/routes"
 import type { IPricingPageData } from "@/types/pricing"
+
+const dashboardSignUpWithUtm = `${ROUTE.dashboardV2SignUp}?utm_campaign=gs-website-inbox`
 
 const renderScheduleCallButton = (
   onScheduleClick: (source: string) => void
@@ -287,7 +290,7 @@ export const pricingPageData: IPricingPageData = {
         extraInfo: "No credit card required",
         isFeatured: false,
         link: {
-          href: "https://dashboard.novu.co/auth/sign-up?utm_campaign=ws_pricing",
+          href: dashboardSignUpWithUtm,
           isExternal: true,
           text: "Get started",
         },
@@ -319,7 +322,7 @@ export const pricingPageData: IPricingPageData = {
         ),
         isFeatured: true,
         link: {
-          href: "https://dashboard.novu.co/auth/sign-up?utm_campaign=ws_pricing",
+          href: dashboardSignUpWithUtm,
           isExternal: true,
           text: "Get started",
         },
@@ -354,7 +357,7 @@ export const pricingPageData: IPricingPageData = {
         ),
         isFeatured: false,
         link: {
-          href: "https://dashboard.novu.co/auth/sign-up?utm_campaign=ws_pricing",
+          href: dashboardSignUpWithUtm,
           isExternal: true,
           text: "Get started",
         },
@@ -393,7 +396,7 @@ export const pricingPageData: IPricingPageData = {
         ),
         isFeatured: false,
         link: {
-          href: "https://novu.co/contact-us/?utm_campaign=ws_pricing",
+          href: "/contact-us",
           isExternal: false,
           text: "Contact us",
         },
@@ -454,7 +457,7 @@ export const pricingPageData: IPricingPageData = {
   pageCta: {
     actions: [
       {
-        href: "https://dashboard.novu.co/?utm_campaign=gs-website-inbox",
+        href: `${ROUTE.dashboard}?utm_campaign=gs-website-inbox`,
         label: "Get started",
         kind: "primary-button",
       },
@@ -472,24 +475,21 @@ export const pricingPageData: IPricingPageData = {
     headings: [
       {
         buttonText: "Get started",
-        buttonUrl:
-          "https://dashboard.novu.co/auth/sign-up?utm_campaign=ws_pricing_table_free",
+        buttonUrl: dashboardSignUpWithUtm,
         id: "free",
         label: "Free",
         isFeatured: false,
       },
       {
         buttonText: "Get started",
-        buttonUrl:
-          "https://dashboard.novu.co/auth/sign-up?utm_campaign=ws_pricing_table_pro",
+        buttonUrl: dashboardSignUpWithUtm,
         id: "pro",
         isFeatured: true,
         label: "Pro",
       },
       {
         buttonText: "Get started",
-        buttonUrl:
-          "https://dashboard.novu.co/auth/sign-up?utm_campaign=ws_pricing_table_team",
+        buttonUrl: dashboardSignUpWithUtm,
         id: "team",
         label: "Team",
         isFeatured: false,

--- a/src/data/pages/pricing/index.tsx
+++ b/src/data/pages/pricing/index.tsx
@@ -38,8 +38,6 @@ import logoWhoppah from "@/images/pages/pricing/logos/whoppah.svg"
 import { ROUTE } from "@/constants/routes"
 import type { IPricingPageData } from "@/types/pricing"
 
-const dashboardSignUpWithUtm = `${ROUTE.dashboardV2SignUp}?utm_campaign=gs-website-inbox`
-
 const renderScheduleCallButton = (
   onScheduleClick: (source: string) => void
 ) => (
@@ -290,7 +288,7 @@ export const pricingPageData: IPricingPageData = {
         extraInfo: "No credit card required",
         isFeatured: false,
         link: {
-          href: dashboardSignUpWithUtm,
+          href: ROUTE.dashboardV2SignUp,
           isExternal: true,
           text: "Get started",
         },
@@ -322,7 +320,7 @@ export const pricingPageData: IPricingPageData = {
         ),
         isFeatured: true,
         link: {
-          href: dashboardSignUpWithUtm,
+          href: ROUTE.dashboardV2SignUp,
           isExternal: true,
           text: "Get started",
         },
@@ -357,7 +355,7 @@ export const pricingPageData: IPricingPageData = {
         ),
         isFeatured: false,
         link: {
-          href: dashboardSignUpWithUtm,
+          href: ROUTE.dashboardV2SignUp,
           isExternal: true,
           text: "Get started",
         },
@@ -457,7 +455,7 @@ export const pricingPageData: IPricingPageData = {
   pageCta: {
     actions: [
       {
-        href: `${ROUTE.dashboard}?utm_campaign=gs-website-inbox`,
+        href: ROUTE.dashboard,
         label: "Get started",
         kind: "primary-button",
       },
@@ -475,21 +473,21 @@ export const pricingPageData: IPricingPageData = {
     headings: [
       {
         buttonText: "Get started",
-        buttonUrl: dashboardSignUpWithUtm,
+        buttonUrl: ROUTE.dashboardV2SignUp,
         id: "free",
         label: "Free",
         isFeatured: false,
       },
       {
         buttonText: "Get started",
-        buttonUrl: dashboardSignUpWithUtm,
+        buttonUrl: ROUTE.dashboardV2SignUp,
         id: "pro",
         isFeatured: true,
         label: "Pro",
       },
       {
         buttonText: "Get started",
-        buttonUrl: dashboardSignUpWithUtm,
+        buttonUrl: ROUTE.dashboardV2SignUp,
         id: "team",
         label: "Team",
         isFeatured: false,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes legacy UTM campaign parameters from marketing links: `ws_pricing` / `ws_pricing_table_*` on pricing, and **`gs-website-inbox`** on dashboard CTAs across blog, changelog, customers, and pricing.

## Changes

- **Pricing**: Hero sign-up and comparison table use `ROUTE.dashboardV2SignUp` with no query string; page CTA uses `ROUTE.dashboard` only; Enterprise contact uses `/contact-us`.
- **Blog** (index, slug, sub-layout), **changelog**, **customers** (index + slug): “Get started” CTA uses `ROUTE.dashboard` with no UTM.

## Notes

Other UTMs (e.g. `utm_campaign=website` on social/docs, `pricing_contact`, `pricing-widget-self-host`) were not part of this cleanup.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1774528501158539?thread_ts=1774528501.158539&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-3645b0ab-54be-5025-bd87-089a633484d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3645b0ab-54be-5025-bd87-089a633484d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated navigation links across blog, changelog, pricing, and customer pages to use centralized routing throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->