### PR TITLE
fix(web): Point connect page CTAs to connect.novu.co

### DIFF
--- a/src/components/pages/connect/channels.tsx
+++ b/src/components/pages/connect/channels.tsx
@@ -180,7 +180,7 @@ function ChannelCard({ name, description, state = "default", icon }: IChannel) {
 
   return (
     <NextLink
-      href={ROUTE.dashboardV2SignUp}
+      href={ROUTE.connectApp}
       target="_blank"
       rel="noopener noreferrer"
       className={cardClassName}

--- a/src/components/pages/connect/connect-header.tsx
+++ b/src/components/pages/connect/connect-header.tsx
@@ -46,7 +46,7 @@ const CONNECT_HEADER_ACTIONS = {
     label: "Novu Platform",
   },
   primary: {
-    href: ROUTE.dashboardV2SignUp,
+    href: ROUTE.connectApp,
     label: "Novu Connect",
   },
 }

--- a/src/components/pages/connect/final-cta.tsx
+++ b/src/components/pages/connect/final-cta.tsx
@@ -59,7 +59,7 @@ function FinalCta() {
           asChild
         >
           <NextLink
-            href={ROUTE.dashboardV2SignUp}
+            href={ROUTE.connectApp}
             target="_blank"
             rel="noopener noreferrer"
             data-click-location="connect_final_cta"

--- a/src/components/pages/connect/hero.tsx
+++ b/src/components/pages/connect/hero.tsx
@@ -62,7 +62,7 @@ function Hero() {
                 asChild
               >
                 <NextLink
-                  href={ROUTE.dashboardV2SignUp}
+                  href={ROUTE.connectApp}
                   target="_blank"
                   rel="noopener noreferrer"
                   data-click-location="connect_hero"

--- a/src/components/pages/connect/how-it-works.tsx
+++ b/src/components/pages/connect/how-it-works.tsx
@@ -201,7 +201,7 @@ function ConnectAgentButton() {
       asChild
     >
       <NextLink
-        href={ROUTE.dashboardV2SignUp}
+        href={ROUTE.connectApp}
         target="_blank"
         rel="noopener noreferrer"
         data-click-location="connect_how_it_works"

--- a/src/components/pages/connect/pricing.tsx
+++ b/src/components/pages/connect/pricing.tsx
@@ -141,7 +141,7 @@ function PricingButton({
 }) {
   return (
     <NextLink
-      href={ROUTE.dashboardV2SignUp}
+      href={ROUTE.connectApp}
       target="_blank"
       rel="noopener noreferrer"
       className={cn(

--- a/src/components/pages/connect/templates.tsx
+++ b/src/components/pages/connect/templates.tsx
@@ -162,7 +162,7 @@ function TemplateActionLink({
       asChild
     >
       <NextLink
-        href={ROUTE.dashboardV2SignUp}
+        href={ROUTE.connectApp}
         target="_blank"
         rel="noopener noreferrer"
         data-click-location="connect_templates"
@@ -245,7 +245,7 @@ function TemplateCardButton({
 }) {
   return (
     <NextLink
-      href={ROUTE.dashboardV2SignUp}
+      href={ROUTE.connectApp}
       target="_blank"
       rel="noopener noreferrer"
       className="group/button relative flex h-10 w-full items-center justify-center overflow-visible rounded border border-[#534b5d] px-5 py-3.5 text-center text-xs leading-none font-medium tracking-normal text-white uppercase transition-[border-color] duration-200 ease-out outline-none hover:border-[#686170] focus-visible:border-[#686170] focus-visible:ring-2 focus-visible:ring-lagune-3/40 motion-reduce:transition-none"

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -49,6 +49,7 @@ export const ROUTE: Record<string, Route<string> | URL> = {
   workflows: "https://dashboard.novu.co/workflows",
 
   // Other services
+  connectApp: "https://connect.novu.co",
   bookMeeting: "https://novu.co/contact-us/",
   careers: "https://careers.novu.co",
   handbook: "https://handbook.novu.co",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Visitors landing on [novu.co/connect](https://novu.co/connect) (e.g. from the GitHub README) were sent to the Novu Platform sign-up (`dashboard.novu.co/auth/sign-up`) instead of the Connect product at `connect.novu.co`.

This PR adds a `ROUTE.connectApp` constant and updates all Connect marketing CTAs to use `https://connect.novu.co`.

## Changes

- Added `connectApp: "https://connect.novu.co"` in `src/constants/routes.ts`
- Updated CTAs in connect page sections:
  - Header (Novu Connect button)
  - Hero
  - Channels
  - How it works
  - Templates (2 links)
  - Pricing tier buttons
  - Final CTA

The **Novu Platform** secondary header action still links to the main site home page. **Contact us** on the Enterprise pricing tier is unchanged.

## Validation

- `pnpm lint` — passed (0 errors)

> **Note:** `pnpm typecheck` fails in this environment due to missing image/SVG assets (pre-existing). Linear ticket to be linked when available.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06E6V65HK3/p1780339072712169?thread_ts=1780339072.712169&cid=C06E6V65HK3)

<div><a href="https://cursor.com/agents/bc-840c06db-0ab1-5ae8-a001-1f42af961a1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-840c06db-0ab1-5ae8-a001-1f42af961a1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Connect app destination for user navigation.

* **Updates**
  * Updated call-to-action links across the Connect product pages to navigate to the new Connect app destination instead of the previous sign-up flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->