### PR TITLE
docs(connect): use npx novu@latest in run commands (fixes DOC-347)

### DIFF
--- a/public/auth.md
+++ b/public/auth.md
@@ -21,7 +21,7 @@ Novu now supports **keyless** flows: you can do meaningful work for the user wit
 **Use no authentication (keyless) when the user is testing, prototyping, or just getting started:**
 
 - **Embedding the `<Inbox />` component to see a working notification UI.** Render the Inbox with no `applicationIdentifier` and no `subscriberId` — keyless mode boots an isolated, temporary environment so the user can evaluate look, feel, and behavior instantly. The data is temporary (expires in ~24h) and is **not** tied to real subscribers, so it is for local testing and demos only, never production.
-- **Spinning up a managed Novu agent connected to a channel.** Use the keyless CLI flow (`npx novu connect …`, no `--secret-key`) to create a temporary, hosted agent and connect Slack or email without a Novu account. The full step-by-step runbook for this lives in `https://novu.co/agents.md` — follow that file for the agent-onboarding flow rather than improvising. Keyless agents are temporary until the user **claims** them by signing up through the in-channel link, which migrates the agent, channel, and conversation into their own workspace.
+- **Spinning up a managed Novu agent connected to a channel.** Use the keyless CLI flow (`npx novu@latest connect …`, no `--secret-key`) to create a temporary, hosted agent and connect Slack or email without a Novu account. The full step-by-step runbook for this lives in `https://novu.co/agents.md` — follow that file for the agent-onboarding flow rather than improvising. Keyless agents are temporary until the user **claims** them by signing up through the in-channel link, which migrates the agent, channel, and conversation into their own workspace.
 
 **Use a secret key when the user needs account-owned or production resources:**
 
@@ -64,9 +64,9 @@ export function NotificationInbox() {
 
 The `applicationIdentifier` is public and client-side only (see below). For EU Cloud, also pass `backendUrl="https://eu.api.novu.co"` and `socketUrl="wss://eu.socket.novu.co"`. Setup guide: `https://docs.novu.co/platform/inbox/setup-inbox`.
 
-### Keyless agent (`npx novu connect`)
+### Keyless agent (`npx novu@latest connect`)
 
-To create a hosted agent without an account, follow the dedicated runbook at `https://novu.co/agents.md`. In short: it runs one non-interactive `npx novu connect "<description>" --ci --channel <slack|email|skip>` command (no `--secret-key`), hands the user a channel-specific action, and explains the demo limit and sign-up-to-claim path. Do not pass `--secret-key` for keyless; only add it when the user wants to use their existing account.
+To create a hosted agent without an account, follow the dedicated runbook at `https://novu.co/agents.md`. In short: it runs one non-interactive `npx novu@latest connect "<description>" --ci --channel <slack|email|skip>` command (no `--secret-key`), hands the user a channel-specific action, and explains the demo limit and sign-up-to-claim path. Do not pass `--secret-key` for keyless; only add it when the user wants to use their existing account.
 
 ## Current state for keyed access
 

--- a/public/connect/agent-onboarding.md
+++ b/public/connect/agent-onboarding.md
@@ -181,7 +181,7 @@ Set the agent description in an environment variable first — do **not** paste 
 ```bash
 export NOVU_AGENT_DESCRIPTION='<confirmed agent description>'
 
-npx novu connect "$NOVU_AGENT_DESCRIPTION" \
+npx novu@latest connect "$NOVU_AGENT_DESCRIPTION" \
   --ci \
   --login \
   --channel <slack|email|telegram|whatsapp|teams|skip>
@@ -192,7 +192,7 @@ npx novu connect "$NOVU_AGENT_DESCRIPTION" \
 ```bash
 export NOVU_AGENT_DESCRIPTION='<confirmed agent description>'
 
-npx novu connect "$NOVU_AGENT_DESCRIPTION" \
+npx novu@latest connect "$NOVU_AGENT_DESCRIPTION" \
   --ci \
   --channel <slack|email|telegram|skip>
 ```
@@ -204,7 +204,7 @@ Never pass `--channel whatsapp` or `--channel teams` in keyless mode — those r
 ```bash
 export NOVU_AGENT_DESCRIPTION='<confirmed agent description>'
 
-npx novu connect "$NOVU_AGENT_DESCRIPTION" \
+npx novu@latest connect "$NOVU_AGENT_DESCRIPTION" \
   --ci \
   --login \
   --channel slack
@@ -230,7 +230,7 @@ Conditional flags:
 export NOVU_AGENT_DESCRIPTION='<confirmed agent description>'
 export SLACK_CONFIG_TOKEN='<xoxe.xoxp-...>'
 
-npx novu connect "$NOVU_AGENT_DESCRIPTION" \
+npx novu@latest connect "$NOVU_AGENT_DESCRIPTION" \
   --ci \
   --login \
   --channel slack \
@@ -393,7 +393,7 @@ Adapt the recap to what actually happened (drop the MCP clause when no integrati
 
 ## Command flag reference
 
-Run `novu connect --help` for the full contract. Keep help text in sync when changing connect flags.
+Run `novu@latest connect --help` for the full contract. Keep help text in sync when changing connect flags.
 
 | Flag | Purpose |
 |---|---|

--- a/src/components/pages/connect/command-input.tsx
+++ b/src/components/pages/connect/command-input.tsx
@@ -8,7 +8,7 @@ import CheckIcon from "@/svgs/icons/check.svg"
 import { cn } from "@/lib/utils"
 import useCopyToClipboard from "@/hooks/use-copy-to-clipboard"
 
-const CONNECT_COMMAND = "npx novu connect"
+const CONNECT_COMMAND = "npx novu@latest connect"
 const FIELD_BACKGROUND_IMAGE = fieldBackgroundImage.src
 const INPUT_GLOW_BLURS = [
   "blur-[18px]",


### PR DESCRIPTION
## Summary
- Update connect agent onboarding bash examples to use `npx novu@latest connect`
- Align `public/auth.md` keyless agent references with the same CLI invocation
- Update the connect page copy-to-clipboard command to match

## Test plan
- [x] Verified all `npx novu` references in touched files now use `@latest`
- [ ] Confirm connect page displays `npx novu@latest connect` in the command input


Made with [Cursor](https://cursor.com)