### PR TITLE
ci(web): pin GitHub Actions to commit SHAs (fixes MRK-1745)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,40 @@
+name: PR Checks
+
+on:
+  pull_request:
+    branches: ['*']
+
+jobs:
+  checks:
+    name: Install and typecheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 10
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Next.js types
+        env:
+          NEXT_PUBLIC_DEFAULT_SITE_URL: http://localhost:3000
+          NEXT_PUBLIC_SANITY_PROJECT_ID: placeholder
+          NEXT_PUBLIC_SANITY_DATASET: production
+          NEXT_PUBLIC_SANITY_API_VERSION: '2025-02-19'
+        run: pnpm exec next build --experimental-build-mode compile
+
+      - name: Typecheck
+        run: pnpm run typecheck

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,8 +5,8 @@ on:
     branches: ['*']
 
 jobs:
-  checks:
-    name: Install and typecheck
+  install:
+    name: Install dependencies
     runs-on: ubuntu-latest
 
     steps:
@@ -27,14 +27,3 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Generate Next.js types
-        env:
-          NEXT_PUBLIC_DEFAULT_SITE_URL: http://localhost:3000
-          NEXT_PUBLIC_SANITY_PROJECT_ID: placeholder
-          NEXT_PUBLIC_SANITY_DATASET: production
-          NEXT_PUBLIC_SANITY_API_VERSION: '2025-02-19'
-        run: pnpm exec next build --experimental-build-mode compile
-
-      - name: Typecheck
-        run: pnpm run typecheck


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `website-new` repository had no GitHub Actions workflows. This adds a PR checks workflow with all third-party actions pinned to immutable commit SHAs (with version comments), matching the supply-chain hardening pattern used in `novuhq/docs` and `novuhq/novu`.

## Pinned actions

| Action | SHA | Tag |
|--------|-----|-----|
| `actions/checkout` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4 |
| `pnpm/action-setup` | `b906affcce14559ad1aafd4ab0e942779e9f58b1` | v4 |
| `actions/setup-node` | `49933ea5288caeca8642d1e84afbd3f7d6820020` | v4 |

## CI steps

- Install dependencies with `pnpm install --frozen-lockfile`

## Notes

- An initial commit included a typecheck step that failed in CI due to missing static asset type declarations; that step was removed so this PR stays focused on action pinning.
- Uses Node.js 22 to avoid the Node.js 20 deprecation warning on GitHub-hosted runners.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C0ALBUKK3FA/p1779257738322569?thread_ts=1779257738.322569&cid=C0ALBUKK3FA)

<div><a href="https://cursor.com/agents/bc-bee0df8e-f17b-5e01-922a-80c23171f727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bee0df8e-f17b-5e01-922a-80c23171f727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

