### PR TITLE
feat(web): replace connect hero CTA with copyable CLI command

### DIFF
--- a/src/components/pages/connect/hero.tsx
+++ b/src/components/pages/connect/hero.tsx
@@ -1,11 +1,13 @@
 import Image from "next/image"
 import NextLink from "next/link"
-import { ROUTE } from "@/constants/routes"
 import claudeLogo from "@/svgs/pages/connect/hero/claude-logo.svg"
 
 import { Button } from "@/components/ui/button"
+import CopyCliCommand from "@/components/ui/copy-cli-command"
 
 import ConnectHeroVideo from "./hero-video"
+
+const CONNECT_CLI_COMMAND = "npx novu connect"
 
 function Hero() {
   return (
@@ -55,22 +57,12 @@ function Hero() {
             </div>
 
             <div className="flex w-full flex-col items-center gap-3 sm:w-auto sm:flex-row sm:justify-center lg:justify-start lg:gap-7">
-              <Button
-                variant="default"
-                size="lg"
-                className="w-full px-5 sm:w-auto"
-                asChild
-              >
-                <NextLink
-                  href={ROUTE.connectApp}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  data-click-location="connect_hero"
-                  data-click-text="connect_agent_for_free_now"
-                >
-                  Connect agent for free now
-                </NextLink>
-              </Button>
+              <CopyCliCommand
+                command={CONNECT_CLI_COMMAND}
+                className="w-full sm:w-auto"
+                clickLocation="connect_hero"
+                clickText="copy_npx_novu_connect"
+              />
               <Button
                 variant="outline"
                 size="lg"

--- a/src/components/ui/copy-cli-command.tsx
+++ b/src/components/ui/copy-cli-command.tsx
@@ -1,0 +1,76 @@
+"use client"
+
+import { Check, Copy } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import useCopyToClipboard from "@/hooks/use-copy-to-clipboard"
+
+import { Button } from "./button"
+
+interface ICopyCliCommandProps {
+  command: string
+  className?: string
+  clickLocation?: string
+  clickText?: string
+}
+
+function CopyCliCommand({
+  command,
+  className,
+  clickLocation,
+  clickText,
+}: ICopyCliCommandProps) {
+  const { isCopied, handleCopy } = useCopyToClipboard(1500)
+
+  function handleCopyClick() {
+    handleCopy(command)
+  }
+
+  return (
+    <div
+      className={cn(
+        "relative flex h-12 w-full min-w-0 items-center justify-between gap-3 rounded-md border border-transparent bg-black bg-clip-border pl-4 pr-1.5 sm:max-w-98 sm:pl-5",
+        "before:pointer-events-none before:absolute before:-inset-0.5 before:-z-10 before:rounded-md before:bg-[linear-gradient(0deg,rgba(255,255,255,0.5),rgba(255,255,255,0.5)),radial-gradient(30.74%_144.53%_at_59.44%_100%,#FFFFFF_2.5%,#A7BBFF_21.5%,rgba(183,165,255,0.2)_100%)]",
+        className
+      )}
+    >
+      <code className="min-w-0 font-mono text-sm leading-none font-medium tracking-tight whitespace-nowrap text-foreground select-all">
+        {command}
+      </code>
+
+      <Button
+        type="button"
+        variant="default"
+        size="sm"
+        className="h-9 shrink-0 min-w-22 px-4 text-sm normal-case sm:min-w-22"
+        onClick={handleCopyClick}
+        data-click-location={clickLocation}
+        data-click-text={clickText ?? "copy_command"}
+        aria-label={isCopied ? "Command copied" : "Copy command"}
+      >
+        {isCopied ? (
+          <>
+            <span className="sm:hidden">Copied!</span>
+            <Check className="hidden size-4 sm:block" aria-hidden />
+          </>
+        ) : (
+          <>
+            <span className="sm:hidden">Copy</span>
+            <Copy className="hidden size-4 sm:block" aria-hidden />
+          </>
+        )}
+      </Button>
+
+      <span
+        className="pointer-events-none absolute -top-0.5 right-px h-0.75 w-36 bg-[linear-gradient(91.15deg,rgba(205,204,255,0)_2.67%,rgba(205,204,255,0.76156)_21.19%,#CDCCFF_60.95%,rgba(205,204,255,0)_93.27%)] opacity-70 mix-blend-plus-lighter blur-[2px]"
+        aria-hidden
+      />
+      <span
+        className="pointer-events-none absolute -bottom-0.75 left-38.75 h-0.75 w-36 bg-[linear-gradient(91.15deg,rgba(205,204,255,0)_2.67%,rgba(205,204,255,0.76156)_21.19%,#CDCCFF_60.95%,rgba(205,204,255,0)_93.27%)] opacity-50 mix-blend-plus-lighter blur-[2px]"
+        aria-hidden
+      />
+    </div>
+  )
+}
+
+export default CopyCliCommand


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the `/connect` page hero so the primary call-to-action is a copyable CLI command (`npx novu connect`) instead of the previous "Connect agent for free now" button.

## Changes

- Added `CopyCliCommand` (`src/components/ui/copy-cli-command.tsx`), a reusable client component based on the legacy novu.co homepage CTA pattern: monospace command text, gradient border, and a Copy/Copied control.
- Wired the connect hero to use `CopyCliCommand` with analytics attributes (`connect_hero` / `copy_npx_novu_connect`).
- Left the secondary "Watch the 30-sec demo" button unchanged.

## Verification

- `pnpm lint` passes (existing warnings only).
- `pnpm typecheck` and `pnpm build` require Sanity/env configuration in this environment (`projectId` missing); not introduced by this change.
- Local `/connect` dev verification blocked for the same Sanity configuration reason.

## Notes

- Linear ticket: MCP Linear integration requires authentication in this environment; please attach an NV- ticket to this PR if one is created separately.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1780383970654969?thread_ts=1780383970.654969&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-e0742a3f-0fbb-5b65-924e-4b3dd1232710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0742a3f-0fbb-5b65-924e-4b3dd1232710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

