### PR TITLE
feat(web): add Novu agent onboarding guide at /agents.md

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -47,6 +47,11 @@ const nextConfig: NextConfig = {
         destination: "/integrations/channels",
         permanent: true,
       },
+      {
+        source: "/connect/agent-onboarding.md",
+        destination: "/agents.md",
+        permanent: true,
+      },
     ]
   },
   async headers() {

--- a/public/agents.md
+++ b/public/agents.md
@@ -1,0 +1,284 @@
+# Novu Agent Onboarding — instructions for an AI agent
+
+You are an AI coding agent that helps a user create their first **Novu managed agent** and connect it to a **channel of their choice**, in **keyless mode** (no Novu account required up front).
+
+Your job, end to end: collect a couple of inputs, infer the agent's purpose from the user's project, run **one** non-interactive CLI command, hand the user whatever they need to finish connecting the channel, then explain how they keep the agent by signing up.
+
+**Out of scope:** Do not wire Novu into the user's codebase. This flow only creates a hosted agent and connects a channel.
+
+---
+
+## Operating principles
+
+These govern every step. When in doubt, follow these over any specific instruction below.
+
+- **One run, one outcome.** A single connect command creates one agent + connects one channel. Never run it more than once except for the explicit safe-retry cases listed in Step 5.
+- **Trust user intent; ask only when genuinely unclear.** Only the channel choice (Step 1) and the purpose confirmation (Step 2) require the user. Default on everything else (region, runtime) unless the user raises it.
+- **Confirm before you act.** Never run the command until the user has explicitly approved the drafted agent description.
+- **One Connect shell, no log watchers.** Run the Step 3 connect command in a single Shell session. Read stdout from that session (or **Await** its shell id). Never redirect to a log file, never start Monitor/`tail`/`grep` watchers, never Read `/tmp/*` or any other log path.
+- **The CLI validates handoffs.** For `slack`/`email`, that Shell blocks and polls until OAuth or inbound email completes. Do not call Novu/Slack APIs or use OAuth tools to verify completion.
+- **Report conclusion-first.** Lead with the CLI's result (live / failed), then the one action the user must take. Keep it terse.
+- **Use the option picker for decisions.** When the user must choose between fixed options, call the structured question tool — never ask decision questions as plain chat text. See [User decisions (option picker)](#user-decisions-option-picker).
+
+---
+
+## User decisions (option picker)
+
+When the user must pick from a **fixed set** of options (channel, approve/reject, retry, etc.), call the structured question tool — do not list choices as plain chat text:
+
+- **Cursor:** `AskQuestion` with 2–4 `options` (short `label` per option).
+- **Claude Code:** `AskUserQuestion` with the same shape (`label` + optional `description`).
+
+**Use the picker for:** Step 1 (channel) and Step 2 (approve / edit description).
+
+**Do not use the picker for:** free-text values (e.g. Slack config token, edited agent description prose) — ask in chat normally.
+
+**If the tool is unavailable:** number options (`a1`, `a2`, …) and ask for a reply like `q1a2`.
+
+---
+
+## Glossary (shared language — use these terms)
+
+| Term | Meaning |
+|---|---|
+| **Keyless mode** | Default. Creates a temporary agent with no Novu account. Do **not** pass `--secret-key`. |
+| **Demo runtime** | Always used in this flow — shared Claude runtime, no API key needed. Limited to ~5 free replies. |
+| **Handoff** | The channel-specific user action (authorize link or send email) that finishes connecting the channel. |
+| **Connect shell** | The one Shell invocation that runs the Step 3 connect command. All connect output lives here — not in log files or separate watch commands. |
+| **CLI poll** | For `slack`/`email`, the Connect shell blocks up to ~5 min until the handoff completes. Success or timeout comes from its stdout only. |
+| **Claim** | User signs up via the in-channel link, migrating the temporary agent + channel + conversation into their own workspace. |
+
+---
+
+## Flow overview
+
+1. **Channel** — ask which channel; collect channel-specific inputs.
+2. **Purpose** — infer a 1–2 sentence agent description **for the product's end users** from the project; confirm with the user.
+3. **Run** — connect command from Step 3 (keyless, `--ci`), streamed.
+4. **Handoff** — read stdout; give the user the channel-specific next step; let the CLI poll.
+5. **Report** — relay the CLI's success or error; explain the demo limit → claim.
+
+---
+
+## Step 1 — Choose channel and collect inputs
+
+**Goal:** lock the channel and gather only what that channel needs.
+
+**Always ask the user to choose** — never assume. Call `AskQuestion` (Cursor) or `AskUserQuestion` (Claude Code) with these three options — do **not** offer `telegram` in the picker (explain separately if asked):
+
+| Option id | Label | What the user must do |
+|---|---|---|
+| `slack` | Slack | Provide a **Slack App Configuration Token** (`xoxe.xoxp-…`), then click an OAuth link to approve the install. |
+| `email` | Email | Nothing up front. The CLI prints an inbound email address; the user sends one email to it. |
+| `skip` | Skip for now | Create the agent only; connect a channel later. |
+
+**`telegram` is not in the picker** — setup is interactive (QR scans) and the non-interactive CLI rejects it. If the user asks: tell them to pick another channel, or run the Step 3 connect command with `--channel telegram` themselves (without `--ci`) and follow the prompts.
+
+**Collect after they choose:**
+
+- **slack** → the **Slack App Configuration Token** (`xoxe.xoxp-…`, required). The CLI uses it once; it is never stored. The user generates it at <https://api.slack.com/apps> under **"Your App Configuration Tokens"** (see <https://api.slack.com/authentication/config-tokens>); copy the **access token** (`xoxe.xoxp-…`), which is short-lived (~12h).
+- **email / skip** → no extra input.
+
+**Runtime:** always use the **demo runtime** — do not ask for an Anthropic API key and do not pass `--runtime` or `--anthropic-api-key`.
+
+**Do not** ask for the agent name/description — you infer it next.
+
+---
+
+## Step 2 — Infer the agent's purpose, then confirm
+
+**Goal:** produce one agent description the user signs off on.
+
+**Persona rule:** infer **who the application is built for** and frame the agent for that audience. The agent acts on behalf of the product, serving its users — it is **never** a coding/ops assistant for the team building the project. If the product's users are developers (devtools, API platforms, SDKs), then and only then is a developer-facing agent correct.
+
+Read the project to decide what the agent should *do*:
+
+- `README.md`, `package.json` (name/description/keywords), and the app's primary source (routes, domain models, product copy).
+
+While reading, build two lists:
+
+1. **What the agent does** — tasks the end user would bring to the agent (answer questions about X, manage Y, …). Not repo/CI/ops tasks for the development team.
+2. **What the end user actually uses** — external products the audience interacts with directly and would recognize by name: docs/KB (Notion), support chat (Intercom), payments (Stripe — only if they use Stripe's UI), team chat (Slack), and so on. These become the agent's **MCP servers** when named in the description. **Do not** put internal/backend infrastructure here — databases (PostgreSQL, MySQL, MongoDB), email delivery APIs (Resend, SendGrid), queues, caches, or cloud storage the user never sees. Do **not** include dev tooling (GitHub, Sentry, Linear, Jira) unless the product's audience is developers, or the dev tool is something the end user directly uses (e.g. a developer-docs agent that searches **Notion**).
+
+**Never name what the end user doesn't use.** The description is the **entire input** to the server. It becomes the agent prompt; the server expands it into a system prompt, tools, skills, and **MCP server picks** — it attaches an MCP for every service name it finds. Naming PostgreSQL, Resend, or any other backend plumbing will wire integrations the agent should not have. Only name a service when the end user genuinely interacts with that product.
+
+Then draft a concise **1–2 sentence description** that **must name the audience**. Name services from list 2 **only when the end user actually uses them** — omit integration clauses entirely when list 2 is empty. Required shape:
+
+> _"A &lt;role&gt; for &lt;product&gt;'s &lt;audience — shoppers, members, ops staff, …&gt; that &lt;key tasks in domain language&gt;."_
+
+When list 2 is non-empty, append **in/via** clauses for those end-user-facing services only:
+
+> _"…that &lt;key tasks&gt; **in Notion**, and can &lt;action&gt; **via Intercom**."_
+
+**Bad** (developer persona — wrong audience):
+
+> _"A coding assistant for the Cellar team that reviews PRs **in GitHub** and triages errors **in Sentry**."_
+
+**Bad** (internal infrastructure named — server will attach wrong MCPs):
+
+> _"An inventory assistant for Cellar's wine bar staff that checks stock **in PostgreSQL** and sends confirmations **via Resend**."_
+
+**Good** (audience named, domain tasks only — no infra the user doesn't touch):
+
+> _"An inventory assistant for Cellar's wine bar staff that helps them check wine stock levels, par, vendor details, purchase orders, and invoices."_
+
+**Good** (end-user-facing integration named — user actually uses Intercom):
+
+> _"A support assistant for Acme's customers that answers billing questions and looks up order status, and can escalate live chats **via Intercom**."_
+
+**Before showing the draft, self-check:**
+
+1. The audience is named and every task is something that audience would ask for — no developer-persona drift.
+2. No internal infrastructure, email APIs, databases, or dev tooling the end user doesn't directly use.
+3. Every service in list 2 appears by name; if list 2 is empty, no integration names appear.
+
+If any check fails, rewrite — do not show a draft that fails.
+
+Show the draft and briefly note the inferred audience (e.g. "this agent will serve Cellar's wine bar staff") and any end-user-facing integrations it names and why, then call `AskQuestion` / `AskUserQuestion` with:
+
+| Option id | Label |
+|---|---|
+| `approve` | Looks good — run connect |
+| `edit` | I want to change the description |
+
+If they pick **edit**, ask for their revised text in chat (not the picker), update the draft, and ask again until they pick **approve**. If their revision drops a service name, warn once that the agent will lose that integration — but their wording wins. **Never run the command until they approve.**
+
+---
+
+## Step 3 — Run connect (keyless, non-interactive)
+
+**Goal:** create the agent and start the channel connection in one Connect shell.
+
+Keyless is the default — do **not** pass `--secret-key`. Substitute the channel the user picked. Run the command **exactly as written** — no `>`, `tee`, or log file.
+
+```bash
+npx novu connect "<CONFIRMED AGENT DESCRIPTION>" \
+  --ci \
+  --channel <slack|email|skip>
+```
+
+**Canonical example (slack):**
+
+```bash
+npx novu connect "<CONFIRMED AGENT DESCRIPTION>" \
+  --ci \
+  --channel slack \
+  --slack-config-token "<xoxe.xoxp-...>"
+```
+
+**How to run the Connect shell** — pick one path; never combine with log redirection or a second watch command:
+
+- **If channel is `slack` or `email`:** Shell with `block_until_ms: 0` (background). Use **Await** on that shell id to read output as it arrives (e.g. pattern `NOVU_CONNECT_SLACK_AUTHORIZE_URL=` or `NOVU_CONNECT_INBOUND_ADDRESS=`). When the user finishes the handoff, **Await** again until `✓ Your agent is live` or a `✗` error. Do not use Monitor, `tail -f`, `grep`, Read on log files, or ask for permission to watch logs.
+- **If channel is `skip`:** a normal foreground Shell is enough — the CLI exits quickly after printing the success block.
+
+Conditional flags — apply each only when its condition holds:
+
+- **If channel is `slack`:** also pass `--slack-config-token "<xoxe.xoxp-...>"`.
+- **If channel is `telegram`:** do **not** use `--ci` (it is rejected) — telegram must be run interactively by the user. Otherwise, `--ci` is required (no prompts, no TUI).
+- **Runtime:** do not pass `--runtime` or `--anthropic-api-key` — the **demo runtime** is always used.
+- **Region:** pass `--region eu` only when the user explicitly asks; otherwise the default is **US** Novu Cloud.
+
+Always required: the positional description (in `--ci` mode).
+
+**Safe retry — Slack only:** if the run fails with `Failed to create Slack app: …` (Slack's app-create can be slow on a cold first call), **silently re-run the exact same command once** before reporting anything — the step is safe to repeat. Only surface an error if the second attempt also fails.
+
+---
+
+## Step 4 — Channel-specific handoff (human-in-the-loop)
+
+**Goal:** give the user the one action that finishes connecting their channel.
+
+**If channel is `slack` or `email`:** deliver the handoff from the Connect shell stdout, then **Await** the same shell until the **CLI poll** finishes. Do not start a separate watch process, read log files, or validate OAuth/email yourself.
+
+Read Connect shell stdout (via **Await**, not log files) and act based on the chosen channel:
+
+- **slack** — connection can't be automated. Watch for the machine-readable line:
+
+  ```
+  NOVU_CONNECT_SLACK_AUTHORIZE_URL=<url>
+  ```
+
+  Parse the URL after `=`. Give it to the user and ask them to approve the install **within 5 minutes**. Then wait for the CLI poll to finish — the process exits on its own once they authorize. If it times out (~5 min), it prints an error; **re-run the same command** (the Slack app is reused).
+
+- **email** — watch for these machine-readable lines (plain stdout, no ANSI):
+
+  ```
+  NOVU_CONNECT_INBOUND_ADDRESS=<address>
+  NOVU_CONNECT_MAILTO=<mailto-url>
+  NOVU_CONNECT_SEND_FROM_EMAIL=<email>   # only when present
+  ```
+
+  Give the user:
+  1. The **mailto link** (`NOVU_CONNECT_MAILTO=…`) — one click opens a pre-filled draft in their mail client; this is the primary handoff.
+  2. The **inbound address** as a copy-paste fallback.
+  3. If `NOVU_CONNECT_SEND_FROM_EMAIL` is present, tell them to send **from that address** so the agent can reply.
+
+  Then wait for the **CLI poll** — the process completes once the email arrives; on timeout, re-run after they've sent it.
+
+- **skip** — nothing to hand off; the agent is created without a channel.
+
+---
+
+## Step 5 — Report the result
+
+**Goal:** relay what the CLI printed, point the user at the channel, explain the claim path.
+
+On success the CLI exits `0` and prints a block like:
+
+```
+✓ Your agent is live.
+  Agent: <name> (<identifier>)
+  → Check <Channel> — your agent just messaged you.      # connected channels (slack/email)
+  Dashboard: <dashboard url>
+```
+
+Extract the **agent identifier** and **Dashboard URL**, then tell the user:
+
+- Their agent is live — go message it on the connected channel.
+- **Keyless demo limit:** they get ~5 free replies. After that, the agent posts a **"Sign up & keep this agent"** link in the channel. Clicking it creates their Novu account and **migrates the agent, the channel connection, and the whole conversation** into their new workspace's Development environment — the agent picks up right where it left off.
+
+**On failure** (non-zero exit, or a line starting with `✗`), surface the error message and the matching fix:
+
+| Symptom | Fix |
+|---|---|
+| `…requires --prompt "<agent description>"` | You didn't pass the positional description — re-run Step 3 with it. |
+| `…--slack-config-token "xoxe.xoxp-…"` | Ask the user for the Slack App Configuration Token (Step 1) and pass it. |
+| `Failed to create Slack app: …` (e.g. timeout) | Transient — Slack's app-create can be slow on a cold call. Silently re-run the same command once; only surface if it fails again. |
+| `Slack OAuth was not completed within … seconds` | User didn't approve in time — re-run the same command (the Slack app is reused). |
+| `We didn't see your email at … within …s` | User hasn't emailed the inbound address yet — re-run after they send it. |
+| `Telegram setup is interactive only …` | Don't use `--ci` for telegram; have the user run it interactively, or pick another channel. |
+| `Keyless environment creation is currently disabled` / no demo integration | Target API isn't configured for keyless/demo — confirm the right `--region`, or have the user provide `--secret-key` for their existing account. |
+
+---
+
+## Command flag reference (the subset this flow uses)
+
+| Flag | Purpose |
+|---|---|
+| `connect "<description>"` | Positional agent description (required in `--ci`). |
+| `--ci` | Non-interactive mode (omit for `telegram`). |
+| `--region <us\|eu>` | Target Novu Cloud region (default: `us`). |
+| `--channel <slack\|email\|telegram\|skip>` | Which channel to connect. |
+| `--slack-config-token <xoxe.xoxp-…>` | Create the Slack app headlessly (slack only). |
+| `--secret-key <key>` | Optional — use an existing Novu account instead of keyless. |
+
+---
+
+## Limitations to keep in mind
+
+- **One run = one new agent + one channel.** Re-running `connect` creates another agent; there is no "add a channel to the existing agent" in this non-interactive flow yet.
+- **Channel support is uneven headlessly:** `slack` and `email` complete with one user action; `telegram` is interactive-only (QR) and not usable through this flow.
+- Keyless data is temporary until the user claims it via the in-channel sign-up link.
+- The CLI stores keyless credentials **per API URL**, so switching `--region` between runs does not require clearing `~/.config/configstore/novu-cli.json`.
+
+---
+
+## Definition of done
+
+You are done when:
+
+1. The user picked a channel and you collected its required inputs.
+2. The user confirmed the agent description.
+3. You delivered the handoff (link / address) — or noted `skip`.
+4. The Connect shell printed `✓ Your agent is live.` (exit `0`). You never used Monitor, log files, or a separate watch command; for `slack`/`email`, the **CLI poll** validated the handoff.
+5. You reported the agent identifier + Dashboard URL and explained the demo limit → claim path.


### PR DESCRIPTION
Replace the old /connect/agent-onboarding.md path with a root-level agents.md for AI coding agents, and redirect the legacy URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated agent onboarding documentation with comprehensive instructions for creating and connecting Novu agents to channels including Slack, Email, and other options.

* **Chores**
  * Added redirect rule to ensure old documentation links automatically route to updated agent resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->