### PR TITLE
fix(web): redirect novu.co/docs to docs.novu.co (fixes NV-8136)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -64,6 +64,16 @@ const nextConfig: NextConfig = {
         permanent: true,
       },
       {
+        source: "/docs",
+        destination: "https://docs.novu.co",
+        permanent: true,
+      },
+      {
+        source: "/docs/:path*",
+        destination: "https://docs.novu.co/:path*",
+        permanent: true,
+      },
+      {
         source: "/connect/agent-onboarding.md",
         destination: "/agents.md",
         permanent: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds permanent (301) redirects from `https://novu.co/docs` to `https://docs.novu.co`, including any subpaths under `/docs/*`.

## Changes

- Added two redirect rules in `next.config.ts`:
  - `/docs` → `https://docs.novu.co`
  - `/docs/:path*` → `https://docs.novu.co/:path*`

## Validation

- `pnpm lint` — passed
- `pnpm build` — failed in this environment due to missing Sanity `projectId` (pre-existing env issue, unrelated to this change). Next.js config compiled successfully.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-141bf27f-f12d-4d99-a967-07aad442da3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-141bf27f-f12d-4d99-a967-07aad442da3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

