### PR TITLE
web: add RFC 8288 Link headers for agent discovery (fixes MRK-1796)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,9 @@
 import type { NextConfig } from "next"
 import createMDX from "@next/mdx"
 
+const agentDiscoveryLinkHeader =
+  '</.well-known/api-catalog>; rel="api-catalog", </llms.txt>; rel="describedby", </agents.md>; rel="describedby", </auth.md>; rel="describedby", <https://docs.novu.co/api-reference>; rel="service-doc", <https://api.novu.co/openapi.json>; rel="service-desc"'
+
 const securityHeaders = [
   {
     key: "X-Content-Type-Options",
@@ -56,6 +59,29 @@ const nextConfig: NextConfig = {
   },
   async headers() {
     return [
+      {
+        source: "/",
+        headers: [
+          {
+            key: "Link",
+            value: agentDiscoveryLinkHeader,
+          },
+        ],
+      },
+      {
+        source: "/.well-known/api-catalog",
+        headers: [
+          {
+            key: "Content-Type",
+            value:
+              'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"',
+          },
+          {
+            key: "Cache-Control",
+            value: "public, max-age=3600",
+          },
+        ],
+      },
       {
         source: "/.well-known/agent-skills/index.json",
         headers: [

--- a/public/.well-known/api-catalog
+++ b/public/.well-known/api-catalog
@@ -1,0 +1,55 @@
+{
+  "linkset": [
+    {
+      "anchor": "https://novu.co/.well-known/api-catalog",
+      "item": [
+        { "href": "https://api.novu.co/v1" },
+        { "href": "https://eu.api.novu.co/v1" },
+        { "href": "https://mcp.novu.co/" }
+      ]
+    },
+    {
+      "anchor": "https://api.novu.co/v1",
+      "service-desc": [
+        {
+          "href": "https://api.novu.co/openapi.json",
+          "type": "application/json"
+        }
+      ],
+      "service-doc": [
+        {
+          "href": "https://docs.novu.co/api-reference",
+          "type": "text/html"
+        }
+      ]
+    },
+    {
+      "anchor": "https://eu.api.novu.co/v1",
+      "service-desc": [
+        {
+          "href": "https://eu.api.novu.co/openapi.json",
+          "type": "application/json"
+        }
+      ],
+      "service-doc": [
+        {
+          "href": "https://docs.novu.co/api-reference",
+          "type": "text/html"
+        }
+      ]
+    },
+    {
+      "anchor": "https://mcp.novu.co/",
+      "service-doc": [
+        {
+          "href": "https://docs.novu.co/platform/build-with-ai/mcp",
+          "type": "text/html"
+        },
+        {
+          "href": "https://novu.co/mcp/",
+          "type": "text/html"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Moves the agent discovery implementation from [novuhq/website#426](https://github.com/novuhq/website/pull/426) into `website-new`, where the other agent-facing resources (`llms.txt`, `agents.md`, `auth.md`) already live.

## Changes

### `public/.well-known/api-catalog`

New RFC 9727 linkset document listing:

- **Novu REST API (US)** — `https://api.novu.co/v1`
- **Novu REST API (EU)** — `https://eu.api.novu.co/v1`
- **Novu MCP Server** — `https://mcp.novu.co/`

Each entry includes `service-desc` (OpenAPI JSON) and `service-doc` links.

### `next.config.ts`

- Homepage `/` response includes RFC 8288 `Link` headers pointing to the api-catalog, agent docs, API reference, and OpenAPI spec
- `/.well-known/api-catalog` served with `application/linkset+json` content type and cache headers

## Companion PR

Requires [novuhq/website#TBD](https://github.com/novuhq/website) for Netlify proxy + homepage Link headers on `novu.co`.

## Verification

```bash
curl -sI https://novu.co/ | grep -i '^link:'
curl -s https://novu.co/.well-known/api-catalog | jq .
```

## References

- [RFC 8288 — Web Linking](https://www.rfc-editor.org/rfc/rfc8288)
- [RFC 9727 — api-catalog Link Relation](https://www.rfc-editor.org/rfc/rfc9727#section-3)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-294dd69e-2b91-4cbd-b6f4-0fce1ec41094"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-294dd69e-2b91-4cbd-b6f4-0fce1ec41094"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

