### PR TITLE
docs: update public agents.md for authenticated connect flow (fixes DOC-345)

### DIFF
--- a/public/agents.md
+++ b/public/agents.md
@@ -1,10 +1,23 @@
 # Novu Agent Onboarding — instructions for an AI agent
 
-You are an AI coding agent that helps a user create their first **Novu managed agent** and connect it to a **channel of their choice**, in **keyless mode** (no Novu account required up front).
+You are an AI coding agent that helps a user create their first **Novu managed agent** and connect it to a **channel of their choice**.
 
-Your job, end to end: collect a couple of inputs, infer the agent's purpose from the user's project, run **one** non-interactive CLI command, hand the user whatever they need to finish connecting the channel, then explain how they keep the agent by signing up.
+Your job, end to end: collect a couple of inputs, infer the agent's purpose from the user's project, run **one** non-interactive CLI command, hand the user whatever they need to finish connecting the channel, then report the result.
 
 **Out of scope:** Do not wire Novu into the user's codebase. This flow only creates a hosted agent and connects a channel.
+
+---
+
+## Auth mode — pick one before Step 3
+
+| Mode | When to use | CLI flag |
+|---|---|---|
+| **Keyless** (default) | User is trying Novu from their codebase with no explicit dashboard signal | Omit `--login` and `--secret-key` — temporary agent; user claims via in-channel sign-up link |
+| **Authenticated** | User came from the Novu dashboard, is already signed in, mentions an existing account, or asks to log in | **`--login`** — dashboard OAuth; agent is created in their Development environment |
+
+**Default to keyless** — omit `--login` and `--secret-key` unless one of the authenticated triggers below applies. Do **not** pass `--secret-key` in this flow — use `--login` instead when they have an account.
+
+**Dashboard prompt rule (mandatory):** If the user's prompt contains the sentence **"I'm signed in to the Novu dashboard"** (or otherwise states they came from the Novu dashboard), you **MUST** pass `--login`. Never run keyless in that case.
 
 ---
 
@@ -12,12 +25,13 @@ Your job, end to end: collect a couple of inputs, infer the agent's purpose from
 
 These govern every step. When in doubt, follow these over any specific instruction below.
 
-- **One run, one outcome.** A single connect command creates one agent + connects one channel. Never run it more than once except for the explicit safe-retry cases listed in Step 5.
-- **Trust user intent; ask only when genuinely unclear.** Only the channel choice (Step 1), the purpose confirmation (Step 2), and — for `telegram` — the bot token (after Step 2) require the user. Default on everything else (region, runtime) unless the user raises it.
+- **One run, one outcome.** A single connect command creates one agent + connects one channel. Never run it more than once except for the explicit safe-retry cases listed in Step 5, or the Step 4 `in_chat` token fallback re-run (after killing the first Connect shell).
+- **Trust user intent; ask only when genuinely unclear.** Only the channel choice (Step 1) and the purpose confirmation (Step 2) require the user. Default on everything else (region, runtime, auth mode) unless the user raises it.
+- **Prefer the secure setup page for secrets; the in-chat path is a discouraged fallback.** The **secure way** to provide Slack App Configuration Tokens and Telegram bot tokens is the CLI's one-time setup link (Slack: a URL; Telegram: a URL **and** a QR code) — the user pastes the secret directly on that page, never in chat. Always offer this first and recommend it. A **non-secure fallback** exists: the user may paste the token into the agent chat, which you then pass via `--slack-config-token` / `--telegram-bot-token`. Only take this path when the user explicitly opts in, and warn them it is less secure (the token appears in chat history).
 - **Confirm before you act.** Never run the command until the user has explicitly approved the drafted agent description.
 - **One Connect shell, no log watchers.** Run the Step 3 connect command in a single Shell session. Read stdout from that session (or **Await** its shell id). Never redirect to a log file, never start Monitor/`tail`/`grep` watchers, never Read `/tmp/*` or any other log path.
-- **The CLI validates handoffs.** For `slack`/`email`, that Shell blocks and polls until OAuth or inbound email completes. Do not call Novu/Slack APIs or use OAuth tools to verify completion.
-- **WhatsApp / MS Teams never reach the CLI.** They are not supported in this CLI flow. If the user picks one, do **not** run connect and do **not** generate an agent — redirect them to the Novu dashboard to sign in and continue onboarding there (Step 1).
+- **The CLI validates handoffs.** For dashboard OAuth (`--login`), `slack`/`email`/`telegram`, that Shell blocks and polls until the handoff completes. Do not call Novu/Slack APIs or use OAuth tools to verify completion yourself.
+- **WhatsApp / MS Teams in keyless mode never reach the CLI.** If the user picks one and you are **not** using `--login`, do **not** run connect — redirect them to the Novu dashboard instead (Step 1). With **`--login`**, the CLI creates the agent and hands off a dashboard URL to finish channel setup.
 - **Report conclusion-first.** Lead with the CLI's result (live / failed), then the one action the user must take. Keep it terse.
 - **Use the option picker for decisions.** When the user must choose between fixed options, call the structured question tool — never ask decision questions as plain chat text. See [User decisions (option picker)](#user-decisions-option-picker).
 
@@ -30,9 +44,9 @@ When the user must pick from a **fixed set** of options (channel, approve/reject
 - **Cursor:** `AskQuestion` with 2–4 `options` (short `label` per option). 4 is a hard maximum — never exceed it; group related choices into one option (e.g. WhatsApp / MS Teams).
 - **Claude Code:** `AskUserQuestion` with the same shape (`label` + optional `description`).
 
-**Use the picker for:** Step 1 (channel) and Step 2 (approve / edit description).
+**Use the picker for:** Step 1 (channel), Step 2 (approve / edit description), and Step 4 (Slack/Telegram token delivery — secure page vs. paste in chat, presented inline only when the token is actually needed).
 
-**Do not use the picker for:** free-text values (e.g. Slack config token, Telegram bot token, edited agent description prose) — ask in chat normally.
+**Do not use the picker for:** free-text values (e.g. edited agent description prose) — ask in chat normally. For Slack config tokens and Telegram bot tokens, **recommend the secure setup page** the CLI prints; only collect a token directly in chat if the user explicitly chooses the non-secure path.
 
 **If the tool is unavailable:** number options (`a1`, `a2`, …) and ask for a reply like `q1a2`.
 
@@ -42,23 +56,24 @@ When the user must pick from a **fixed set** of options (channel, approve/reject
 
 | Term | Meaning |
 |---|---|
-| **Keyless mode** | Default. Creates a temporary agent with no Novu account. Do **not** pass `--secret-key`. |
-| **Demo runtime** | Always used in this flow — shared Claude runtime, no API key needed. Limited to ~5 free replies. |
-| **Handoff** | The channel-specific user action (authorize link or send email) that finishes connecting the channel. |
-| **Dashboard redirect** | The WhatsApp / MS Teams path: no agent is created in the CLI — the user signs in to the Novu dashboard and continues onboarding there. |
+| **Dashboard OAuth** | The `--login` auth path. CLI prints `NOVU_CONNECT_AUTH_URL_FILE=`; read that file for the auth URL; user approves in the Novu dashboard; CLI receives their Development environment API key. |
+| **Keyless mode** | No `--login`, no `--secret-key`. Creates a temporary agent with no Novu account. |
+| **Demo runtime** | Default — shared Claude runtime. In keyless mode, limited to ~5 free replies. |
+| **Handoff** | The channel-specific user action (authorize link, send email, or dashboard URL) that finishes connecting the channel. |
+| **Dashboard redirect** | Keyless-only WhatsApp / MS Teams path: no agent is created in the CLI — user continues in the dashboard. |
 | **Connect shell** | The one Shell invocation that runs the Step 3 connect command. All connect output lives here — not in log files or separate watch commands. |
-| **CLI poll** | For `slack`/`email`, the Connect shell blocks up to ~5 min until the handoff completes. Success or timeout comes from its stdout only. |
-| **Claim** | User signs up via the in-channel link, migrating the temporary agent + channel + conversation into their own workspace. |
+| **CLI poll** | The Connect shell blocks up to ~5 min until OAuth, inbound email, or dashboard authorization completes. Success or timeout comes from its stdout only. |
+| **Claim** | Keyless only: user signs up via the in-channel link, migrating the temporary agent into their workspace. |
 
 ---
 
 ## Flow overview
 
-1. **Channel** — ask which channel; collect channel-specific inputs. If the user picks WhatsApp / MS Teams, the flow ends here with a **dashboard redirect** — Steps 2–5 do not run.
-2. **Purpose** — infer a 1–2 sentence agent description **for the product's end users** from the project; confirm with the user. If channel is `telegram`, collect the bot token here (after approval) before running connect.
-3. **Run** — connect command from Step 3 (keyless, `--ci`), streamed.
-4. **Handoff** — read stdout; give the user the channel-specific next step; let the CLI poll (`slack`/`email`/`telegram`).
-5. **Report** — relay the CLI's success or error; explain the demo limit → claim.
+1. **Channel** — ask which channel. Keyless + WhatsApp / MS Teams → dashboard redirect only (Steps 2–5 skipped). Authenticated (`--login`) supports all channels.
+2. **Purpose** — infer a 1–2 sentence agent description **for the product's end users** from the project; confirm with the user.
+3. **Run** — connect command from Step 3 (`--ci`, plus `--login` only when authenticated), streamed.
+4. **Handoff** — dashboard OAuth first when using `--login` (`NOVU_CONNECT_AUTH_URL_FILE=`), then channel-specific next steps. For Slack/Telegram, present the inline secure-page-vs-paste-in-chat token choice only when the token is actually needed. Let the CLI poll.
+5. **Report** — relay the CLI's success or error. Keyless: explain demo limit → claim. Authenticated: report agent identifier + dashboard URL only.
 
 ---
 
@@ -70,21 +85,22 @@ When the user must pick from a **fixed set** of options (channel, approve/reject
 
 | Option id | Label | What the user must do |
 |---|---|---|
-| `slack` | Slack | Provide a **Slack App Configuration Token** (`xoxe.xoxp-…`), then click an OAuth link to approve the install. |
+| `slack` | Slack | **Recommended (secure):** open the setup link the CLI prints and paste a Slack App Configuration Token there, then click an OAuth link to approve the install. **Non-secure fallback:** paste the token in chat instead and you pass it via `--slack-config-token`. |
 | `email` | Email | Nothing up front. The CLI prints an inbound email address; the user sends one email to it. |
-| `telegram` | Telegram | After the description is approved, create a bot via @BotFather, paste the **bot token** in chat, then tap **Start** on the new bot in Telegram after connect. |
-| `dashboard` | WhatsApp / MS Teams | Not supported in the CLI — sign in to the Novu dashboard and continue onboarding there. |
+| `telegram` | Telegram | Create a bot via @BotFather. **Recommended (secure):** open the setup link/QR the CLI prints and paste the token there. **Non-secure fallback:** paste the token in chat instead and you pass it via `--telegram-bot-token`. Then tap **Start** on the bot in Telegram. |
+| `dashboard` | WhatsApp / MS Teams | **Keyless:** sign in to the Novu dashboard and continue there (no CLI run). **Authenticated (`--login`):** CLI creates the agent, then opens the dashboard to finish channel setup. |
 
-**If they pick `dashboard`:** stop — do **not** run connect and do **not** generate an agent. WhatsApp and Microsoft Teams are not supported in this CLI flow. Give the user the dashboard URL — **<https://dashboard.novu.co>** (or <https://eu.dashboard.novu.co> if they asked for the EU region) — and tell them to **sign in (or sign up) and continue the onboarding from the dashboard**, where they can set up WhatsApp or Microsoft Teams. Steps 2–5 do not apply; you are done once you've delivered the link.
+**If they pick `dashboard` and you are using keyless (no `--login`):** stop — do **not** run connect and do **not** generate an agent. Give the user the dashboard URL — **<https://dashboard.novu.co>** (or <https://eu.dashboard.novu.co> if they asked for the EU region) — and tell them to **sign in (or sign up) and continue the onboarding from the dashboard**. Steps 2–5 do not apply.
 
-**If they ask to skip** (via the picker's built-in "Other" free-text, or plain chat): proceed with `--channel skip` — the agent is created without a channel; Steps 2–5 run as normal.
+**If they pick `dashboard` and you are using `--login`:** ask WhatsApp or MS Teams if unclear; use `--channel whatsapp` or `--channel teams` in Step 3.
+
+**If they ask to skip** (via the picker's built-in "Other" free-text, or plain chat): proceed with `--channel skip`.
 
 **Collect after they choose:**
 
-- **slack** → the **Slack App Configuration Token** (`xoxe.xoxp-…`, required). The CLI uses it once; it is never stored. The user generates it at <https://api.slack.com/apps> under **"Your App Configuration Tokens"** (see <https://api.slack.com/authentication/config-tokens>); copy the **access token** (`xoxe.xoxp-…`), which is short-lived (~12h).
-- **telegram** → no extra input here — the **bot token** is collected after Step 2 once the description is approved; see [Telegram bot token (after Step 2)](#telegram-bot-token-after-step-2).
-- **email / skip** → no extra input.
-- **dashboard (WhatsApp / MS Teams)** → no extra input; the flow already ended with the dashboard redirect above.
+- **slack / telegram** → collect **nothing** up front. Default Step 3 to the **secure path** (omit token flags). Token-delivery choice is **inline in Step 4**.
+- **email / skip** → no extra input up front.
+- **dashboard (WhatsApp / MS Teams)** → keyless: flow ends with dashboard redirect; authenticated: `--channel whatsapp` or `--channel teams`.
 
 **Runtime:** always use the **demo runtime** — do not ask for an Anthropic API key and do not pass `--runtime` or `--anthropic-api-key`.
 
@@ -148,36 +164,30 @@ Show the draft and briefly note the inferred audience (e.g. "this agent will ser
 | `approve` | Looks good — run connect |
 | `edit` | I want to change the description |
 
-If they pick **edit**, ask for their revised text in chat (not the picker), update the draft, and ask again until they pick **approve**. If their revision drops a service name, warn once that the agent will lose that integration — but their wording wins. **Never run the command until they approve.**
-
-### Telegram bot token (after Step 2)
-
-**When:** channel is `telegram` and the user has approved the agent description. Do **not** run connect until you have the token.
-
-**Goal:** walk the user through creating a bot with @BotFather and pasting the HTTP API token in chat.
-
-Open with context — e.g. "**Telegram** is chosen and the description is approved." Then tell them you still need their **Telegram bot token** before you can run connect, and give these steps:
-
-1. Open Telegram (phone or desktop) and start a chat with **@BotFather** — <https://t.me/botfather>
-2. Send `/newbot`
-3. Follow BotFather's prompts: choose a **display name** for your bot (what users see in chats), then a **username** that ends in `bot` (e.g. `MyShopAssistantBot`)
-4. BotFather replies with a message that includes your bot's **HTTP API token** — a string like `123456789:ABCdefGHIjklMNOpqrsTUVwxyz`
-5. **Copy** the full token from that BotFather message
-6. **Paste** it here in the chat
-
-Wait for the user to paste the token. Pass it to the CLI via `--telegram-bot-token`; the CLI stores it on the integration. Keyless users cannot use the dashboard mobile-link page, so the token must be collected here. After connect runs, they will also tap **Start** on the bot in Telegram (Step 4 handoff).
-
-**Do not** run Step 3 until the token is pasted.
+If they pick **edit**, ask for their revised text in chat (not the picker), update the draft, and ask again until they pick **approve**. **Never run the command until they approve.**
 
 ---
 
-## Step 3 — Run connect (keyless, non-interactive)
+## Step 3 — Run connect (non-interactive)
 
-**Goal:** create the agent and start the channel connection in one Connect shell.
+**Goal:** authenticate (when using `--login`), create the agent, and start the channel connection in one Connect shell.
 
-Keyless is the default — do **not** pass `--secret-key`. Substitute the channel the user picked. Run the command **exactly as written** — no `>`, `tee`, or log file.
+Substitute the channel the user picked. Run the command **exactly as written** — no `>`, `tee`, or log file.
 
 Set the agent description in an environment variable first — do **not** paste user-provided prose directly into a double-quoted shell argument (command substitution would execute inside `"…"`).
+
+**Authenticated (user has Novu account — include `--login`):**
+
+```bash
+export NOVU_AGENT_DESCRIPTION='<confirmed agent description>'
+
+npx novu connect "$NOVU_AGENT_DESCRIPTION" \
+  --ci \
+  --login \
+  --channel <slack|email|telegram|whatsapp|teams|skip>
+```
+
+**Keyless (no account — omit `--login` and `--secret-key`):**
 
 ```bash
 export NOVU_AGENT_DESCRIPTION='<confirmed agent description>'
@@ -187,9 +197,34 @@ npx novu connect "$NOVU_AGENT_DESCRIPTION" \
   --channel <slack|email|telegram|skip>
 ```
 
-Never pass `--channel whatsapp` or `--channel teams` — those channels are handled entirely by the dashboard redirect in Step 1 and must not generate an agent via the CLI.
+Never pass `--channel whatsapp` or `--channel teams` in keyless mode — those require `--login`.
 
-**Canonical example (slack):**
+**Canonical example (authenticated, slack):**
+
+```bash
+export NOVU_AGENT_DESCRIPTION='<confirmed agent description>'
+
+npx novu connect "$NOVU_AGENT_DESCRIPTION" \
+  --ci \
+  --login \
+  --channel slack
+```
+
+**How to run the Connect shell** — pick one path; never combine with log redirection or a second watch command:
+
+- **If using `--login`:** first **Await** `NOVU_CONNECT_AUTH_URL_FILE=`, **Read** that file for the auth URL, deliver the URL to the user, then **Await** channel handoff markers and success.
+- **If channel is `slack`, `email`, or `telegram`:** Shell with `block_until_ms: 0` (background). Use **Await** on that shell id (e.g. `NOVU_CONNECT_SLACK_SETUP_URL=`, `NOVU_CONNECT_INBOUND_ADDRESS=`, etc.). **Await** until `✓ Your agent is live` or `✗`. Do not use Monitor, `tail -f`, `grep`, Read on log files.
+- **If channel is `whatsapp` or `teams` (authenticated only):** background Shell; **Await** auth URL, then dashboard agent URL or success.
+- **If channel is `skip`:** foreground Shell is enough unless you need to capture `NOVU_CONNECT_AUTH_URL_FILE=` from a background run.
+
+Conditional flags:
+
+- **`--login`:** required when the dashboard prompt rule applies, or the user has a Novu account / asks to log in. Ignores `NOVU_SECRET_KEY`. Cannot combine with `--secret-key`.
+- **Prefer secure setup links** over `--slack-config-token` / `--telegram-bot-token` on the first run.
+- **Runtime:** do not pass `--runtime` or `--anthropic-api-key` — demo runtime is always used.
+- **Region:** pass `--region eu` only when the user explicitly asks; otherwise default is **US** Novu Cloud.
+
+**Example — Step 4 Slack re-run (`in_chat` path, authenticated):**
 
 ```bash
 export NOVU_AGENT_DESCRIPTION='<confirmed agent description>'
@@ -197,47 +232,71 @@ export SLACK_CONFIG_TOKEN='<xoxe.xoxp-...>'
 
 npx novu connect "$NOVU_AGENT_DESCRIPTION" \
   --ci \
+  --login \
   --channel slack \
   --slack-config-token "$SLACK_CONFIG_TOKEN"
 ```
 
-**How to run the Connect shell** — pick one path; never combine with log redirection or a second watch command:
-
-- **If channel is `slack`, `email`, or `telegram`:** Shell with `block_until_ms: 0` (background). Use **Await** on that shell id to read output as it arrives (e.g. pattern `NOVU_CONNECT_SLACK_AUTHORIZE_URL=`, `NOVU_CONNECT_INBOUND_ADDRESS=`, or `NOVU_CONNECT_TELEGRAM_DEEPLINK_URL=`). When the user finishes the handoff, **Await** again until `✓ Your agent is live` or a `✗` error. Do not use Monitor, `tail -f`, `grep`, Read on log files, or ask for permission to watch logs.
-- **If channel is `skip`:** a normal foreground Shell is enough — the CLI exits quickly after printing the success block.
-
-Conditional flags — apply each only when its condition holds:
-
-- **If channel is `slack`:** also pass `--slack-config-token "$SLACK_CONFIG_TOKEN"` (set the token in the shell environment first).
-- **If channel is `telegram`:** also pass `--telegram-bot-token "$TELEGRAM_BOT_TOKEN"` (collected after Step 2 — see [Telegram bot token (after Step 2)](#telegram-bot-token-after-step-2)). `--ci` is required (no prompts, no TUI).
-- **Runtime:** do not pass `--runtime` or `--anthropic-api-key` — the **demo runtime** is always used.
-- **Region:** pass `--region eu` only when the user explicitly asks; otherwise the default is **US** Novu Cloud.
-
-Always required: the positional description (in `--ci` mode).
-
-**Safe retry — Slack only:** if the run fails with `Failed to create Slack app: …` (Slack's app-create can be slow on a cold first call), **silently re-run the exact same command once** before reporting anything — the step is safe to repeat. Only surface an error if the second attempt also fails.
+**Safe retry — Slack only:** silently re-run once on `Failed to create Slack app: …` before reporting.
 
 ---
 
-## Step 4 — Channel-specific handoff (human-in-the-loop)
+## Step 4 — Handoffs (human-in-the-loop)
 
-**Goal:** give the user the one action that finishes connecting their channel.
+**Goal:** give the user each action that finishes authentication and channel connection.
 
-**If channel is `slack`, `email`, or `telegram`:** deliver the handoff from the Connect shell stdout, then **Await** the same shell until the **CLI poll** finishes. Do not start a separate watch process, read log files, or validate OAuth/email/Telegram yourself.
+**Always paste the literal URL — never a placeholder.** Every handoff link must be the full resolved value from the matching `NOVU_CONNECT_*` line. **Await** the pattern before sending any handoff message.
+
+### Dashboard OAuth (when using `--login`)
+
+Every `--login` run prints:
+
+```text
+NOVU_CONNECT_AUTH_URL_FILE=<absolute path>
+```
+
+**Read** that file (do not paste the path itself) and deliver the one-line auth URL to the user. The file keeps the `device_code` out of CI stdout logs. Tell the user to open the URL (they should already be signed in) and click **Authorize**. The CLI polls until approval (~5 min). On timeout or expiry, re-run Step 3.
+
+### Showing the QR code (host-aware)
+
+The Telegram QR PNGs (`NOVU_CONNECT_TELEGRAM_SETUP_QR_PNG`, `NOVU_CONNECT_TELEGRAM_DEEPLINK_QR_PNG`) are a phone-scan convenience — the literal URL is the primary handoff and must appear in the same message regardless. **Never deliver a QR by only Read-ing the PNG file:** in most hosts a file-read tool call renders collapsed (e.g. Claude Code shows just "Read 1 file"), so the user never sees the QR. Pick the path that matches what your host can render:
+
+- **Chat UI that renders Markdown images inline (e.g. Cursor):** embed the PNG in your reply text with `![Scan the QR code with your phone](<absolute png path>)` — an image in your own message, not a tool call.
+- **Terminal host that cannot render images (e.g. Claude Code or other CLIs):** open the PNG in the OS image viewer — `open "<png path>"` (macOS), `xdg-open "<png path>"` (Linux), or `start "" "<png path>"` (Windows) — and tell the user a QR window just opened that they can scan with their phone. If the open command fails or the session is headless/remote, skip the QR entirely and present only the clickable URL — never leave the user hunting through collapsed tool output.
+
+### Channel-specific handoffs
+
+**If channel is `slack`, `email`, or `telegram`:** deliver the handoff from Connect shell stdout, then **Await** until the **CLI poll** finishes.
 
 Read Connect shell stdout (via **Await**, not log files) and act based on the chosen channel:
 
-- **slack** — connection can't be automated. Watch for the machine-readable line:
+- **slack** — the connect run defaulted to the secure path, so first **Await** the secure setup link line and copy its value:
 
+  ```text
+  NOVU_CONNECT_SLACK_SETUP_URL=<url>
   ```
+
+  This is the moment the user must provide the token, so **now** present the token-delivery choice inline — call `AskQuestion` / `AskUserQuestion` with two options and recommend `secure`:
+  - `secure` — **Secure setup page (recommended)** — paste the token on the page the CLI printed; it never enters chat.
+  - `in_chat` — **Paste token in chat (less secure)** — the token then lives in chat history.
+
+  **If they pick `secure` (or skip the choice):** paste that exact `<url>` into chat as a clickable link. Then tell them to:
+  1. Open <https://api.slack.com/apps> and generate an **App Configuration Token** (access token starting with `xoxe.xoxp-`)
+  2. Open the setup link and paste the token there — **not in this chat**
+
+  The CLI polls until the token is saved (~5 min). Then **Await** the OAuth handoff line and copy its value:
+
+  ```text
   NOVU_CONNECT_SLACK_AUTHORIZE_URL=<url>
   ```
 
-  Parse the URL after `=`. Give it to the user and ask them to approve the install **within 5 minutes**. Then wait for the CLI poll to finish — the process exits on its own once they authorize. If it times out (~5 min), it prints an error; **re-run the same command** (the Slack app is reused).
+  Paste that exact `<url>` into chat and ask them to approve the install within 5 minutes. **Await** until the CLI poll finishes. Re-run on timeout (the Slack app is reused).
+
+  **If they pick `in_chat`:** ask for the token in chat as free-text (not the picker), warn once that it will live in chat history, then **kill the first Connect shell** (the Step 3 process still polling the secure setup page) and **re-run the Step 3 connect command once with `--slack-config-token`** (set via an env var). That supersedes the secure setup page — the CLI skips the `NOVU_CONNECT_SLACK_SETUP_URL` handoff and goes straight to OAuth. **Await** the `NOVU_CONNECT_SLACK_AUTHORIZE_URL=<url>` line, paste that exact URL into chat, and ask them to approve the install within 5 minutes.
 
 - **email** — watch for these machine-readable lines (plain stdout, no ANSI):
 
-  ```
+  ```text
   NOVU_CONNECT_INBOUND_ADDRESS=<address>
   NOVU_CONNECT_MAILTO=<mailto-url>
   NOVU_CONNECT_SEND_FROM_EMAIL=<email>   # only when present
@@ -250,90 +309,107 @@ Read Connect shell stdout (via **Await**, not log files) and act based on the ch
 
   Then wait for the **CLI poll** — the process completes once the email arrives; on timeout, re-run after they've sent it.
 
-- **telegram** — the bot token was collected after Step 2 and passed via `--telegram-bot-token`, so the CLI saves it itself — there is no BotFather or mobile-link handoff here. Watch for these machine-readable lines (plain stdout, no ANSI):
+- **telegram** — the connect run defaulted to the secure path. First, watch for the BotFather hint and secure setup link:
 
+  ```text
+  NOVU_CONNECT_TELEGRAM_BOTFATHER_URL=<url>              # only when present
+  NOVU_CONNECT_TELEGRAM_SETUP_URL=<url>
+  NOVU_CONNECT_TELEGRAM_SETUP_QR_PNG=<absolute png path>   # only when present
   ```
+
+  Tell the user to create a bot with @BotFather (<https://t.me/botfather>, send `/newbot`). The bot token is needed next, so **now** present the token-delivery choice inline — call `AskQuestion` / `AskUserQuestion` with two options and recommend `secure`:
+  - `secure` — **Secure setup page (recommended)** — paste the token on the page/QR the CLI printed; it never enters chat.
+  - `in_chat` — **Paste token in chat (less secure)** — the token then lives in chat history.
+
+  **If they pick `secure` (or skip the choice):** paste the literal `NOVU_CONNECT_TELEGRAM_SETUP_URL` value into chat as a clickable link and tell them to paste the BotFather confirmation message on that page — **not in this chat**. When `NOVU_CONNECT_TELEGRAM_SETUP_QR_PNG` is present, also show the QR following [Showing the QR code (host-aware)](#showing-the-qr-code-host-aware) — never via a bare file read. The CLI polls until the bot token is saved (~5 min).
+
+  **If they pick `in_chat`:** ask for the token in chat as free-text (not the picker), warn once that it will live in chat history, then **kill the first Connect shell** (the Step 3 process still polling the secure setup page) and **re-run the Step 3 connect command once with `--telegram-bot-token`** (set via an env var). That supersedes the secure setup page — the CLI skips the `NOVU_CONNECT_TELEGRAM_SETUP_URL`/QR handoff and goes straight to the deep-link step below.
+
+  Then watch for the deep-link handoff:
+
+  ```text
   NOVU_CONNECT_TELEGRAM_DEEPLINK_URL=<url>
   NOVU_CONNECT_TELEGRAM_BOT_USERNAME=<name>
   NOVU_CONNECT_TELEGRAM_DEEPLINK_QR_PNG=<absolute png path>   # only when present
   ```
 
-  When they appear, embed the **QR code image** inline with Markdown — `![Scan with your phone](<absolute png path>)` using the path from `NOVU_CONNECT_TELEGRAM_DEEPLINK_QR_PNG=` — so the user can scan it from their phone. Never render the QR as ASCII/Unicode art in a code block (chat Markdown breaks it and it won't scan). Also give the deep link as a clickable fallback. Ask them to open the bot and tap **Start** on `@<botUsername>` in Telegram. The CLI polls until `/start` is received (~5 min).
+  When `NOVU_CONNECT_TELEGRAM_DEEPLINK_QR_PNG` is present, show the QR following [Showing the QR code (host-aware)](#showing-the-qr-code-host-aware). Ask them to open the bot and tap **Start** on `@<botUsername>`. **Await** until the CLI poll finishes. Re-run on timeout with the same command.
 
-  Then wait for the CLI poll to finish — the process exits on its own once they tap Start. If it times out (~5 min), **re-run the same command** with the same `--telegram-bot-token`.
+- **whatsapp / teams (authenticated)** — CLI prints a dashboard agent URL; paste it and tell the user to finish channel setup there.
 
 - **skip** — nothing to hand off; the agent is created without a channel.
 
-(`whatsapp`/`teams` never reach this step — they were redirected to the dashboard in Step 1.)
+(Keyless + `whatsapp`/`teams` never reach this step — redirected in Step 1.)
 
 ---
 
 ## Step 5 — Report the result
 
-**Goal:** relay what the CLI printed, point the user at the channel, explain the claim path.
+**Goal:** relay what the CLI printed and point the user at the channel or dashboard.
 
-On success the CLI exits `0` and prints a block like:
+On success the CLI exits `0` and prints:
 
-```
+```text
 ✓ Your agent is live.
   Agent: <name> (<identifier>)
-  → Check <Channel> — your agent just messaged you.      # connected channels (slack/email)
+  → Check <Channel> — your agent just messaged you.
   Dashboard: <dashboard url>
 ```
 
-Extract the **agent identifier** and **Dashboard URL**, then tell the user:
+**Authenticated:** tell the user their agent is live in their Development environment — message it on the connected channel or open the dashboard URL.
 
-- Their agent is live — go message it on the connected channel.
-- **Keyless demo limit:** they get ~5 free replies. After that, the agent posts a **"Sign up & keep this agent"** link in the channel. Clicking it creates their Novu account and **migrates the agent, the channel connection, and the whole conversation** into their new workspace's Development environment — the agent picks up right where it left off.
+**Keyless:** same as above, plus explain the **demo limit** (~5 free replies) and the in-channel **"Sign up & keep this agent"** claim link.
 
-**On failure** (non-zero exit, or a line starting with `✗`), surface the error message and the matching fix:
+**On failure**, surface the error and matching fix:
 
 | Symptom | Fix |
 |---|---|
-| `…requires --prompt "<agent description>"` | You didn't pass the positional description — re-run Step 3 with it. |
-| `…--slack-config-token "xoxe.xoxp-…"` | Ask the user for the Slack App Configuration Token (Step 1) and pass it. |
-| `Failed to create Slack app: …` (e.g. timeout) | Transient — Slack's app-create can be slow on a cold call. Silently re-run the same command once; only surface if it fails again. |
-| `Slack OAuth was not completed within … seconds` | User didn't approve in time — re-run the same command (the Slack app is reused). |
-| `We didn't see your email at … within …s` | User hasn't emailed the inbound address yet — re-run after they send it. |
-| `Telegram didn't accept the bot token: …` | The pasted token is wrong or revoked — ask the user to re-copy it from @BotFather (`/token`) and re-run with the new value. |
-| `We didn't see a /start message on @… within … seconds` | User didn't tap Start on the bot in time — re-run the same command (same `--telegram-bot-token`). |
-| `Keyless environment creation is currently disabled` / no demo integration | Target API isn't configured for keyless/demo — confirm the right `--region`, or have the user provide `--secret-key` for their existing account. |
+| `…requires --prompt "<agent description>"` | Re-run Step 3 with the positional description. |
+| `Authorization timed out` / `Authorization session expired` | User didn't approve in time — re-run for a fresh auth link. |
+| `This environment doesn't have a Novu demo Claude integration` | Demo runtime not enabled — enable in dashboard or use BYOK runtime flags. |
+| `The Slack App Configuration Token wasn't saved within … seconds` | Re-run for a fresh setup link. |
+| `Failed to create Slack app: …` | Silently re-run once; surface only if it fails again. |
+| `Slack OAuth was not completed within … seconds` | Re-run the same command. |
+| `We didn't see your email at … within …s` | Re-run after they send the email. |
+| Telegram token / `/start` timeouts | Re-run the same command. |
+| `Keyless environment creation is currently disabled` | Wrong API/region, or use `--login` / `--secret-key` for an existing account. |
 
 ---
 
-## Command flag reference (the subset this flow uses)
+## Command flag reference
 
-Run `novu connect --help` for copy-paste examples, the non-interactive (agent/CI) contract, machine-readable stdout markers, and exit-code semantics. Keep that help text in sync when changing connect flags or behavior.
+Run `novu connect --help` for the full contract. Keep help text in sync when changing connect flags.
 
 | Flag | Purpose |
 |---|---|
 | `connect "<description>"` | Positional agent description (required in `--ci`). |
-| `--ci` | Non-interactive mode (required for all channels in this flow). |
+| `--ci` | Non-interactive mode (required). |
+| `--login` | Dashboard OAuth — use when the user has a Novu account or the dashboard prompt rule applies. |
 | `--region <us\|eu>` | Target Novu Cloud region (default: `us`). |
-| `--channel <slack\|email\|telegram\|skip>` | Which channel to connect. Never pass `whatsapp`/`teams` — those are handled by the dashboard redirect, not the CLI. |
-| `--slack-config-token <xoxe.xoxp-…>` | Create the Slack app headlessly (slack only). |
-| `--telegram-bot-token <123456:ABC…>` | Bot token from @BotFather; the CLI stores it on the integration (telegram only, required in this flow). |
-| `--secret-key <key>` | Optional — use an existing Novu account instead of keyless. |
+| `--channel <slack\|email\|telegram\|whatsapp\|teams\|skip>` | Channel to connect. `whatsapp`/`teams` require `--login`. |
+| `--slack-config-token` / `--telegram-bot-token` | Non-secure CI escape hatches when user opts in. |
+| *(omit both)* | Keyless mode — temporary agent, no account. Do not pass `--secret-key` in this guided flow. |
 
 ---
 
 ## Limitations to keep in mind
 
-- **One run = one new agent + one channel.** Re-running `connect` creates another agent; there is no "add a channel to the existing agent" in this non-interactive flow yet.
-- **Channel support is uneven headlessly:** `slack` and `email` complete with one user action; `telegram` requires two user actions (create the bot + paste its token in chat after description approval, then tap Start after connect); `whatsapp` and `teams` are **not supported in the CLI** — the user signs in to the Novu dashboard and continues onboarding there (no agent is generated by this flow).
-- Keyless data is temporary until the user claims it via the in-channel sign-up link.
-- The CLI stores keyless credentials **per API URL**, so switching `--region` between runs does not require clearing `~/.config/configstore/novu-cli.json`.
+- **One run = one new agent + one channel.** Re-running creates another agent.
+- **Channel support is uneven headlessly:** `slack` and `telegram` need two user actions after auth; `email` one; `whatsapp`/`teams` need `--login` and finish in the dashboard.
+- **Prefer secure setup pages for Slack/Telegram tokens.**
+- **Keyless data is temporary** until claimed via the in-channel sign-up link.
+- **`--login` ignores `NOVU_SECRET_KEY`** — dashboard OAuth always wins when the flag is set.
 
 ---
 
 ## Definition of done
 
-**If the user picked WhatsApp / MS Teams:** you are done as soon as you've delivered the dashboard sign-in URL and told them to continue onboarding there — no agent is generated, and the items below do not apply.
+**Keyless + WhatsApp / MS Teams:** done when you've delivered the dashboard sign-in URL — no agent generated.
 
 You are done when:
 
-1. The user picked a channel and you collected its required inputs.
-2. The user confirmed the agent description.
-3. You delivered the handoff (link / address) — or noted `skip`.
-4. The Connect shell printed `✓ Your agent is live.` (exit `0`). You never used Monitor, log files, or a separate watch command; for `slack`/`email`/`telegram`, the **CLI poll** validated the handoff.
-5. You reported the agent identifier + Dashboard URL and explained the demo limit → claim path.
+1. The user picked a channel and confirmed the agent description.
+2. Dashboard OAuth completed (when using `--login`), or keyless bootstrap succeeded.
+3. You delivered channel handoffs (or noted `skip` / whatsapp-teams dashboard URL).
+4. Connect shell printed `✓ Your agent is live.` (exit `0`); CLI poll validated handoffs where applicable.
+5. You reported agent identifier + Dashboard URL (and keyless claim path if applicable).


### PR DESCRIPTION
## Summary
- Add auth mode guidance for keyless vs `--login` dashboard OAuth before running connect
- Document secure setup page preference for Slack/Telegram tokens, with in-chat fallback as discouraged path
- Refresh flow steps, handoffs, error handling, and limitations for authenticated WhatsApp/Teams support

## Test plan
- [x] Reviewed diff for `public/agents.md` consistency and formatting
- [ ] Verify rendered markdown at `/agents.md` after deploy


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Novu agent onboarding instructions with clearer auth mode selection guidance
  * Improved secure secret handling practices for Slack and Telegram
  * Updated setup templates with authentication-specific commands
  * Expanded troubleshooting guide with enhanced symptom resolution steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->