### PR TITLE
fix(web): align ACI copy prompt to canonical wording (MRK-1878)

### DIFF
--- a/src/components/pages/aci/aci-cta-actions.tsx
+++ b/src/components/pages/aci/aci-cta-actions.tsx
@@ -10,7 +10,7 @@ import { Button } from "@/components/ui/button"
 
 const CONNECT_COMMAND = "npx novu connect"
 const ACI_PROMPT =
-  "Add an agent to my app using instructions from https://novu.co/agents.md"
+  "Add an agent to my app https://novu.co/agents.md"
 const CLAUDE_PROMPT_URL = `https://claude.ai/new?q=${encodeURIComponent(ACI_PROMPT)}`
 
 function AciCtaActions() {

--- a/src/components/pages/aci/hero-actions.tsx
+++ b/src/components/pages/aci/hero-actions.tsx
@@ -8,7 +8,7 @@ import useCopyToClipboard from "@/hooks/use-copy-to-clipboard"
 import { Button } from "@/components/ui/button"
 
 const ACI_PROMPT =
-  "Add an agent to my app using instructions from https://novu.co/agents.md"
+  "Add an agent to my app https://novu.co/agents.md"
 
 function HeroActions() {
   const { isCopied, handleCopy } = useCopyToClipboard(3000)


### PR DESCRIPTION
Closes MRK-1878.

## What

Sets the ACI page copy prompt to the canonical wording requested by Netanel:

`Add an agent to my app https://novu.co/agents.md`

Changed in `aci-cta-actions.tsx` (Claude prompt URL) and `aci/hero-actions.tsx` (copy-to-clipboard), dropping the "using instructions from" variant added in #113.

## Why

Netanel asked (Slack #marketing-squad) that the copy prompt be exactly `Add an agent to my app https://novu.co/agents.md`. The **connect** page already uses this exact text (since June 11), but the **ACI** page diverged with "using instructions from". This aligns ACI with connect and the requested canonical wording.

## Scope

Copy-only, 2 lines. No behavior change beyond the copied/linked prompt string. The connect page already matches and is untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified wording in agent setup prompts for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->