### PR TITLE
fix(web): update novu.co/mcp for DCR OAuth MCP setup (fixes MRK-1908)

### DIFF
--- a/public/.well-known/api-catalog
+++ b/public/.well-known/api-catalog
@@ -5,7 +5,8 @@
       "item": [
         { "href": "https://api.novu.co/v1" },
         { "href": "https://eu.api.novu.co/v1" },
-        { "href": "https://mcp.novu.co/" }
+        { "href": "https://mcp.novu.co/" },
+        { "href": "https://eu.mcp.novu.co/" }
       ]
     },
     {
@@ -40,6 +41,19 @@
     },
     {
       "anchor": "https://mcp.novu.co/",
+      "service-doc": [
+        {
+          "href": "https://docs.novu.co/platform/build-with-ai/mcp",
+          "type": "text/html"
+        },
+        {
+          "href": "https://novu.co/mcp/",
+          "type": "text/html"
+        }
+      ]
+    },
+    {
+      "anchor": "https://eu.mcp.novu.co/",
       "service-doc": [
         {
           "href": "https://docs.novu.co/platform/build-with-ai/mcp",

--- a/public/.well-known/integrations.json
+++ b/public/.well-known/integrations.json
@@ -8,17 +8,11 @@
       "generateUrl": "https://dashboard.novu.co/settings/api-keys",
       "setup": "Create a Secret Key in the Novu dashboard for the target environment (Development or Production). Store it as NOVU_SECRET_KEY and send it as `Authorization: ApiKey <key>` on REST API calls. For EU Cloud, use https://eu.dashboard.novu.co/settings/api-keys and call https://eu.api.novu.co."
     },
-    "novu_api_key": {
-      "type": "api_key",
-      "label": "Novu API key (MCP)",
-      "generateUrl": "https://dashboard.novu.co/settings/api-keys",
-      "setup": "Use the same Secret Key value as REST access. Store it as NOVU_API_KEY in MCP client config and send it as `Authorization: Bearer <key>` to the Novu MCP server."
-    },
     "novu_application_identifier": {
       "type": "api_key",
       "label": "Novu application identifier",
       "generateUrl": "https://dashboard.novu.co/settings/api-keys",
-      "setup": "Public identifier for client-side Inbox and SDK initialization only. It is not a substitute for the secret key on server-side API or MCP calls. For keyless Inbox demos, omit it entirely."
+      "setup": "Public identifier for client-side Inbox and SDK initialization only. It is not a substitute for the secret key on server-side API calls. For keyless Inbox demos, omit it entirely."
     }
   },
   "surfaces": [
@@ -114,12 +108,11 @@
           {
             "use": [
               {
-                "id": "novu_api_key",
+                "id": "oauth",
                 "mechanics": {
-                  "source": "http",
-                  "in": "header",
-                  "headerName": "Authorization",
-                  "scheme": "Bearer"
+                  "source": "oauth",
+                  "flow": "authorization_code",
+                  "registration": "dcr"
                 }
               }
             ],
@@ -130,13 +123,13 @@
           }
         ]
       },
-      "notes": "Hosted remote MCP over Streamable HTTP. Exposes subscribers, preferences, workflows, triggers, notifications, integrations, and environments. Also reachable via `npx mcp-remote https://mcp.novu.co/ --header \"Authorization: Bearer ${NOVU_API_KEY}\"`."
+      "notes": "Hosted remote MCP over Streamable HTTP with OAuth (DCR). Exposes subscribers, preferences, workflows, triggers, notifications, integrations, and environments. Connect with the MCP URL only — your client handles sign-in."
     },
     {
       "slug": "novu-mcp-eu",
       "name": "Novu MCP server (EU)",
       "type": "mcp",
-      "url": "https://mcp.novu.co/?region=eu",
+      "url": "https://eu.mcp.novu.co/",
       "transports": ["streamable-http"],
       "docs": "https://docs.novu.co/platform/build-with-ai/mcp",
       "basis": {
@@ -149,12 +142,11 @@
           {
             "use": [
               {
-                "id": "novu_api_key",
+                "id": "oauth",
                 "mechanics": {
-                  "source": "http",
-                  "in": "header",
-                  "headerName": "Authorization",
-                  "scheme": "Bearer"
+                  "source": "oauth",
+                  "flow": "authorization_code",
+                  "registration": "dcr"
                 }
               }
             ],
@@ -165,7 +157,7 @@
           }
         ]
       },
-      "notes": "EU region endpoint. Use the EU secret key and match with eu.api.novu.co."
+      "notes": "EU region endpoint. OAuth sessions pair with eu.dashboard.novu.co and eu.api.novu.co."
     },
     {
       "slug": "novu-cli",

--- a/public/auth.md
+++ b/public/auth.md
@@ -9,7 +9,7 @@ Several hosts are relevant:
 - **Dashboard (US)** — `https://dashboard.novu.co` — where the user manages environments, workflows, and keys.
 - **Dashboard (EU)** — `https://eu.dashboard.novu.co` — EU Cloud dashboard.
 - **MCP (US)** — `https://mcp.novu.co/` — Novu MCP server for agent tooling.
-- **MCP (EU)** — `https://mcp.novu.co/?region=eu` — EU MCP endpoint.
+- **MCP (EU)** — `https://eu.mcp.novu.co/` — EU MCP endpoint.
 - **Documentation** — `https://docs.novu.co` — guides, API reference, and MCP setup.
 
 Match the user's region across API, dashboard, and MCP. If their dashboard is `eu.dashboard.novu.co`, use the EU API and EU MCP URLs.
@@ -78,7 +78,7 @@ Novu keys are **environment-specific** (Development vs Production). Always use t
 
 Before you do anything credential-shaped, check whether the user has already wired Novu into your environment.
 
-1. **Novu MCP server** — if you are an MCP client (Claude, Cursor, Codex, etc.), Novu ships a remote MCP server that exposes subscribers, preferences, workflows, triggers, notifications, integrations, and environments as tools. The user configures it once with their secret key; you call the tools without ever seeing the key. Setup: `https://docs.novu.co/platform/build-with-ai/mcp`. Product page: `https://novu.co/mcp/`.
+1. **Novu MCP server** — if you are an MCP client (Claude, Cursor, Codex, ChatGPT, etc.), Novu ships a remote MCP server that exposes subscribers, preferences, workflows, triggers, notifications, integrations, and environments as tools. The user connects with OAuth through their client — you call the tools without handling credentials directly. Setup: `https://docs.novu.co/platform/build-with-ai/mcp`. Product page: `https://novu.co/mcp/`.
 2. **Novu documentation** — server-side API usage, workflow design, channel providers, and Framework patterns live at `https://docs.novu.co`. Read the relevant guide before calling the API directly (especially authentication, triggers, and subscriber management).
 3. **Novu CLI** — for Framework workflows, Local Studio, and syncing workflows to Novu Cloud, prefer `npx novu@latest` over hand-rolled `curl`. It accepts `--secret-key`, `--api-url`, and region-aware `--dashboard-url`. Package: `https://www.npmjs.com/package/novu`. Docs: `https://docs.novu.co/framework/studio` and `https://docs.novu.co/framework/deployment/cli`.
 
@@ -88,7 +88,7 @@ If any of these is already configured, use it and stop. Do not ask the user for 
 
 The credential for server-side API access is a **Secret Key** from the Novu dashboard. It grants administrative access to the linked environment. The user issues it from **Developer → API Keys** (`https://dashboard.novu.co/settings/api-keys` or `https://eu.dashboard.novu.co/settings/api-keys`) and supplies it through a secure channel — never by pasting it into chat.
 
-Novu also exposes an **Application Identifier**, which is public and used only to initialize the Inbox and other client-side SDKs. It is **not** a substitute for the secret key on server-side or MCP-authenticated calls.
+Novu also exposes an **Application Identifier**, which is public and used only to initialize the Inbox and other client-side SDKs. It is **not** a substitute for the secret key on server-side API calls.
 
 ### How to pick the secret key up
 
@@ -96,16 +96,14 @@ Look for it in this order. Stop at the first one that exists:
 
 1. `--secret-key` on `npx novu@latest` commands (`dev`, `sync`, `init`), if the user passed one for this invocation.
 2. `NOVU_SECRET_KEY` in your process environment (common in SDK and backend apps).
-3. `NOVU_API_KEY` in your process environment (common in MCP client config; same secret key value).
-4. A project `.env` file the user has told you to read.
-5. `secretKey` (or equivalent) in an initialized `@novu/api` / `@novu/node` client config.
-6. The Novu MCP server's environment or headers, if you are calling through it (`Authorization: Bearer …`).
+3. A project `.env` file the user has told you to read.
+4. `secretKey` (or equivalent) in an initialized `@novu/api` / `@novu/node` client config.
 
 If none of the above is set and you genuinely need a key, do not ask the user to paste it into the conversation. Instead, tell them to:
 
 - Open **API Keys** in the dashboard for the correct environment (Development or Production).
 - Copy the **Secret Key** for that environment.
-- Put it in `NOVU_SECRET_KEY` or `NOVU_API_KEY` in their shell, `.env`, MCP client config, or pass it to the Novu CLI via `--secret-key` — whichever matches how they invoke you.
+- Put it in `NOVU_SECRET_KEY` in their shell, `.env`, or pass it to the Novu CLI via `--secret-key` — whichever matches how they invoke you.
 - Resume the task once it is set.
 
 This keeps the key out of your transcript, out of any logs the user shares, and out of the model provider's training data.
@@ -137,15 +135,9 @@ Read the key from the environment at the moment of the call. Do not copy it into
 
 The Novu API and backend SDKs are **server-side only**. Using the secret key in browser code will fail with CORS errors and exposes the key publicly.
 
-**Novu MCP** — use the same secret key value with a Bearer token (not the `ApiKey` prefix):
+**Novu MCP** — connect through OAuth in the user's MCP client. Point the client at `https://mcp.novu.co/` (US) or `https://eu.mcp.novu.co/` (EU) with no `Authorization` header — the client handles sign-in. Run the `whoami` tool to verify the session. OAuth sessions default to the Development environment; call `get_environments` and pass an `_id` as `environmentId` to act on Production or another environment. See `https://docs.novu.co/platform/build-with-ai/mcp` for Cursor, Codex, Claude Code, ChatGPT, and Claude Desktop examples.
 
-```http
-Authorization: Bearer $NOVU_API_KEY
-```
-
-Point the MCP client at `https://mcp.novu.co/` (US) or `https://mcp.novu.co/?region=eu` (EU). See `https://docs.novu.co/platform/build-with-ai/mcp` for Cursor, Codex, Claude Code, and Claude Desktop examples.
-
-Regenerating the secret key in the dashboard invalidates the previous value. Treat a `401` on a previously-working key as revocation: drop it from memory and ask the user to refresh whichever source you read it from.
+Regenerating the secret key in the dashboard invalidates the previous value. Treat a `401` on a previously-working key as revocation: drop it from memory and ask the user to refresh whichever source you read it from. For MCP OAuth sessions, ask the user to reconnect through their client if a `401` appears.
 
 ### Application identifier (public, client-side only)
 

--- a/public/auth.md
+++ b/public/auth.md
@@ -135,7 +135,7 @@ Read the key from the environment at the moment of the call. Do not copy it into
 
 The Novu API and backend SDKs are **server-side only**. Using the secret key in browser code will fail with CORS errors and exposes the key publicly.
 
-**Novu MCP** — connect through OAuth in the user's MCP client. Point the client at `https://mcp.novu.co/` (US) or `https://eu.mcp.novu.co/` (EU) with no `Authorization` header — the client handles sign-in. Run the `whoami` tool to verify the session. OAuth sessions default to the Development environment; call `get_environments` and pass an `_id` as `environmentId` to act on Production or another environment. See `https://docs.novu.co/platform/build-with-ai/mcp` for Cursor, Codex, Claude Code, ChatGPT, and Claude Desktop examples.
+**Novu MCP** — connect through OAuth in the user's MCP client. Point the client at `https://mcp.novu.co/` (US) or `https://eu.mcp.novu.co/` (EU) with no `Authorization` header — the client handles sign-in. Run the `whoami` tool to verify the session. OAuth sessions default to the Development environment; call `get_environments` and pass an `_id` as `environmentId` to act on Production or another environment. See `https://docs.novu.co/platform/build-with-ai/mcp` for Cursor, Claude Code, ChatGPT, Codex, and other client-specific setup.
 
 Regenerating the secret key in the dashboard invalidates the previous value. Treat a `401` on a previously-working key as revocation: drop it from memory and ask the user to refresh whichever source you read it from. For MCP OAuth sessions, ask the user to reconnect through their client if a `401` appears.
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -16,9 +16,9 @@ Novu provides a unified platform for building, operating, and debugging notifica
 - User preferences, HMAC encryption, and customizable UI
 
 ### MCP Server
-- [MCP Overview](https://novu.co/mcp/): Give AI agents native access to Novu notification tools
+- [MCP Overview](https://novu.co/mcp/): Give AI agents native access to Novu notification tools via OAuth
 - 23+ tools for subscribers, workflows, triggers, notifications, and integrations
-- Works with Claude, Cursor, Copilot, and any MCP-compatible client
+- Works with Claude, Cursor, ChatGPT, Copilot, and any MCP-compatible client
 
 ### Copilot
 - [Copilot Overview](https://novu.co/copilot/): Generate production-ready notification workflows from plain English

--- a/src/components/pages/mcp/agentic-tools.tsx
+++ b/src/components/pages/mcp/agentic-tools.tsx
@@ -19,6 +19,26 @@ interface IAgenticToolGroup {
 
 const TOOL_GROUPS: IAgenticToolGroup[] = [
   {
+    category: "Auth",
+    tools: [
+      {
+        name: "whoami",
+        description:
+          "Verify the current credential and show your identity and region",
+      },
+    ],
+  },
+  {
+    category: "Environments",
+    tools: [
+      {
+        name: "get_environments",
+        description:
+          "List environments — use an _id as the environmentId parameter on other tools",
+      },
+    ],
+  },
+  {
     category: "Subscriber management",
     tools: [
       {
@@ -134,20 +154,6 @@ const TOOL_GROUPS: IAgenticToolGroup[] = [
       {
         name: "set_primary_integration",
         description: "Mark an integration as the primary for its channel",
-      },
-    ],
-  },
-  {
-    category: "Other",
-    tools: [
-      {
-        name: "get_environments",
-        description: "Get all environments with their details and API keys",
-      },
-      {
-        name: "get_api_key_status",
-        description:
-          "Check the current API key status and server region configuration",
       },
     ],
   },

--- a/src/components/pages/mcp/how-it-works.tsx
+++ b/src/components/pages/mcp/how-it-works.tsx
@@ -21,12 +21,12 @@ const STEPS: IMcpHowItWorksStep[] = [
   {
     title: "Connect your AI client",
     description:
-      "Add the Novu MCP Server in Cursor, Claude, or any MCP client — OAuth sign-in handles authentication automatically.",
+      "Add the Novu MCP Server to Cursor, Claude, ChatGPT, or any MCP client — sign in with your Novu account when prompted.",
   },
   {
     title: "Discover available tools",
     description:
-      "Your agent finds 23 tools: subscribers, preferences, workflows, triggers, notifications, integrations, and environments.",
+      "Your agent discovers 23 tools. Run whoami to confirm you're connected, then manage subscribers, workflows, triggers, and more.",
   },
   {
     title: "Novu delivers everywhere",

--- a/src/components/pages/mcp/how-it-works.tsx
+++ b/src/components/pages/mcp/how-it-works.tsx
@@ -21,7 +21,7 @@ const STEPS: IMcpHowItWorksStep[] = [
   {
     title: "Connect your AI client",
     description:
-      "Point any MCP client — Claude, Cursor, or your app — to the Novu MCP Server.",
+      "Add the Novu MCP Server in Cursor, Claude, or any MCP client — OAuth sign-in handles authentication automatically.",
   },
   {
     title: "Discover available tools",
@@ -38,16 +38,7 @@ const STEPS: IMcpHowItWorksStep[] = [
 const BASE_JSON_SNIPPET = `{
   "mcpServers": {
     "novu": {
-      "command": "npx",
-      "args": [
-        "mcp-remote",
-        "https://mcp.novu.co/",
-        "--header",
-        "Authorization: Bearer \${NOVU_API_KEY}"
-      ],
-      "env": {
-        "NOVU_API_KEY": "your-novu-api-key-here"
-      }
+      "url": "https://mcp.novu.co/"
     }
   }
 }`
@@ -55,42 +46,35 @@ const BASE_JSON_SNIPPET = `{
 const VSCODE_JSON_SNIPPET = `{
   "servers": {
     "novu": {
-      "type": "stdio",
-      "command": "npx",
-      "args": [
-        "mcp-remote",
-        "https://mcp.novu.co/",
-        "--header",
-        "Authorization: Bearer \${input:novu-api-key}"
-      ]
+      "type": "http",
+      "url": "https://mcp.novu.co/"
     }
-  },
-  "inputs": [
-    {
-      "id": "novu-api-key",
-      "type": "promptString",
-      "description": "Novu API key",
-      "password": true
-    }
-  ]
+  }
 }`
 
 const CODEX_TOML_SNIPPET = `[mcp_servers.novu]
-command = "npx"
-args = [
-  "mcp-remote",
-  "https://mcp.novu.co/",
-  "--header",
-  "Authorization: Bearer \${NOVU_API_KEY}",
-]
+url = "https://mcp.novu.co/"`
 
-[mcp_servers.novu.env]
-NOVU_API_KEY = "your-novu-api-key-here"`
+const CLAUDE_DESKTOP_JSON_SNIPPET = `{
+  "mcpServers": {
+    "novu": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://mcp.novu.co/"
+      ]
+    }
+  }
+}`
 
 const CLIENT_SNIPPETS: IMcpClientSnippet[] = [
   { label: "Cursor", language: "json", code: BASE_JSON_SNIPPET },
   { label: "Codex", language: "toml", code: CODEX_TOML_SNIPPET },
-  { label: "Claude Desktop", language: "json", code: BASE_JSON_SNIPPET },
+  {
+    label: "Claude Desktop",
+    language: "json",
+    code: CLAUDE_DESKTOP_JSON_SNIPPET,
+  },
   { label: "VS Code", language: "json", code: VSCODE_JSON_SNIPPET },
   { label: "Windsurf", language: "json", code: BASE_JSON_SNIPPET },
   { label: "GitHub Copilot", language: "json", code: VSCODE_JSON_SNIPPET },

--- a/src/components/pages/mcp/how-it-works.tsx
+++ b/src/components/pages/mcp/how-it-works.tsx
@@ -13,7 +13,7 @@ interface IMcpHowItWorksStep {
 
 interface IMcpClientSnippet {
   label: string
-  language: "json" | "toml"
+  language: "json" | "toml" | "bash"
   code: string
 }
 
@@ -21,7 +21,7 @@ const STEPS: IMcpHowItWorksStep[] = [
   {
     title: "Connect your AI client",
     description:
-      "Add the Novu MCP Server to Cursor, Claude, ChatGPT, or any MCP client — sign in with your Novu account when prompted.",
+      "Add the Novu MCP Server to Cursor, Claude Code, ChatGPT, or any MCP client — sign in with your Novu account when prompted.",
   },
   {
     title: "Discover available tools",
@@ -55,25 +55,15 @@ const VSCODE_JSON_SNIPPET = `{
 const CODEX_TOML_SNIPPET = `[mcp_servers.novu]
 url = "https://mcp.novu.co/"`
 
-const CLAUDE_DESKTOP_JSON_SNIPPET = `{
-  "mcpServers": {
-    "novu": {
-      "command": "npx",
-      "args": [
-        "mcp-remote",
-        "https://mcp.novu.co/"
-      ]
-    }
-  }
-}`
+const CLAUDE_CODE_BASH_SNIPPET = `claude mcp add --transport http novu https://mcp.novu.co/`
 
 const CLIENT_SNIPPETS: IMcpClientSnippet[] = [
   { label: "Cursor", language: "json", code: BASE_JSON_SNIPPET },
   { label: "Codex", language: "toml", code: CODEX_TOML_SNIPPET },
   {
-    label: "Claude Desktop",
-    language: "json",
-    code: CLAUDE_DESKTOP_JSON_SNIPPET,
+    label: "Claude Code",
+    language: "bash",
+    code: CLAUDE_CODE_BASH_SNIPPET,
   },
   { label: "VS Code", language: "json", code: VSCODE_JSON_SNIPPET },
   { label: "Windsurf", language: "json", code: BASE_JSON_SNIPPET },
@@ -127,7 +117,7 @@ function HowItWorks() {
             aria-hidden
             className="pointer-events-none absolute top-0 left-0 h-auto w-full max-w-full -translate-y-1/2 md:w-[50%] md:max-w-[50%]"
           />
-          <McpConfigSelect snippets={snippets} defaultLabel="Claude Desktop" />
+          <McpConfigSelect snippets={snippets} defaultLabel="Claude Code" />
 
           <div className="relative pl-12">
             <ol className="flex flex-col gap-10 md:gap-15">

--- a/src/components/pages/mcp/prompts.tsx
+++ b/src/components/pages/mcp/prompts.tsx
@@ -10,6 +10,10 @@ interface IMcpPromptCard {
 const PROMPT_CARDS: IMcpPromptCard[] = [
   {
     prompt:
+      "Run whoami to verify I'm authenticated and show my Novu region.",
+  },
+  {
+    prompt:
       "List all failed chat notifications from the last 24 hours and show me the error details.",
   },
   {

--- a/src/lib/markdown/pages/static.ts
+++ b/src/lib/markdown/pages/static.ts
@@ -60,16 +60,7 @@ async function customerStoriesMarkdown() {
 const MCP_CONFIG_SNIPPET = `{
   "mcpServers": {
     "novu": {
-      "command": "npx",
-      "args": [
-        "mcp-remote",
-        "https://mcp.novu.co/",
-        "--header",
-        "Authorization: Bearer \${NOVU_API_KEY}"
-      ],
-      "env": {
-        "NOVU_API_KEY": "your-novu-api-key-here"
-      }
+      "url": "https://mcp.novu.co/"
     }
   }
 }`
@@ -78,7 +69,7 @@ const MCP_STEPS = [
   {
     title: "Connect your AI client",
     description:
-      "Point any MCP client — Claude, Cursor, or your app — to the Novu MCP Server.",
+      "Add the Novu MCP Server in Cursor, Claude, or any MCP client — OAuth sign-in handles authentication automatically.",
   },
   {
     title: "Discover available tools",

--- a/src/lib/markdown/pages/static.ts
+++ b/src/lib/markdown/pages/static.ts
@@ -69,7 +69,7 @@ const MCP_STEPS = [
   {
     title: "Connect your AI client",
     description:
-      "Add the Novu MCP Server to Cursor, Claude, ChatGPT, or any MCP client — sign in with your Novu account when prompted.",
+      "Add the Novu MCP Server to Cursor, Claude Code, ChatGPT, or any MCP client — sign in with your Novu account when prompted.",
   },
   {
     title: "Discover available tools",
@@ -478,7 +478,7 @@ function mcpBody() {
     section("Trigger a workflow with your agent, and let Novu do the rest", [
       itemSections(MCP_STEPS),
       formatCodeFence(MCP_CONFIG_SNIPPET, "json"),
-      "Supported MCP clients shown on the page: Cursor, Codex, Claude Desktop, VS Code, Windsurf, GitHub Copilot, and ChatGPT.",
+      "Supported MCP clients shown on the page: Cursor, Codex, Claude Code, VS Code, Windsurf, GitHub Copilot, and ChatGPT.",
     ]),
     section(
       "Paste any prompt into your MCP client to interact with Novu in natural language",

--- a/src/lib/markdown/pages/static.ts
+++ b/src/lib/markdown/pages/static.ts
@@ -69,12 +69,12 @@ const MCP_STEPS = [
   {
     title: "Connect your AI client",
     description:
-      "Add the Novu MCP Server in Cursor, Claude, or any MCP client — OAuth sign-in handles authentication automatically.",
+      "Add the Novu MCP Server to Cursor, Claude, ChatGPT, or any MCP client — sign in with your Novu account when prompted.",
   },
   {
     title: "Discover available tools",
     description:
-      "Your agent finds 23 tools: subscribers, preferences, workflows, triggers, notifications, integrations, and environments.",
+      "Your agent discovers 23 tools. Run whoami to confirm you're connected, then manage subscribers, workflows, triggers, and more.",
   },
   {
     title: "Novu delivers everywhere",
@@ -84,6 +84,7 @@ const MCP_STEPS = [
 ]
 
 const MCP_PROMPTS = [
+  "Run whoami to verify I'm authenticated and show my Novu region.",
   "List all failed chat notifications from the last 24 hours and show me the error details.",
   "Create a workflow that sends an order confirmation via email, an SMS with the tracking number, and an in-app notification through Novu Inbox.",
   "Check if my SendGrid and Twilio integrations are active.",
@@ -93,6 +94,18 @@ const MCP_PROMPTS = [
 ]
 
 const MCP_TOOL_GROUPS = [
+  {
+    title: "Auth",
+    bullets: [
+      "whoami: Verify the current credential and show your identity and region",
+    ],
+  },
+  {
+    title: "Environments",
+    bullets: [
+      "get_environments: List environments — use an _id as the environmentId parameter on other tools",
+    ],
+  },
   {
     title: "Subscriber management",
     bullets: [
@@ -142,13 +155,6 @@ const MCP_TOOL_GROUPS = [
       "get_active_integrations: List only the active integrations",
       "delete_integration: Delete an integration by its integrationId",
       "set_primary_integration: Mark an integration as the primary for its channel",
-    ],
-  },
-  {
-    title: "Other",
-    bullets: [
-      "get_environments: Get all environments with their details and API keys",
-      "get_api_key_status: Check the current API key status and server region configuration",
     ],
   },
 ]
@@ -472,7 +478,7 @@ function mcpBody() {
     section("Trigger a workflow with your agent, and let Novu do the rest", [
       itemSections(MCP_STEPS),
       formatCodeFence(MCP_CONFIG_SNIPPET, "json"),
-      "Supported MCP clients shown on the page: Cursor, Codex, Claude Desktop, VS Code, Windsurf, GitHub Copilot.",
+      "Supported MCP clients shown on the page: Cursor, Codex, Claude Desktop, VS Code, Windsurf, GitHub Copilot, and ChatGPT.",
     ]),
     section(
       "Paste any prompt into your MCP client to interact with Novu in natural language",
@@ -489,6 +495,7 @@ function mcpBody() {
       bulletList([
         "Claude",
         "Cursor",
+        "ChatGPT",
         "Windsurf",
         "Copilot",
         "Codex",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns the [novu.co/mcp](https://novu.co/mcp) page and related agent-facing files with [novuhq/novu#11834](https://github.com/novuhq/novu/pull/11834) — OAuth-only MCP setup with no API key instructions.

## Changes

### MCP page (`/mcp`)
- **Client snippets**: URL-only OAuth configs (no Bearer headers or env vars)
- **Claude Code** (not Claude Desktop): `claude mcp add --transport http novu https://mcp.novu.co/` — Claude Desktop does not support remote OAuth per the docs PR
- **How it works**: OAuth sign-in copy; `whoami` verification in step 2
- **Prompts**: Added `whoami` verification prompt
- **Agentic tools**: Replaced `get_api_key_status` with `whoami`; updated `get_environments` for OAuth sessions; added Auth and Environments categories

### Agent-facing files
- **`public/auth.md`**: MCP auth via OAuth; EU endpoint `https://eu.mcp.novu.co/`; removed MCP from secret-key pickup flow
- **`public/.well-known/integrations.json`**: MCP surfaces use OAuth (DCR); removed `novu_api_key` credential
- **`public/.well-known/api-catalog`**: Added EU MCP endpoint
- **`public/llms.txt`**: OAuth + ChatGPT in MCP section
- **Static markdown export**: Synced tools, prompts, and client list

## Test plan

- [x] `pnpm lint` passes
- [ ] Verify `/mcp` page renders updated snippets and tool list
- [ ] Confirm Claude Code snippet shows CLI command (not Claude Desktop mcp-remote)
- [ ] Confirm no API key references remain in MCP setup instructions
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C06NABQRFQU/p1783423157537619?thread_ts=1783423157.537619&cid=C06NABQRFQU)

<div><a href="https://cursor.com/agents/bc-6365703f-184c-5747-8729-c49fd8ff9a07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6365703f-184c-5747-8729-c49fd8ff9a07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

