### PR TITLE
fixes MRK-1808: Serve robots.txt via Next.js route handler

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -5,29 +5,15 @@ const agentDiscoveryFiles = ["/agents.md", "/auth.md", "/llms.txt"]
 
 const siteUrl = process.env.NEXT_PUBLIC_DEFAULT_SITE_URL || "http://localhost:3000"
 
-const CONTENT_SIGNAL = "Content-Signal: ai-train=yes, search=yes, ai-input=yes"
-
-function addContentSignal(robotsTxt) {
-  return robotsTxt
-    .split("\n")
-    .flatMap((line) =>
-      line.trim() === "Allow: /" ? [line, CONTENT_SIGNAL] : [line]
-    )
-    .join("\n")
-}
-
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
   siteUrl,
   trailingSlash: true,
-  generateRobotsTxt: true,
+  // robots.txt is served by src/app/(website)/robots.txt/route.ts so it is
+  // included in the Next.js build output (postbuild public/ files are not).
+  generateRobotsTxt: false,
   sitemapBaseFileName: "next-sitemap",
   exclude: ["/studio", "/studio/*", "/api/*"],
-  robotsTxtOptions: {
-    policies: [{ userAgent: "*", allow: "/" }],
-    additionalSitemaps: [`${siteUrl}/sitemap-index.xml`],
-    transformRobotsTxt: async (_, robotsTxt) => addContentSignal(robotsTxt),
-  },
   additionalPaths: async () =>
     agentDiscoveryFiles.map((loc) => ({
       loc,

--- a/src/app/(website)/robots.txt/route.ts
+++ b/src/app/(website)/robots.txt/route.ts
@@ -1,0 +1,25 @@
+const SITE_URL = process.env.NEXT_PUBLIC_DEFAULT_SITE_URL || "https://novu.co"
+
+const CONTENT_SIGNAL = "Content-Signal: ai-train=yes, search=yes, ai-input=yes"
+
+function buildRobotsTxt() {
+  return [
+    "User-agent: *",
+    "Allow: /",
+    CONTENT_SIGNAL,
+    "",
+    `Host: ${SITE_URL}`,
+    "",
+    `Sitemap: ${SITE_URL}/next-sitemap.xml`,
+    `Sitemap: ${SITE_URL}/sitemap-index.xml`,
+    "",
+  ].join("\n")
+}
+
+export function GET() {
+  return new Response(buildRobotsTxt(), {
+    headers: {
+      "Content-Type": "text/plain",
+    },
+  })
+}


### PR DESCRIPTION
## Summary

- Fixes `/robots.txt` returning 404 on Vercel after #88
- Serves `robots.txt` from `src/app/(website)/robots.txt/route.ts` (same pattern as `blog/rss.xml`)
- Disables `next-sitemap` postbuild `generateRobotsTxt` — files written to `public/` after `next build` are not included in the Vercel deployment output
- Preserves Content-Signal directives and both sitemap references (`next-sitemap.xml`, `sitemap-index.xml`)

## Root cause

PR #88 enabled `generateRobotsTxt: true` in `next-sitemap`, which runs in `postbuild` after `next build`. The generated `public/robots.txt` is gitignored and never makes it into the Vercel static asset bundle. Committed `public/` files (e.g. `/agents.md`) work fine.

## Test plan

- [ ] Deploy preview and confirm `GET /robots.txt` returns 200
- [ ] Verify response includes Content-Signal, Host, and both Sitemap lines
- [ ] Confirm `NEXT_PUBLIC_DEFAULT_SITE_URL` is respected in Host/Sitemap URLs


Made with [Cursor](https://cursor.com)