### PR TITLE
fix: add SCIM on pricing page

### DIFF
--- a/src/data/pages/pricing/index.tsx
+++ b/src/data/pages/pricing/index.tsx
@@ -1320,14 +1320,14 @@ export const pricingPageData: IPricingPageData = {
         team: {
           booleanValue: false,
         },
-        title: "Custom SSO / OIDC",
+        title: "Custom SSO / OIDC, SCIM",
         tooltip: (
           <p>
             <strong>Enterprise authentication</strong> that allows organizations
             to integrate their own identity providers (Okta, Azure AD, Auth0,
             etc.) for user authentication.
             {"\n\n"}
-            Supports <strong>SAML SSO and OIDC</strong> protocols. Enables
+            Supports <strong>SAML SSO, OIDC, SCIM</strong> protocols. Enables
             centralized user management, enforcement of corporate security
             policies, and compliance with enterprise authentication
             requirements—distinct from standard built-in authentication

--- a/src/data/pages/pricing/index.tsx
+++ b/src/data/pages/pricing/index.tsx
@@ -1456,7 +1456,7 @@ export const pricingPageData: IPricingPageData = {
         },
         team: {
           booleanValue: false,
-          value: "Custom",
+          value: "Standard",
         },
         title: "DPA",
         tooltip: (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Pricing comparison now lists SCIM alongside SAML SSO and OIDC in the Enterprise authentication row.
  * DPA entry updated for the Enterprise tier from "Custom" to "Standard" in the pricing table.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/website-new/pull/61)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->