### PR TITLE
chore: add pnpm minimum-release-age of 3 days (fixes MRK-1722)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=4320


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Add a `.npmrc` setting `minimum-release-age=4320` (4320 minutes = 3 days) to the repo.

## Why

Supply-chain hardening. With this setting, pnpm will refuse to install a package whose latest matching version has been published on the registry for less than 3 days. This gives the community time to detect and yank compromised releases before they make it into our `pnpm install` runs (CI, local dev, deploys).

## Change

Created `.npmrc`:

```
minimum-release-age=4320
```

## Notes

- 4320 minutes = 3 × 24 × 60 = 3 days.
- Setting is honored by pnpm 10.x (current lockfile is `lockfileVersion: '9.0'`, used by pnpm 9/10).
- Existing `pnpm-lock.yaml` resolutions are unaffected — the constraint applies when resolving new versions.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1778558485111329?thread_ts=1778558485.111329&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-b7ac9761-342e-509a-b2c1-ff976a8e0da9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7ac9761-342e-509a-b2c1-ff976a8e0da9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

