### PR TITLE
fixes MRK-1808: Migrate robots.txt with Content-Signal directives

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -3,13 +3,28 @@
 // (not directories), so `trailingSlash: false` keeps the canonical URL exact.
 const agentDiscoveryFiles = ["/agents.md", "/auth.md", "/llms.txt"]
 
+const CONTENT_SIGNAL = "Content-Signal: ai-train=yes, search=yes, ai-input=yes"
+
+function addContentSignal(robotsTxt) {
+  return robotsTxt
+    .split("\n")
+    .flatMap((line) =>
+      line.trim() === "Allow: /" ? [line, CONTENT_SIGNAL] : [line]
+    )
+    .join("\n")
+}
+
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
   siteUrl: process.env.NEXT_PUBLIC_DEFAULT_SITE_URL || "http://localhost:3000",
   trailingSlash: true,
-  generateRobotsTxt: false,
+  generateRobotsTxt: true,
   sitemapBaseFileName: "next-sitemap",
   exclude: ["/studio", "/studio/*", "/api/*"],
+  robotsTxtOptions: {
+    policies: [{ userAgent: "*", allow: "/" }],
+    transformRobotsTxt: async (_, robotsTxt) => addContentSignal(robotsTxt),
+  },
   additionalPaths: async () =>
     agentDiscoveryFiles.map((loc) => ({
       loc,

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -3,6 +3,8 @@
 // (not directories), so `trailingSlash: false` keeps the canonical URL exact.
 const agentDiscoveryFiles = ["/agents.md", "/auth.md", "/llms.txt"]
 
+const siteUrl = process.env.NEXT_PUBLIC_DEFAULT_SITE_URL || "http://localhost:3000"
+
 const CONTENT_SIGNAL = "Content-Signal: ai-train=yes, search=yes, ai-input=yes"
 
 function addContentSignal(robotsTxt) {
@@ -16,13 +18,14 @@ function addContentSignal(robotsTxt) {
 
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
-  siteUrl: process.env.NEXT_PUBLIC_DEFAULT_SITE_URL || "http://localhost:3000",
+  siteUrl,
   trailingSlash: true,
   generateRobotsTxt: true,
   sitemapBaseFileName: "next-sitemap",
   exclude: ["/studio", "/studio/*", "/api/*"],
   robotsTxtOptions: {
     policies: [{ userAgent: "*", allow: "/" }],
+    additionalSitemaps: [`${siteUrl}/sitemap-index.xml`],
     transformRobotsTxt: async (_, robotsTxt) => addContentSignal(robotsTxt),
   },
   additionalPaths: async () =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Migrates `robots.txt` generation from the Gatsby site to website-new using the existing `next-sitemap` postbuild step.

## Changes

- Enable `generateRobotsTxt` in `next-sitemap.config.js`
- Add `Content-Signal: ai-train=yes, search=yes, ai-input=yes` inside the wildcard user-agent group
- Reference `next-sitemap.xml` as the sitemap (matching the new site)

## Expected output

```
User-agent: *
Allow: /
Content-Signal: ai-train=yes, search=yes, ai-input=yes

Host: https://novu.co

Sitemap: https://novu.co/next-sitemap.xml
```

## Related

- Companion PR in `novuhq/website` adds the Netlify proxy redirect for `novu.co/robots.txt`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52e0728b-54eb-4aa6-9e9f-e720750c3824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52e0728b-54eb-4aa6-9e9f-e720750c3824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

