### PR TITLE
fix: point dashboard CTAs to root URL with click tracking

### DIFF
--- a/docs/cta-tracking-conventions.md
+++ b/docs/cta-tracking-conventions.md
@@ -36,7 +36,9 @@ The location must be globally unique across the site so events from different pa
 | Comparison (Courier) | Banner       | `comparison_courier_banner`       |
 | Comparison (Courier) | Bottom CTA   | `comparison_courier_cta`          |
 | Comparison (Knock)   | Hero         | `comparison_knock_hero`           |
-| Pricing              | Hero         | `pricing_hero`                    |
+| Pricing              | Hero Free    | `pricing_hero_free`               |
+| Pricing              | Hero Pro     | `pricing_hero_pro`                |
+| Pricing              | Hero Team    | `pricing_hero_team`               |
 | Pricing              | FAQ          | `pricing_faq`                     |
 | Homepage             | Hero         | `home_hero`                       |
 | Homepage             | Bottom CTA   | `home_cta`                        |
@@ -91,7 +93,7 @@ Set the values in the page data file:
 // src/data/pages/comparison/courier.tsx
 primaryCta: {
   label: "Start for Free",
-  href: "https://dashboard.novu.co/auth/sign-up",
+  href: "https://dashboard.novu.co",
   clickLocation: "comparison_courier_hero",
   clickText: "start_for_free",
 },
@@ -120,9 +122,7 @@ Adding hardcoded UTMs like `utm_source=internal` to CTA links causes Google Anal
 **Bad -- hardcoded internal UTMs that overwrite acquisition attribution:**
 
 ```html
-<a
-  href="https://dashboard.novu.co/auth/sign-up?utm_source=internal&utm_campaign=comparison"
->
+<a href="https://dashboard.novu.co?utm_source=internal&utm_campaign=comparison">
   Start for Free
 </a>
 ```
@@ -131,7 +131,7 @@ Adding hardcoded UTMs like `utm_source=internal` to CTA links causes Google Anal
 
 ```html
 <a
-  href="https://dashboard.novu.co/auth/sign-up"
+  href="https://dashboard.novu.co"
   data-click-location="comparison_courier_hero"
   data-click-text="start_for_free"
 >
@@ -141,7 +141,7 @@ Adding hardcoded UTMs like `utm_source=internal` to CTA links causes Google Anal
 
 ## Acquisition UTM forwarding (UtmForwarder component)
 
-The `UtmForwarder` component (`src/components/utm-forwarder.tsx`) automatically forwards the visitor's **original acquisition UTMs** (from the URL they landed on, e.g. from a Google Ad) to dashboard.novu.co links. This is different from hardcoding internal UTMs -- it preserves the original paid campaign attribution through to signup.
+The `UtmForwarder` component (`src/components/utm-forwarder.tsx`) automatically forwards the visitor's **original acquisition UTMs** (from the URL they landed on, e.g. from a Google Ad) to dashboard.novu.co links. This is different from hardcoding internal UTMs -- it preserves the original paid campaign attribution through to the dashboard.
 
 - It only appends params that are NOT already present on the link
 - It only targets links where `url.hostname === "dashboard.novu.co"`
@@ -151,12 +151,14 @@ The `UtmForwarder` component (`src/components/utm-forwarder.tsx`) automatically 
 
 The following components already support `clickLocation` / `clickText`:
 
-| Component                 | File                                               |
-| ------------------------- | -------------------------------------------------- |
-| Comparison Hero           | `src/components/pages/comparison/hero.tsx`         |
-| Comparison Intro          | `src/components/pages/comparison/intro.tsx`        |
-| Comparison Frustrations   | `src/components/pages/comparison/frustrations.tsx` |
-| Comparison Difference     | `src/components/pages/comparison/difference.tsx`   |
-| Banner                    | `src/components/pages/banner.tsx`                  |
-| ActionGroup (CTA section) | `src/components/ui/action-group.tsx`               |
-| Content CTA               | `src/components/content/cta.tsx`                   |
+| Component                 | File                                                        |
+| ------------------------- | ----------------------------------------------------------- |
+| Comparison Hero           | `src/components/pages/comparison/hero.tsx`                  |
+| Comparison Intro          | `src/components/pages/comparison/intro.tsx`                 |
+| Comparison Frustrations   | `src/components/pages/comparison/frustrations.tsx`          |
+| Comparison Difference     | `src/components/pages/comparison/difference.tsx`            |
+| Pricing Cards             | `src/components/pages/pricing/pricing-plans-cards/card.tsx` |
+| Pricing Table             | `src/components/pages/pricing/comparison-table.tsx`         |
+| Banner                    | `src/components/pages/banner.tsx`                           |
+| ActionGroup (CTA section) | `src/components/ui/action-group.tsx`                        |
+| Content CTA               | `src/components/content/cta.tsx`                            |

--- a/src/app/(website)/(default-footer)/blog/(sub-pages)/layout.tsx
+++ b/src/app/(website)/(default-footer)/blog/(sub-pages)/layout.tsx
@@ -65,7 +65,9 @@ export default async function BlogPagesLayout({
           {
             kind: "primary-button",
             label: "Get started",
-            href: `${ROUTE.dashboard}?utm_campaign=gs-website-inbox`,
+            href: ROUTE.dashboard,
+            clickLocation: "blog_archive_cta",
+            clickText: "get_started",
           },
           {
             kind: "secondary-button",

--- a/src/app/(website)/(default-footer)/blog/[slug]/page.tsx
+++ b/src/app/(website)/(default-footer)/blog/[slug]/page.tsx
@@ -82,7 +82,9 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
           {
             kind: "primary-button",
             label: "Get started",
-            href: `${ROUTE.dashboard}?utm_campaign=gs-website-inbox`,
+            href: ROUTE.dashboard,
+            clickLocation: "blog_post_cta",
+            clickText: "get_started",
           },
           {
             kind: "secondary-button",

--- a/src/app/(website)/(default-footer)/blog/page.tsx
+++ b/src/app/(website)/(default-footer)/blog/page.tsx
@@ -133,7 +133,9 @@ export default async function BlogPage() {
           {
             kind: "primary-button",
             label: "Get started",
-            href: `${ROUTE.dashboard}?utm_campaign=gs-website-inbox`,
+            href: ROUTE.dashboard,
+            clickLocation: "blog_index_cta",
+            clickText: "get_started",
           },
           {
             kind: "secondary-button",

--- a/src/app/(website)/(default-footer)/changelog/page.tsx
+++ b/src/app/(website)/(default-footer)/changelog/page.tsx
@@ -84,7 +84,9 @@ export default async function ChangelogPage({
           {
             kind: "primary-button",
             label: "Get started",
-            href: `${ROUTE.dashboard}?utm_campaign=gs-website-inbox`,
+            href: ROUTE.dashboard,
+            clickLocation: "changelog_cta",
+            clickText: "get_started",
           },
           {
             kind: "secondary-button",

--- a/src/app/(website)/(default-footer)/customers/[slug]/page.tsx
+++ b/src/app/(website)/(default-footer)/customers/[slug]/page.tsx
@@ -203,7 +203,9 @@ export default async function CustomerStoryPage({
           {
             kind: "primary-button",
             label: "Get started",
-            href: `${ROUTE.dashboard}?utm_campaign=gs-website-inbox`,
+            href: ROUTE.dashboard,
+            clickLocation: "customers_story_cta",
+            clickText: "get_started",
           },
           {
             kind: "secondary-button",

--- a/src/app/(website)/(default-footer)/customers/page.tsx
+++ b/src/app/(website)/(default-footer)/customers/page.tsx
@@ -98,7 +98,9 @@ export default async function CustomersPage() {
           {
             kind: "primary-button",
             label: "Get started",
-            href: `${ROUTE.dashboard}?utm_campaign=gs-website-inbox`,
+            href: ROUTE.dashboard,
+            clickLocation: "customers_cta",
+            clickText: "get_started",
           },
           {
             kind: "secondary-button",

--- a/src/app/(website)/(default-footer)/integrations/[slug]/page.tsx
+++ b/src/app/(website)/(default-footer)/integrations/[slug]/page.tsx
@@ -113,7 +113,9 @@ export default async function IntegrationDetailPage({ params }: PageProps) {
           {
             kind: "primary-button",
             label: "Start building",
-            href: `${ROUTE.dashboard}?utm_campaign=gs-website-inbox`,
+            href: ROUTE.dashboard,
+            clickLocation: "integrations_detail_cta",
+            clickText: "start_building",
           },
           {
             kind: "secondary-button",

--- a/src/app/(website)/(default-footer)/integrations/_components/integrations-tab-page-content.tsx
+++ b/src/app/(website)/(default-footer)/integrations/_components/integrations-tab-page-content.tsx
@@ -92,7 +92,9 @@ async function IntegrationsTabPageContent({
           {
             kind: "primary-button",
             label: "Start building",
-            href: `${ROUTE.dashboard}?utm_campaign=gs-website-inbox`,
+            href: ROUTE.dashboard,
+            clickLocation: `integrations_${tab}_cta`,
+            clickText: "start_building",
             openInNewTab: true,
           },
           {

--- a/src/components/content/cta.tsx
+++ b/src/components/content/cta.tsx
@@ -4,16 +4,31 @@ import bgIllustration from "@/images/pages/customers/cta/bg-illustration.png"
 import shine from "@/svgs/pages/customers/cta/shine.svg"
 
 import { IContentCtaBlock } from "@/types/content"
+import { normalizeDashboardUrl } from "@/lib/normalize-dashboard-url"
 import { Button } from "@/components/ui/button"
 
-function Cta({ text, buttonText, buttonUrl, clickLocation, clickText }: IContentCtaBlock) {
+function Cta({
+  text,
+  buttonText,
+  buttonUrl,
+  clickLocation,
+  clickText,
+}: IContentCtaBlock) {
+  const normalizedButtonUrl = normalizeDashboardUrl(buttonUrl)
+
   return (
     <div className="not-prose relative my-6 flex items-center justify-between gap-x-4 rounded-xl px-4 py-6 md:px-5">
       <h2 className="relative z-20 text-[20px] leading-tight font-medium md:text-[22px]">
         {text}
       </h2>
       <Button className="relative z-20 h-9" asChild>
-        <NextLink href={buttonUrl} data-click-location={clickLocation} data-click-text={clickText}>{buttonText}</NextLink>
+        <NextLink
+          href={normalizedButtonUrl}
+          data-click-location={clickLocation}
+          data-click-text={clickText}
+        >
+          {buttonText}
+        </NextLink>
       </Button>
 
       <div className="absolute inset-0 z-10 overflow-hidden rounded-[inherit]">

--- a/src/components/pages/integrations/integrations-hero.tsx
+++ b/src/components/pages/integrations/integrations-hero.tsx
@@ -52,9 +52,11 @@ function IntegrationsHero({ className }: IntegrationsHeroProps) {
                       asChild
                     >
                       <NextLink
-                        href={`${ROUTE.dashboardV2SignUp}?utm_campaign=ws_integrations_hero`}
+                        href={ROUTE.dashboardV2SignUp}
                         target="_blank"
                         rel="noopener noreferrer"
+                        data-click-location="integrations_hero"
+                        data-click-text="try_now"
                       >
                         Try now
                       </NextLink>

--- a/src/components/pages/pricing/comparison-table.tsx
+++ b/src/components/pages/pricing/comparison-table.tsx
@@ -3,7 +3,7 @@
 import React, { ReactNode, useState } from "react"
 import { Check, ChevronLeft, ChevronRight, Info } from "lucide-react"
 
-import { Headings, Plans, Row } from "@/types/pricing"
+import { Headings, PlanHeading, Plans, Row } from "@/types/pricing"
 import { cn, normalizeString } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Link } from "@/components/ui/link"
@@ -34,8 +34,7 @@ const getColumnStartClass = (columnIndex: number) => {
   }
 }
 interface TableHeaderProps {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  plan?: any
+  plan?: PlanHeading
   planId: string
   isFeatured: boolean
   plansCount: number
@@ -48,7 +47,8 @@ function TableHeader({
   plansCount,
   onContactUsClick,
 }: TableHeaderProps) {
-  const { label, isFeatured, buttonUrl, buttonText } = plan || {}
+  const { label, isFeatured, buttonUrl, buttonText, clickLocation, clickText } =
+    plan || {}
   const isContactCta =
     buttonText?.trim().toLowerCase().includes("contact") ?? false
 
@@ -109,7 +109,13 @@ function TableHeader({
             }}
             asChild
           >
-            <Link variant="white" className="rounded-sm" href={buttonUrl}>
+            <Link
+              variant="white"
+              className="rounded-sm"
+              href={buttonUrl}
+              data-click-location={clickLocation}
+              data-click-text={clickText}
+            >
               {buttonText}
             </Link>
           </Button>
@@ -120,7 +126,9 @@ function TableHeader({
 }
 
 interface Feature {
-  value?: ReactNode | ((onContactUsClick: (source: string) => void) => ReactNode)
+  value?:
+    | ReactNode
+    | ((onContactUsClick: (source: string) => void) => ReactNode)
   booleanValue?: boolean
 }
 interface ITableCellProps {

--- a/src/components/pages/pricing/pricing-plans-cards/card.tsx
+++ b/src/components/pages/pricing/pricing-plans-cards/card.tsx
@@ -106,6 +106,8 @@ const Card = ({
               <Link
                 variant="white"
                 href={link.href}
+                data-click-location={link.clickLocation}
+                data-click-text={link.clickText}
                 rel={link.isExternal ? "noopener noreferrer" : undefined}
                 target={link.isExternal ? "_blank" : undefined}
               >

--- a/src/components/ui/link.tsx
+++ b/src/components/ui/link.tsx
@@ -4,6 +4,7 @@ import NextLink from "next/link"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
 
+import { normalizeDashboardUrl } from "@/lib/normalize-dashboard-url"
 import { cn } from "@/lib/utils"
 
 const linkVariants = cva(
@@ -54,14 +55,15 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkProps<string>>(
     { className, variant, size, animation, asChild = false, href, ...props },
     ref
   ) => {
+    const normalizedHref = normalizeDashboardUrl(href)
     const Comp = asChild ? Slot : "a"
-    const isInternalLink = typeof href === "string" && href.startsWith("/")
+    const isInternalLink = normalizedHref.startsWith("/")
 
     if (isInternalLink) {
       return (
         <NextLink
           className={cn(linkVariants({ variant, size, animation, className }))}
-          href={href}
+          href={normalizedHref}
           ref={ref}
           {...props}
         />
@@ -71,7 +73,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkProps<string>>(
     return (
       <Comp
         className={cn(linkVariants({ variant, size, animation, className }))}
-        href={href.toString()}
+        href={normalizedHref}
         ref={ref}
         target="_blank"
         rel="noopener noreferrer"

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -47,8 +47,8 @@ export const ROUTE: Record<string, Route<string> | URL> = {
   // Dashboard
   dashboard: "https://dashboard.novu.co",
   dashboardV2: "https://dashboard.novu.co",
-  dashboardV2SignIn: "https://dashboard.novu.co/auth/sign-in",
-  dashboardV2SignUp: "https://dashboard.novu.co/auth/sign-up",
+  dashboardV2SignIn: "https://dashboard.novu.co",
+  dashboardV2SignUp: "https://dashboard.novu.co",
   dashboardV2AgentsSignUp:
     "https://dashboard.novu.co/auth/sign-up?product_type=agents",
   workflows: "https://dashboard.novu.co/workflows",

--- a/src/data/pages/comparison/building-in-house.tsx
+++ b/src/data/pages/comparison/building-in-house.tsx
@@ -34,7 +34,7 @@ export const buildingInHouseComparisonData: IComparisonPageData = {
       "All your notification infrastructure needs, workflows, routing, preferences, and <Inbox /> in one platform, open source and built for builders and teams.",
     primaryCta: {
       label: "Start for Free",
-      href: "https://dashboard.novu.co/auth/sign-up",
+      href: "https://dashboard.novu.co",
       clickLocation: "comparison_building_in_house_hero",
       clickText: "start_for_free",
     },
@@ -75,7 +75,7 @@ export const buildingInHouseComparisonData: IComparisonPageData = {
     ],
     cta: {
       label: "Get Started",
-      href: "https://dashboard.novu.co/auth/sign-up",
+      href: "https://dashboard.novu.co",
       clickLocation: "comparison_building_in_house_intro",
       clickText: "get_started",
     },
@@ -118,7 +118,7 @@ export const buildingInHouseComparisonData: IComparisonPageData = {
     ],
     cta: {
       label: "Switch to Novu",
-      href: "https://dashboard.novu.co/auth/sign-up",
+      href: "https://dashboard.novu.co",
       clickLocation: "comparison_building_in_house_frustrations",
       clickText: "switch_to_novu",
     },
@@ -173,7 +173,7 @@ export const buildingInHouseComparisonData: IComparisonPageData = {
     ],
     cta: {
       label: "Explore Novu",
-      href: "https://dashboard.novu.co/auth/sign-up",
+      href: "https://dashboard.novu.co",
       clickLocation: "comparison_building_in_house_difference",
       clickText: "explore_novu",
     },
@@ -303,7 +303,7 @@ export const buildingInHouseComparisonData: IComparisonPageData = {
       "Replace your internal notification service with Novu's unified API. Most teams start by migrating one workflow, validate it works, and progressively move the rest.",
     cta: {
       label: "Get Started",
-      href: "https://dashboard.novu.co/auth/sign-up",
+      href: "https://dashboard.novu.co",
       clickLocation: "comparison_building_in_house_banner",
       clickText: "get_started",
     },

--- a/src/data/pages/comparison/courier.tsx
+++ b/src/data/pages/comparison/courier.tsx
@@ -34,7 +34,7 @@ export const courierComparisonData: IComparisonPageData = {
       "All your notification infrastructure needs, workflows, routing, preferences, and <Inbox /> in one platform, open source and built for builders and teams.",
     primaryCta: {
       label: "Start for Free",
-      href: "https://dashboard.novu.co/auth/sign-up",
+      href: "https://dashboard.novu.co",
       clickLocation: "comparison_courier_hero",
       clickText: "start_for_free",
     },
@@ -75,7 +75,7 @@ export const courierComparisonData: IComparisonPageData = {
     ],
     cta: {
       label: "Get Started",
-      href: "https://dashboard.novu.co/auth/sign-up",
+      href: "https://dashboard.novu.co",
       clickLocation: "comparison_courier_intro",
       clickText: "get_started",
     },
@@ -106,7 +106,7 @@ export const courierComparisonData: IComparisonPageData = {
     ],
     cta: {
       label: "Switch to Novu",
-      href: "https://dashboard.novu.co/auth/sign-up",
+      href: "https://dashboard.novu.co",
       clickLocation: "comparison_courier_frustrations",
       clickText: "switch_to_novu",
     },
@@ -161,7 +161,7 @@ export const courierComparisonData: IComparisonPageData = {
     ],
     cta: {
       label: "Explore Novu",
-      href: "https://dashboard.novu.co/auth/sign-up",
+      href: "https://dashboard.novu.co",
       clickLocation: "comparison_courier_difference",
       clickText: "explore_novu",
     },

--- a/src/data/pages/comparison/knock.tsx
+++ b/src/data/pages/comparison/knock.tsx
@@ -34,7 +34,7 @@ export const knockComparisonData: IComparisonPageData = {
       "All your notification infrastructure needs, workflows, routing, preferences, and <Inbox /> in one platform, open source and built for builders and teams.",
     primaryCta: {
       label: "Start for Free",
-      href: "https://dashboard.novu.co/auth/sign-up",
+      href: "https://dashboard.novu.co",
       clickLocation: "comparison_knock_hero",
       clickText: "start_for_free",
     },
@@ -75,7 +75,7 @@ export const knockComparisonData: IComparisonPageData = {
     ],
     cta: {
       label: "Get Started",
-      href: "https://dashboard.novu.co/auth/sign-up",
+      href: "https://dashboard.novu.co",
       clickLocation: "comparison_knock_intro",
       clickText: "get_started",
     },
@@ -118,7 +118,7 @@ export const knockComparisonData: IComparisonPageData = {
     ],
     cta: {
       label: "Switch to Novu",
-      href: "https://dashboard.novu.co/auth/sign-up",
+      href: "https://dashboard.novu.co",
       clickLocation: "comparison_knock_frustrations",
       clickText: "switch_to_novu",
     },
@@ -173,7 +173,7 @@ export const knockComparisonData: IComparisonPageData = {
     ],
     cta: {
       label: "Explore Novu",
-      href: "https://dashboard.novu.co/auth/sign-up",
+      href: "https://dashboard.novu.co",
       clickLocation: "comparison_knock_difference",
       clickText: "explore_novu",
     },

--- a/src/data/pages/comparison/magicbell.tsx
+++ b/src/data/pages/comparison/magicbell.tsx
@@ -34,7 +34,7 @@ export const magicbellComparisonData: IComparisonPageData = {
       "All your notification infrastructure needs, workflows, routing, preferences, and <Inbox /> in one platform, open source and built for builders and teams.",
     primaryCta: {
       label: "Start for Free",
-      href: "https://dashboard.novu.co/auth/sign-up",
+      href: "https://dashboard.novu.co",
       clickLocation: "comparison_magicbell_hero",
       clickText: "start_for_free",
     },
@@ -75,7 +75,7 @@ export const magicbellComparisonData: IComparisonPageData = {
     ],
     cta: {
       label: "Get Started",
-      href: "https://dashboard.novu.co/auth/sign-up",
+      href: "https://dashboard.novu.co",
       clickLocation: "comparison_magicbell_intro",
       clickText: "get_started",
     },
@@ -112,7 +112,7 @@ export const magicbellComparisonData: IComparisonPageData = {
     ],
     cta: {
       label: "Switch to Novu",
-      href: "https://dashboard.novu.co/auth/sign-up",
+      href: "https://dashboard.novu.co",
       clickLocation: "comparison_magicbell_frustrations",
       clickText: "switch_to_novu",
     },
@@ -167,7 +167,7 @@ export const magicbellComparisonData: IComparisonPageData = {
     ],
     cta: {
       label: "Explore Novu",
-      href: "https://dashboard.novu.co/auth/sign-up",
+      href: "https://dashboard.novu.co",
       clickLocation: "comparison_magicbell_difference",
       clickText: "explore_novu",
     },

--- a/src/data/pages/comparison/suprsend.tsx
+++ b/src/data/pages/comparison/suprsend.tsx
@@ -37,7 +37,7 @@ export const suprsendComparisonData: IComparisonPageData = {
       "All your notification infrastructure needs, workflows, routing, preferences, and <Inbox /> in one platform, open source and built for builders and teams.",
     primaryCta: {
       label: "Start for Free",
-      href: "https://dashboard.novu.co/auth/sign-up",
+      href: "https://dashboard.novu.co",
       clickLocation: "comparison_suprsend_hero",
       clickText: "start_for_free",
     },
@@ -78,7 +78,7 @@ export const suprsendComparisonData: IComparisonPageData = {
     ],
     cta: {
       label: "Get Started",
-      href: "https://dashboard.novu.co/auth/sign-up",
+      href: "https://dashboard.novu.co",
       clickLocation: "comparison_suprsend_intro",
       clickText: "get_started",
     },
@@ -115,7 +115,7 @@ export const suprsendComparisonData: IComparisonPageData = {
     ],
     cta: {
       label: "Switch to Novu",
-      href: "https://dashboard.novu.co/auth/sign-up",
+      href: "https://dashboard.novu.co",
       clickLocation: "comparison_suprsend_frustrations",
       clickText: "switch_to_novu",
     },
@@ -170,7 +170,7 @@ export const suprsendComparisonData: IComparisonPageData = {
     ],
     cta: {
       label: "Explore Novu",
-      href: "https://dashboard.novu.co/auth/sign-up",
+      href: "https://dashboard.novu.co",
       clickLocation: "comparison_suprsend_difference",
       clickText: "explore_novu",
     },

--- a/src/data/pages/pricing/index.tsx
+++ b/src/data/pages/pricing/index.tsx
@@ -58,7 +58,7 @@ export const pricingPageData: IPricingPageData = {
   _updatedAt: "2026-02-12T13:59:33Z",
   cta: {
     buttonText: "Schedule a call",
-    buttonUrl: "https://dashboard-v2.novu.co/auth/sign-up",
+    buttonUrl: "https://dashboard.novu.co",
     description:
       "Schedule a call with our team to find the perfect plan for your use case",
     text: "Not sure what plan fits your needs?",
@@ -287,9 +287,11 @@ export const pricingPageData: IPricingPageData = {
         extraInfo: "No credit card required",
         isFeatured: false,
         link: {
-          href: "https://dashboard.novu.co/auth/sign-up?utm_campaign=ws_pricing",
+          href: "https://dashboard.novu.co",
           isExternal: true,
           text: "Get started",
+          clickLocation: "pricing_hero_free",
+          clickText: "get_started",
         },
         price: [
           {
@@ -319,9 +321,11 @@ export const pricingPageData: IPricingPageData = {
         ),
         isFeatured: true,
         link: {
-          href: "https://dashboard.novu.co/auth/sign-up?utm_campaign=ws_pricing",
+          href: "https://dashboard.novu.co",
           isExternal: true,
           text: "Get started",
+          clickLocation: "pricing_hero_pro",
+          clickText: "get_started",
         },
         price: [
           {
@@ -354,9 +358,11 @@ export const pricingPageData: IPricingPageData = {
         ),
         isFeatured: false,
         link: {
-          href: "https://dashboard.novu.co/auth/sign-up?utm_campaign=ws_pricing",
+          href: "https://dashboard.novu.co",
           isExternal: true,
           text: "Get started",
+          clickLocation: "pricing_hero_team",
+          clickText: "get_started",
         },
         price: [
           {
@@ -455,9 +461,11 @@ export const pricingPageData: IPricingPageData = {
   pageCta: {
     actions: [
       {
-        href: "https://dashboard.novu.co/?utm_campaign=gs-website-inbox",
+        href: "https://dashboard.novu.co",
         label: "Get started",
         kind: "primary-button",
+        clickLocation: "pricing_page_cta",
+        clickText: "get_started",
       },
       {
         href: "/contact-us",
@@ -473,24 +481,27 @@ export const pricingPageData: IPricingPageData = {
     headings: [
       {
         buttonText: "Get started",
-        buttonUrl:
-          "https://dashboard.novu.co/auth/sign-up?utm_campaign=ws_pricing_table_free",
+        buttonUrl: "https://dashboard.novu.co",
+        clickLocation: "pricing_table_free",
+        clickText: "get_started",
         id: "free",
         label: "Free",
         isFeatured: false,
       },
       {
         buttonText: "Get started",
-        buttonUrl:
-          "https://dashboard.novu.co/auth/sign-up?utm_campaign=ws_pricing_table_pro",
+        buttonUrl: "https://dashboard.novu.co",
+        clickLocation: "pricing_table_pro",
+        clickText: "get_started",
         id: "pro",
         isFeatured: true,
         label: "Pro",
       },
       {
         buttonText: "Get started",
-        buttonUrl:
-          "https://dashboard.novu.co/auth/sign-up?utm_campaign=ws_pricing_table_team",
+        buttonUrl: "https://dashboard.novu.co",
+        clickLocation: "pricing_table_team",
+        clickText: "get_started",
         id: "team",
         label: "Team",
         isFeatured: false,

--- a/src/lib/normalize-dashboard-url.ts
+++ b/src/lib/normalize-dashboard-url.ts
@@ -1,0 +1,30 @@
+const DASHBOARD_URL = "https://dashboard.novu.co"
+const DASHBOARD_HOST = "dashboard.novu.co"
+const LEGACY_DASHBOARD_HOST = "dashboard-v2.novu.co"
+const DASHBOARD_AUTH_PATHS = new Set(["/auth/sign-in", "/auth/sign-up"])
+
+export function normalizeDashboardUrl(href: string | URL): string {
+  const value = href.toString()
+
+  try {
+    const url = new URL(value)
+    const pathname = url.pathname.replace(/\/$/, "")
+    const isDashboardHost = url.hostname === DASHBOARD_HOST
+    const isLegacyDashboardHost = url.hostname === LEGACY_DASHBOARD_HOST
+
+    if (isLegacyDashboardHost) {
+      const normalizedPath =
+        !pathname || DASHBOARD_AUTH_PATHS.has(pathname) ? "" : url.pathname
+
+      return `${DASHBOARD_URL}${normalizedPath}${url.search}${url.hash}`
+    }
+
+    if (isDashboardHost && DASHBOARD_AUTH_PATHS.has(pathname)) {
+      return `${DASHBOARD_URL}${url.search}${url.hash}`
+    }
+  } catch {
+    // Relative URLs are left unchanged.
+  }
+
+  return value
+}

--- a/src/lib/sanity/schemas/shared/content/cta-block.ts
+++ b/src/lib/sanity/schemas/shared/content/cta-block.ts
@@ -33,7 +33,7 @@ const ctaBlock = defineType({
       name: "buttonUrl",
       type: "url",
       title: "Button URL",
-      initialValue: "https://dashboard.novu.co/auth/sign-up",
+      initialValue: "https://dashboard.novu.co",
       validation: (rule: UrlRule) =>
         rule.error("You have to fill in this field.").required(),
     }),

--- a/src/types/pricing.ts
+++ b/src/types/pricing.ts
@@ -17,6 +17,8 @@ export type Link = {
   href: string
   isExternal?: boolean
   variant?: "primary" | "secondary" | "text"
+  clickLocation?: string
+  clickText?: string
 }
 
 export type NumericPrice = {
@@ -71,6 +73,8 @@ export type PlanHeading = {
   isFeatured: boolean
   buttonUrl?: string
   buttonText?: string
+  clickLocation?: string
+  clickText?: string
 }
 
 export type Headings = PlanHeading[]


### PR DESCRIPTION
## Summary

- Point dashboard CTAs to `https://dashboard.novu.co` instead of auth-specific dashboard paths with hardcoded internal UTMs.
- Add dashboard URL normalization for shared links/content CTAs so legacy `dashboard-v2` and dashboard auth URLs resolve to the current dashboard root.
- Replace removed internal UTM campaigns with `data-click-location` / `data-click-text` tracking across blog, changelog, customers, integrations, comparison, and pricing CTAs.
- Add pricing card/table click-tracking fields, including plan-specific pricing hero locations.
- Update CTA tracking conventions and Sanity CTA defaults to match the new dashboard link strategy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CTA tracking conventions documentation with refined examples and expanded supported components list.

* **Improvements**
  * Enhanced click tracking on CTAs across the site with improved analytics metadata.
  * Simplified dashboard URLs by removing unnecessary query parameters for cleaner navigation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->