### PR TITLE
feat(analytics): fire attributed demo_booked event on Cal.com bookings

### DIFF
--- a/src/components/demo-booking-tracker.tsx
+++ b/src/components/demo-booking-tracker.tsx
@@ -40,29 +40,34 @@ function getStoredUtmParams(): Record<string, string> {
 export default function DemoBookingTracker() {
   useEffect(() => {
     let cancelled = false
+    let cal: Awaited<ReturnType<typeof getCalApi>> | null = null
+
+    // Stable reference so the same callback can be passed to both `on` and
+    // `off` (Cal.com requires an identical reference to unregister).
+    const handleBookingSuccessful = () => {
+      const w = window as Window & {
+        dataLayer?: Record<string, unknown>[]
+      }
+      w.dataLayer = w.dataLayer || []
+      w.dataLayer.push({
+        event: "demo_booked",
+        demo_booking: {
+          source: "cal.com",
+          namespace: NAMESPACE,
+          // UTM/gclid captured on landing, for downstream/offline use.
+          ...getStoredUtmParams(),
+        },
+      })
+    }
 
     const init = async () => {
       try {
-        const cal = await getCalApi({ namespace: NAMESPACE })
+        cal = await getCalApi({ namespace: NAMESPACE })
         if (cancelled) return
 
         cal("on", {
           action: "bookingSuccessful",
-          callback: () => {
-            const w = window as Window & {
-              dataLayer?: Record<string, unknown>[]
-            }
-            w.dataLayer = w.dataLayer || []
-            w.dataLayer.push({
-              event: "demo_booked",
-              demo_booking: {
-                source: "cal.com",
-                namespace: NAMESPACE,
-                // UTM/gclid captured on landing, for downstream/offline use.
-                ...getStoredUtmParams(),
-              },
-            })
-          },
+          callback: handleBookingSuccessful,
         })
       } catch {
         // Cal.com embed unavailable; nothing to track.
@@ -73,6 +78,12 @@ export default function DemoBookingTracker() {
 
     return () => {
       cancelled = true
+      // Unregister so a remount doesn't stack listeners and double-fire the
+      // conversion on a single booking.
+      cal?.("off", {
+        action: "bookingSuccessful",
+        callback: handleBookingSuccessful,
+      })
     }
   }, [])
 

--- a/src/components/demo-booking-tracker.tsx
+++ b/src/components/demo-booking-tracker.tsx
@@ -1,0 +1,80 @@
+"use client"
+
+import { useEffect } from "react"
+import { getCalApi } from "@calcom/embed-react"
+
+import { TRACKING_PARAMS } from "@/constants/forms"
+
+const NAMESPACE = "novu-meeting"
+const STORAGE_KEY = "novu_utm_params"
+
+function getStoredUtmParams(): Record<string, string> {
+  try {
+    const stored = sessionStorage.getItem(STORAGE_KEY)
+    if (!stored) return {}
+    const parsed = JSON.parse(stored)
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {}
+    return Object.fromEntries(
+      TRACKING_PARAMS.flatMap((key) => {
+        const value = (parsed as Record<string, unknown>)[key]
+        return typeof value === "string" && value ? [[key, value]] : []
+      })
+    )
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * Fires an attributed `demo_booked` dataLayer event when a Cal.com booking
+ * completes.
+ *
+ * Cal.com renders the booking flow inside an app.cal.com iframe and fires its
+ * own tracking from that origin, so it cannot read the novu.co Google Ads cookie
+ * (gclid) and every booking lands as "direct" / unattributed. Listening for
+ * Cal.com's `bookingSuccessful` event here, in the parent novu.co context, lets
+ * GTM and the Ads conversion linker attribute the booking to the originating ad
+ * click. One namespace-level listener covers every booking surface and fires
+ * exactly once per booking.
+ */
+export default function DemoBookingTracker() {
+  useEffect(() => {
+    let cancelled = false
+
+    const init = async () => {
+      try {
+        const cal = await getCalApi({ namespace: NAMESPACE })
+        if (cancelled) return
+
+        cal("on", {
+          action: "bookingSuccessful",
+          callback: () => {
+            const w = window as Window & {
+              dataLayer?: Record<string, unknown>[]
+            }
+            w.dataLayer = w.dataLayer || []
+            w.dataLayer.push({
+              event: "demo_booked",
+              demo_booking: {
+                source: "cal.com",
+                namespace: NAMESPACE,
+                // UTM/gclid captured on landing, for downstream/offline use.
+                ...getStoredUtmParams(),
+              },
+            })
+          },
+        })
+      } catch {
+        // Cal.com embed unavailable; nothing to track.
+      }
+    }
+
+    init()
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return null
+}

--- a/src/components/demo-booking-tracker.tsx
+++ b/src/components/demo-booking-tracker.tsx
@@ -25,25 +25,11 @@ function getStoredUtmParams(): Record<string, string> {
   }
 }
 
-/**
- * Fires an attributed `demo_booked` dataLayer event when a Cal.com booking
- * completes.
- *
- * Cal.com renders the booking flow inside an app.cal.com iframe and fires its
- * own tracking from that origin, so it cannot read the novu.co Google Ads cookie
- * (gclid) and every booking lands as "direct" / unattributed. Listening for
- * Cal.com's `bookingSuccessful` event here, in the parent novu.co context, lets
- * GTM and the Ads conversion linker attribute the booking to the originating ad
- * click. One namespace-level listener covers every booking surface and fires
- * exactly once per booking.
- */
 export default function DemoBookingTracker() {
   useEffect(() => {
     let cancelled = false
     let cal: Awaited<ReturnType<typeof getCalApi>> | null = null
 
-    // Stable reference so the same callback can be passed to both `on` and
-    // `off` (Cal.com requires an identical reference to unregister).
     const handleBookingSuccessful = () => {
       const w = window as Window & {
         dataLayer?: Record<string, unknown>[]
@@ -54,32 +40,24 @@ export default function DemoBookingTracker() {
         demo_booking: {
           source: "cal.com",
           namespace: NAMESPACE,
-          // UTM/gclid captured on landing, for downstream/offline use.
           ...getStoredUtmParams(),
         },
       })
     }
 
-    const init = async () => {
-      try {
-        cal = await getCalApi({ namespace: NAMESPACE })
+    getCalApi({ namespace: NAMESPACE })
+      .then((api) => {
         if (cancelled) return
-
-        cal("on", {
+        cal = api
+        api("on", {
           action: "bookingSuccessful",
           callback: handleBookingSuccessful,
         })
-      } catch {
-        // Cal.com embed unavailable; nothing to track.
-      }
-    }
-
-    init()
+      })
+      .catch(() => {})
 
     return () => {
       cancelled = true
-      // Unregister so a remount doesn't stack listeners and double-fire the
-      // conversion on a single booking.
       cal?.("off", {
         action: "bookingSuccessful",
         callback: handleBookingSuccessful,

--- a/src/components/website-layout-shell.tsx
+++ b/src/components/website-layout-shell.tsx
@@ -5,6 +5,7 @@ import Script from "next/script"
 import { Providers } from "@/contexts"
 
 import { cn } from "@/lib/utils"
+import DemoBookingTracker from "@/components/demo-booking-tracker"
 import Fonts from "@/components/fonts"
 import MixpanelTracking from "@/components/mixpanel-tracking"
 import PreviewWarning from "@/components/preview-warning"
@@ -50,6 +51,7 @@ async function WebsiteLayoutShell({
       >
         <MixpanelTracking />
         <UtmForwarder />
+        <DemoBookingTracker />
         <Providers>
           <div
             className={cn(


### PR DESCRIPTION
Sibling of **novuhq/website#438** for the Next.js site. Part of **MRK-1854**.

## Problem

Cal.com demo bookings are **not attributed to Google Ads** — 0 of ~50 bookings in 90 days came from `google / cpc` (28 landed as `(direct)`). Cal.com renders the booking flow inside an **`app.cal.com` iframe** and fires its own tracking from that origin, so by cross-origin rules it can't read the novu.co Google Ads cookie (`_gcl_aw` / `gclid`). The scheduling modal's `bookingSuccessful` callback only closes the modal.

## Fix

Add a `DemoBookingTracker` client component (mirrors the existing `UtmForwarder`), mounted once in `website-layout-shell`. It registers a single listener for Cal.com's `bookingSuccessful` event on the shared `novu-meeting` namespace and pushes a `demo_booked` event to the `dataLayer` **from the parent novu.co context**, where GTM (server-rendered) and the Ads conversion linker can attribute it to the originating ad click.

- One namespace-level listener; fires once per booking; covers all booking surfaces in the website shell.
- Includes captured UTM/`gclid` (sessionStorage) in the payload for downstream/offline use.

## ⚠️ Required follow-up

This emits the `demo_booked` dataLayer event only. Recording the Google Ads conversion requires a **GTM tag + trigger on `demo_booked`** in container `GTM-KXMC4XP2` → Ads conversion `AW-16864812041`. Spec + tracking in **MRK-1854**.

## Testing

- Mirrors `UtmForwarder` conventions; `bookingSuccessful` is already used (typed) in the scheduling modal.
- `dataLayer.push` is a no-op where GTM isn't present.
- Manual after deploy: open the pricing booking modal, complete a test booking, confirm `demo_booked` in `dataLayer` / GTM Preview on the `novu.co` context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved demo booking event tracking and analytics data collection with enhanced source attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->