### PR TITLE
fix: remove self-hosted (OSS) option from pricing page data

### DIFF
--- a/src/data/pages/pricing/index.tsx
+++ b/src/data/pages/pricing/index.tsx
@@ -1739,37 +1739,6 @@ export const pricingPageData: IPricingPageData = {
           booleanValue: true,
         },
         free: {
-          booleanValue: true,
-        },
-        isGroupTitle: false,
-        pro: {
-          booleanValue: true,
-        },
-        team: {
-          booleanValue: true,
-        },
-        title: "Self-hosted (OSS)",
-        tooltip: (
-          <p>
-            <strong>Open-source, self-deployable version</strong> (MIT licensed)
-            that runs on your own infrastructure, giving you complete control
-            over your notification system and data.
-            {"\n\n"}
-            Deploy via{" "}
-            <strong>
-              Docker Compose, Kubernetes/Helm, or manual installation
-            </strong>
-            . Ideal for organizations with strict data residency requirements,
-            compliance needs, or avoiding vendor lock-in. Includes unlimited
-            retention and community-driven support.
-          </p>
-        ),
-      },
-      {
-        enterprise: {
-          booleanValue: true,
-        },
-        free: {
           booleanValue: false,
         },
         isGroupTitle: false,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the Self-hosted (OSS) pricing option from the pricing page plan comparison. The Self-hosted Enterprise plan now directly follows the Novu Cloud plan in the pricing table.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/website-new/pull/69)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->