### PR TITLE
feat(web): publish integrations.json and OpenAPI redirects (fixes MRK-1907)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,7 @@ import type { NextConfig } from "next"
 import createMDX from "@next/mdx"
 
 const agentDiscoveryLinkHeader =
-  '</.well-known/api-catalog>; rel="api-catalog", </llms.txt>; rel="describedby", </agents.md>; rel="describedby", </auth.md>; rel="describedby", <https://docs.novu.co/api-reference>; rel="service-doc", <https://api.novu.co/openapi.json>; rel="service-desc"'
+  '</.well-known/api-catalog>; rel="api-catalog", </.well-known/integrations.json>; rel="describedby", </llms.txt>; rel="describedby", </agents.md>; rel="describedby", </auth.md>; rel="describedby", <https://docs.novu.co/api-reference>; rel="service-doc", <https://api.novu.co/openapi.json>; rel="service-desc"'
 
 const securityHeaders = [
   {
@@ -78,6 +78,21 @@ const nextConfig: NextConfig = {
         destination: "/agents.md",
         permanent: true,
       },
+      {
+        source: "/openapi.json",
+        destination: "https://api.novu.co/openapi.json",
+        permanent: true,
+      },
+      {
+        source: "/openapi.yaml",
+        destination: "https://api.novu.co/openapi.yaml",
+        permanent: true,
+      },
+      {
+        source: "/openapi.yml",
+        destination: "https://api.novu.co/openapi.yaml",
+        permanent: true,
+      },
     ]
   },
   async headers() {
@@ -102,6 +117,23 @@ const nextConfig: NextConfig = {
           {
             key: "Cache-Control",
             value: "public, max-age=3600",
+          },
+        ],
+      },
+      {
+        source: "/.well-known/integrations.json",
+        headers: [
+          {
+            key: "Content-Type",
+            value: "application/json; charset=utf-8",
+          },
+          {
+            key: "Access-Control-Allow-Origin",
+            value: "*",
+          },
+          {
+            key: "Cache-Control",
+            value: "public, max-age=3600, stale-while-revalidate=86400",
           },
         ],
       },

--- a/public/.well-known/integrations.json
+++ b/public/.well-known/integrations.json
@@ -1,0 +1,219 @@
+{
+  "version": 3,
+  "summary": "Novu is notification and agent communication infrastructure. Exposes US and EU REST APIs, a hosted MCP server with 23+ tools, a CLI for Framework workflows and agent connect, and published agent skills for inbox, triggers, subscribers, and workflow design.",
+  "credentials": {
+    "novu_secret_key": {
+      "type": "api_key",
+      "label": "Novu secret key",
+      "generateUrl": "https://dashboard.novu.co/settings/api-keys",
+      "setup": "Create a Secret Key in the Novu dashboard for the target environment (Development or Production). Store it as NOVU_SECRET_KEY and send it as `Authorization: ApiKey <key>` on REST API calls. For EU Cloud, use https://eu.dashboard.novu.co/settings/api-keys and call https://eu.api.novu.co."
+    },
+    "novu_api_key": {
+      "type": "api_key",
+      "label": "Novu API key (MCP)",
+      "generateUrl": "https://dashboard.novu.co/settings/api-keys",
+      "setup": "Use the same Secret Key value as REST access. Store it as NOVU_API_KEY in MCP client config and send it as `Authorization: Bearer <key>` to the Novu MCP server."
+    },
+    "novu_application_identifier": {
+      "type": "api_key",
+      "label": "Novu application identifier",
+      "generateUrl": "https://dashboard.novu.co/settings/api-keys",
+      "setup": "Public identifier for client-side Inbox and SDK initialization only. It is not a substitute for the secret key on server-side API or MCP calls. For keyless Inbox demos, omit it entirely."
+    }
+  },
+  "surfaces": [
+    {
+      "slug": "novu-api-us",
+      "name": "Novu REST API (US)",
+      "type": "http",
+      "url": "https://api.novu.co/v1",
+      "spec": "https://api.novu.co/openapi.json",
+      "specAlternates": [
+        "https://api.novu.co/openapi.yaml",
+        "https://novu.co/openapi.json"
+      ],
+      "docs": "https://docs.novu.co/api-reference",
+      "basis": {
+        "via": "declared",
+        "source": "https://novu.co/.well-known/integrations.json"
+      },
+      "auth": {
+        "status": "required",
+        "entries": [
+          {
+            "use": [
+              {
+                "id": "novu_secret_key",
+                "mechanics": {
+                  "source": "http",
+                  "in": "header",
+                  "headerName": "Authorization",
+                  "scheme": "ApiKey"
+                }
+              }
+            ],
+            "basis": {
+              "via": "declared",
+              "source": "https://novu.co/.well-known/integrations.json"
+            }
+          }
+        ]
+      },
+      "notes": "US Cloud base path is /v1. Match region with dashboard.novu.co and mcp.novu.co."
+    },
+    {
+      "slug": "novu-api-eu",
+      "name": "Novu REST API (EU)",
+      "type": "http",
+      "url": "https://eu.api.novu.co/v1",
+      "spec": "https://eu.api.novu.co/openapi.json",
+      "specAlternates": ["https://eu.api.novu.co/openapi.yaml"],
+      "docs": "https://docs.novu.co/api-reference",
+      "basis": {
+        "via": "declared",
+        "source": "https://novu.co/.well-known/integrations.json"
+      },
+      "auth": {
+        "status": "required",
+        "entries": [
+          {
+            "use": [
+              {
+                "id": "novu_secret_key",
+                "mechanics": {
+                  "source": "http",
+                  "in": "header",
+                  "headerName": "Authorization",
+                  "scheme": "ApiKey"
+                }
+              }
+            ],
+            "basis": {
+              "via": "declared",
+              "source": "https://novu.co/.well-known/integrations.json"
+            }
+          }
+        ]
+      },
+      "notes": "EU Cloud accounts use eu.api.novu.co with the same /v1 paths as US."
+    },
+    {
+      "slug": "novu-mcp-us",
+      "name": "Novu MCP server (US)",
+      "type": "mcp",
+      "url": "https://mcp.novu.co/",
+      "transports": ["streamable-http"],
+      "docs": "https://docs.novu.co/platform/build-with-ai/mcp",
+      "basis": {
+        "via": "declared",
+        "source": "https://novu.co/.well-known/integrations.json"
+      },
+      "auth": {
+        "status": "required",
+        "entries": [
+          {
+            "use": [
+              {
+                "id": "novu_api_key",
+                "mechanics": {
+                  "source": "http",
+                  "in": "header",
+                  "headerName": "Authorization",
+                  "scheme": "Bearer"
+                }
+              }
+            ],
+            "basis": {
+              "via": "declared",
+              "source": "https://novu.co/.well-known/integrations.json"
+            }
+          }
+        ]
+      },
+      "notes": "Hosted remote MCP over Streamable HTTP. Exposes subscribers, preferences, workflows, triggers, notifications, integrations, and environments. Also reachable via `npx mcp-remote https://mcp.novu.co/ --header \"Authorization: Bearer ${NOVU_API_KEY}\"`."
+    },
+    {
+      "slug": "novu-mcp-eu",
+      "name": "Novu MCP server (EU)",
+      "type": "mcp",
+      "url": "https://mcp.novu.co/?region=eu",
+      "transports": ["streamable-http"],
+      "docs": "https://docs.novu.co/platform/build-with-ai/mcp",
+      "basis": {
+        "via": "declared",
+        "source": "https://novu.co/.well-known/integrations.json"
+      },
+      "auth": {
+        "status": "required",
+        "entries": [
+          {
+            "use": [
+              {
+                "id": "novu_api_key",
+                "mechanics": {
+                  "source": "http",
+                  "in": "header",
+                  "headerName": "Authorization",
+                  "scheme": "Bearer"
+                }
+              }
+            ],
+            "basis": {
+              "via": "declared",
+              "source": "https://novu.co/.well-known/integrations.json"
+            }
+          }
+        ]
+      },
+      "notes": "EU region endpoint. Use the EU secret key and match with eu.api.novu.co."
+    },
+    {
+      "slug": "novu-cli",
+      "name": "Novu CLI",
+      "type": "cli",
+      "url": "https://www.npmjs.com/package/novu",
+      "docs": "https://docs.novu.co/framework/deployment/cli",
+      "basis": {
+        "via": "declared",
+        "source": "https://novu.co/.well-known/integrations.json"
+      },
+      "auth": {
+        "status": "optional",
+        "entries": [
+          {
+            "use": [
+              {
+                "id": "novu_secret_key",
+                "mechanics": {
+                  "source": "cli",
+                  "flag": "--secret-key",
+                  "env": "NOVU_SECRET_KEY"
+                }
+              }
+            ],
+            "basis": {
+              "via": "declared",
+              "source": "https://novu.co/.well-known/integrations.json"
+            }
+          }
+        ]
+      },
+      "notes": "Run with `npx novu@latest`. Supports Framework workflow sync, Local Studio, and `novu connect` for managed agent onboarding. Keyless connect omits --secret-key; authenticated flows pass --secret-key or NOVU_SECRET_KEY."
+    },
+    {
+      "slug": "novu-agent-skills",
+      "name": "Novu agent skills",
+      "type": "agent-skills",
+      "url": "https://novu.co/.well-known/agent-skills/index.json",
+      "docs": "https://novu.co/llms.txt",
+      "basis": {
+        "via": "declared",
+        "source": "https://novu.co/.well-known/integrations.json"
+      },
+      "auth": {
+        "status": "none"
+      },
+      "notes": "Published skills for connect agent onboarding, inbox integration, workflow design, triggers, subscribers, and preferences."
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Publishes Novu's integration surface for [integrations.sh](https://integrations.sh/publishing/) discovery and adds canonical OpenAPI redirects from `novu.co`.

## Changes

- Add `/.well-known/integrations.json` (v3) declaring:
  - Novu REST API (US + EU) with OpenAPI spec links and `ApiKey` auth
  - Novu MCP server (US + EU) with `Bearer` auth
  - Novu CLI (`npx novu@latest`) with optional secret-key auth
  - Novu agent skills inventory at `/.well-known/agent-skills/index.json`
- Redirect `novu.co/openapi.json`, `/openapi.yaml`, and `/openapi.yml` to the canonical specs on `https://api.novu.co/`
- Add `Link` header reference to `/.well-known/integrations.json` on the homepage
- Add cache and CORS headers for the integrations manifest

## Verification

- `pnpm lint` passes
- Local dev server:
  - `GET /.well-known/integrations.json` → 200 with correct `Content-Type` and 6 surfaces
  - `GET /openapi.json` → 308 redirect to `https://api.novu.co/openapi.json`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2686-137d-79c0-9095-7c6ccec1d578"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2686-137d-79c0-9095-7c6ccec1d578"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

