### PR TITLE
feat: pass agent template id to the dashboard

### DIFF
--- a/src/components/pages/connect/templates.tsx
+++ b/src/components/pages/connect/templates.tsx
@@ -245,7 +245,7 @@ function TemplateCardButton({
 }) {
   return (
     <NextLink
-      href={ROUTE.connectApp}
+      href={`${ROUTE.connectApp}?agentTemplateId=${templateId}`}
       target="_blank"
       rel="noopener noreferrer"
       className="group/button relative flex h-10 w-full items-center justify-center overflow-visible rounded border border-[#534b5d] px-5 py-3.5 text-center text-xs leading-none font-medium tracking-normal text-white uppercase transition-[border-color] duration-200 ease-out outline-none hover:border-[#686170] focus-visible:border-[#686170] focus-visible:ring-2 focus-visible:ring-lagune-3/40 motion-reduce:transition-none"


### PR DESCRIPTION
**Related Dashboard PR**: https://github.com/novuhq/novu/pull/11448

Agent Templates - include the `agentTemplateId` query param in the `View template` link, that redirects to the Dashboard page. The `agentTemplateId` is used to fill the agent onboarding form with the template data from Sanity. More details in the Dashboard PR above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed template selection flow to properly pass template information when navigating to the connection setup page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->