### PR TITLE
fix: forward UTM params from landing pages to signup links

### DIFF
--- a/docs/cta-tracking-conventions.md
+++ b/docs/cta-tracking-conventions.md
@@ -113,9 +113,11 @@ Components pass the values through as data attributes on the `<a>` / `<NextLink>
 
 The attributes are optional — if not provided, they simply won't render on the element. Existing pages won't break.
 
-## Do NOT use UTM parameters on internal links
+## Do NOT hardcode UTM parameters on internal links
 
-**Bad:**
+Adding hardcoded UTMs like `utm_source=internal` to CTA links causes Google Analytics to start a new session and overwrite the user's original acquisition source (e.g. a paid Google Ads click). Use `data-` attributes for internal click tracking instead.
+
+**Bad -- hardcoded internal UTMs that overwrite acquisition attribution:**
 
 ```html
 <a
@@ -125,7 +127,7 @@ The attributes are optional — if not provided, they simply won't render on the
 </a>
 ```
 
-**Good:**
+**Good -- data attributes for click tracking, no UTMs in the href:**
 
 ```html
 <a
@@ -136,6 +138,14 @@ The attributes are optional — if not provided, they simply won't render on the
   Start for Free
 </a>
 ```
+
+## Acquisition UTM forwarding (UtmForwarder component)
+
+The `UtmForwarder` component (`src/components/utm-forwarder.tsx`) automatically forwards the visitor's **original acquisition UTMs** (from the URL they landed on, e.g. from a Google Ad) to dashboard.novu.co links. This is different from hardcoding internal UTMs -- it preserves the original paid campaign attribution through to signup.
+
+- It only appends params that are NOT already present on the link
+- It only targets links where `url.hostname === "dashboard.novu.co"`
+- It reads from `sessionStorage`, so only params from the user's actual landing are forwarded
 
 ## Supported Components
 

--- a/src/app/(website)/layout.tsx
+++ b/src/app/(website)/layout.tsx
@@ -11,6 +11,7 @@ import Fonts from "@/components/fonts"
 import Footer from "@/components/footer"
 import Header from "@/components/header"
 import MixpanelTracking from "@/components/mixpanel-tracking"
+import UtmForwarder from "@/components/utm-forwarder"
 import PreviewWarning from "@/components/preview-warning"
 import Scripts, { GTM_ID } from "@/components/scripts"
 
@@ -43,6 +44,7 @@ export default async function RootLayout({
         className={`${inter.variable} flex min-h-svh flex-col bg-background font-sans antialiased`}
       >
         <MixpanelTracking />
+        <UtmForwarder />
         <Providers>
           <div
             className="flex grow flex-col rounded-none bg-background aria-hidden:[-webkit-mask-image:-webkit-radial-gradient(white,black)]"

--- a/src/components/utm-forwarder.tsx
+++ b/src/components/utm-forwarder.tsx
@@ -1,19 +1,10 @@
 "use client"
 
-import { useEffect } from "react"
+import { Suspense, useEffect } from "react"
 import { usePathname, useSearchParams } from "next/navigation"
 
-const UTM_PARAMS = [
-  "utm_source",
-  "utm_medium",
-  "utm_campaign",
-  "utm_content",
-  "utm_term",
-  "gclid",
-  "fbclid",
-  "ttclid",
-  "wbraid",
-]
+import { TRACKING_PARAMS } from "@/constants/forms"
+
 const SIGNUP_HOST = "dashboard.novu.co"
 const STORAGE_KEY = "novu_utm_params"
 
@@ -26,20 +17,27 @@ function getStoredUtmParams(): Record<string, string> {
   }
 }
 
-function UtmForwarder() {
+function UtmForwarderInner() {
   const pathname = usePathname()
   const searchParams = useSearchParams()
 
   useEffect(() => {
     const utms: Record<string, string> = {}
-    UTM_PARAMS.forEach((key) => {
+    TRACKING_PARAMS.forEach((key) => {
       const value = searchParams.get(key)
       if (value) utms[key] = value
     })
 
     if (Object.keys(utms).length > 0) {
       try {
-        sessionStorage.setItem(STORAGE_KEY, JSON.stringify(utms))
+        const existing = getStoredUtmParams()
+        const merged = { ...existing, ...utms }
+        sessionStorage.setItem(STORAGE_KEY, JSON.stringify(merged))
+
+        // Also write individual keys for compatibility with subscription-form.tsx
+        Object.entries(merged).forEach(([key, value]) => {
+          sessionStorage.setItem(key, value)
+        })
       } catch {
         // sessionStorage unavailable
       }
@@ -50,24 +48,29 @@ function UtmForwarder() {
     const utms = getStoredUtmParams()
     if (Object.keys(utms).length === 0) return
 
-    document
-      .querySelectorAll<HTMLAnchorElement>(`a[href*="${SIGNUP_HOST}"]`)
-      .forEach((link) => {
-        try {
-          const url = new URL(link.href)
-          Object.entries(utms).forEach(([key, value]) => {
-            if (!url.searchParams.has(key)) {
-              url.searchParams.set(key, value)
-            }
-          })
-          link.href = url.toString()
-        } catch {
-          // skip malformed URLs
-        }
-      })
+    document.querySelectorAll<HTMLAnchorElement>("a[href]").forEach((link) => {
+      try {
+        const url = new URL(link.href)
+        if (url.hostname !== SIGNUP_HOST) return
+        Object.entries(utms).forEach(([key, value]) => {
+          if (!url.searchParams.has(key)) {
+            url.searchParams.set(key, value)
+          }
+        })
+        link.href = url.toString()
+      } catch {
+        // skip malformed URLs
+      }
+    })
   }, [pathname])
 
   return null
 }
 
-export default UtmForwarder
+export default function UtmForwarder() {
+  return (
+    <Suspense>
+      <UtmForwarderInner />
+    </Suspense>
+  )
+}

--- a/src/components/utm-forwarder.tsx
+++ b/src/components/utm-forwarder.tsx
@@ -1,0 +1,73 @@
+"use client"
+
+import { useEffect } from "react"
+import { usePathname, useSearchParams } from "next/navigation"
+
+const UTM_PARAMS = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "utm_term",
+  "gclid",
+  "fbclid",
+  "ttclid",
+  "wbraid",
+]
+const SIGNUP_HOST = "dashboard.novu.co"
+const STORAGE_KEY = "novu_utm_params"
+
+function getStoredUtmParams(): Record<string, string> {
+  try {
+    const stored = sessionStorage.getItem(STORAGE_KEY)
+    return stored ? JSON.parse(stored) : {}
+  } catch {
+    return {}
+  }
+}
+
+function UtmForwarder() {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  useEffect(() => {
+    const utms: Record<string, string> = {}
+    UTM_PARAMS.forEach((key) => {
+      const value = searchParams.get(key)
+      if (value) utms[key] = value
+    })
+
+    if (Object.keys(utms).length > 0) {
+      try {
+        sessionStorage.setItem(STORAGE_KEY, JSON.stringify(utms))
+      } catch {
+        // sessionStorage unavailable
+      }
+    }
+  }, [searchParams])
+
+  useEffect(() => {
+    const utms = getStoredUtmParams()
+    if (Object.keys(utms).length === 0) return
+
+    document
+      .querySelectorAll<HTMLAnchorElement>(`a[href*="${SIGNUP_HOST}"]`)
+      .forEach((link) => {
+        try {
+          const url = new URL(link.href)
+          Object.entries(utms).forEach(([key, value]) => {
+            if (!url.searchParams.has(key)) {
+              url.searchParams.set(key, value)
+            }
+          })
+          link.href = url.toString()
+        } catch {
+          // skip malformed URLs
+        }
+      })
+  }, [pathname])
+
+  return null
+}
+
+export default UtmForwarder

--- a/src/components/utm-forwarder.tsx
+++ b/src/components/utm-forwarder.tsx
@@ -11,7 +11,16 @@ const STORAGE_KEY = "novu_utm_params"
 function getStoredUtmParams(): Record<string, string> {
   try {
     const stored = sessionStorage.getItem(STORAGE_KEY)
-    return stored ? JSON.parse(stored) : {}
+    if (!stored) return {}
+    const parsed = JSON.parse(stored)
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
+      return {}
+    return Object.fromEntries(
+      TRACKING_PARAMS.flatMap((key) => {
+        const value = (parsed as Record<string, unknown>)[key]
+        return typeof value === "string" && value ? [[key, value]] : []
+      })
+    )
   } catch {
     return {}
   }

--- a/src/constants/forms.ts
+++ b/src/constants/forms.ts
@@ -4,5 +4,14 @@ export const UTM_PARAMS = [
   "utm_source",
   "utm_medium",
   "utm_campaign",
+  "utm_content",
   "utm_term",
+]
+
+export const TRACKING_PARAMS = [
+  ...UTM_PARAMS,
+  "gclid",
+  "fbclid",
+  "ttclid",
+  "wbraid",
 ]


### PR DESCRIPTION
## Summary

- UTM parameters from paid campaigns are lost when users click signup CTAs because links to `dashboard.novu.co` are static with no query params
- This causes ~65% of signup page traffic to have zero attribution in Mixpanel
- Adds a `UtmForwarder` client component that captures UTMs into `sessionStorage` and appends them to all `dashboard.novu.co` links

## How it works

1. `UtmForwarder` reads UTM params (`utm_source`, `utm_medium`, `utm_campaign`, `utm_content`, `utm_term`, `gclid`, `fbclid`, `ttclid`, `wbraid`) from the URL on landing and stores them in `sessionStorage`
2. On every route change, it finds all `<a>` tags pointing to `dashboard.novu.co` and appends the stored UTMs
3. Existing query params on links are preserved (won't overwrite hardcoded `utm_campaign` values like `ws_pricing`)

## Context

- Paid campaigns (Google Ads CPC/display) drive 11,000+ marketing page visits/month but only ~300 are tracked through to signup
- Root cause: signup CTAs are static `href="https://dashboard.novu.co/auth/sign-up"` with no UTM forwarding
- Companion PR for the Gatsby site: novuhq/website#407
- Linear: NV-7343

## Test plan

- [ ] Visit any page with UTMs: `novu.co/?utm_source=test&utm_medium=cpc&utm_campaign=test-campaign`
- [ ] Click any "Sign Up" or "Get Started" CTA
- [ ] Verify the destination URL includes the UTM params
- [ ] Navigate to pricing page and verify pricing CTAs have both their hardcoded `utm_campaign` AND the forwarded `utm_source`/`utm_medium`
- [ ] Verify sessionStorage persists UTMs across page navigations
- [ ] Verify comparison pages (e.g. /comparison/knock) also get UTMs forwarded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Campaign and advertising tracking parameters are now automatically forwarded when navigating to the Novu dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->