### PR TITLE
feat: link career applications to source job

### DIFF
--- a/src/app/(website)/api/careers/apply/route.ts
+++ b/src/app/(website)/api/careers/apply/route.ts
@@ -2,10 +2,13 @@ import { NextRequest, NextResponse } from "next/server"
 import { CAREER_DEPARTMENTS } from "@/constants/careers"
 import { z } from "zod"
 
+import { getCareerJobReferenceBySlug } from "@/lib/notion/careers"
+
 const MAX_CV_FILE_SIZE = 10 * 1024 * 1024
 const MAX_MULTIPART_BODY_SIZE = MAX_CV_FILE_SIZE + 1024 * 1024
 const NOTION_REQUEST_TIMEOUT = 8000
 const HONEYPOT_FIELD_NAME = "companyWebsite"
+const CAREER_JOB_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*-\d+$/
 const allowedCvExtensions = [".pdf", ".doc", ".docx"]
 const allowedCvMimeTypes = new Set([
   "application/pdf",
@@ -47,6 +50,13 @@ const applicationSchema = z.object({
     (value) => (typeof value === "string" ? value : ""),
     z.union([z.enum(CAREER_DEPARTMENTS), z.literal("")])
   ),
+  jobSlug: z.preprocess(
+    (value) => (typeof value === "string" ? value : ""),
+    z.union([
+      z.string().trim().max(200).regex(CAREER_JOB_SLUG_PATTERN),
+      z.literal(""),
+    ])
+  ),
 })
 
 const NOTION_VERSION = "2026-03-11"
@@ -66,6 +76,10 @@ type NotionFileUploadResponse = {
 type NotionPageResponse = {
   id: string
 }
+
+type CareerJobReference = NonNullable<
+  Awaited<ReturnType<typeof getCareerJobReferenceBySlug>>
+>
 
 function getNotionConfig() {
   const apiKey = process.env.NOTION_API_KEY
@@ -176,6 +190,31 @@ function getRichText(value: string) {
   }
 }
 
+function getCareerJobUrl(slug: string) {
+  const siteUrl = process.env.NEXT_PUBLIC_DEFAULT_SITE_URL || "https://novu.co"
+
+  return new URL(`/careers/${slug}/`, siteUrl).toString()
+}
+
+function getCareerJobProperties(jobReference: CareerJobReference | null) {
+  if (!jobReference) {
+    return {}
+  }
+
+  return {
+    "Applied for": {
+      relation: [
+        {
+          id: jobReference.id,
+        },
+      ],
+    },
+    "Job URL": {
+      url: getCareerJobUrl(jobReference.slug),
+    },
+  }
+}
+
 async function uploadCvToNotion(cv: File) {
   const fileUpload = await notionFetch<NotionFileUploadResponse>(
     "/file_uploads",
@@ -207,7 +246,8 @@ async function uploadCvToNotion(cv: File) {
 
 async function createNotionApplication(
   application: z.infer<typeof applicationSchema>,
-  cv: File
+  cv: File,
+  jobReference: CareerJobReference | null
 ) {
   const [dataSourceId, cvFileUploadId] = await Promise.all([
     getNotionDataSourceId(),
@@ -277,6 +317,7 @@ async function createNotionApplication(
                 getRichText(application.remoteAsyncExperience),
             }
           : {}),
+        ...getCareerJobProperties(jobReference),
       },
     }),
   })
@@ -326,6 +367,7 @@ export async function POST(req: NextRequest) {
       remoteAsyncExperience: formData.get("remoteAsyncExperience"),
       personalNote: formData.get("personalNote"),
       department: formData.get("department"),
+      jobSlug: formData.get("jobSlug"),
     })
 
     if (!parsed.success || cvIssues.length > 0 || !(cv instanceof File)) {
@@ -347,7 +389,25 @@ export async function POST(req: NextRequest) {
       )
     }
 
-    const application = await createNotionApplication(parsed.data, cv)
+    const jobReference = parsed.data.jobSlug
+      ? await getCareerJobReferenceBySlug(parsed.data.jobSlug)
+      : null
+
+    if (parsed.data.jobSlug && !jobReference) {
+      return NextResponse.json(
+        {
+          error: true,
+          message: "Invalid or closed career job",
+        },
+        { status: 400 }
+      )
+    }
+
+    const application = await createNotionApplication(
+      parsed.data,
+      cv,
+      jobReference
+    )
 
     return NextResponse.json(
       { sent: true, id: application.id },

--- a/src/app/(website)/api/careers/apply/route.ts
+++ b/src/app/(website)/api/careers/apply/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server"
-import { CAREER_DEPARTMENTS } from "@/constants/careers"
+import { CAREER_DEPARTMENTS, EMPTY_CV_ERROR_MESSAGE } from "@/constants/careers"
 import { z } from "zod"
 
 import { getCareerJobReferenceBySlug } from "@/lib/notion/careers"
@@ -154,8 +154,12 @@ async function getNotionDataSourceId() {
 }
 
 function getCvValidationIssues(cv: FormDataEntryValue | null) {
-  if (!(cv instanceof File) || cv.size === 0) {
+  if (!(cv instanceof File)) {
     return ["Please attach your CV."]
+  }
+
+  if (cv.size === 0) {
+    return [EMPTY_CV_ERROR_MESSAGE]
   }
 
   const fileName = cv.name.toLowerCase()

--- a/src/components/pages/careers/interest-form.tsx
+++ b/src/components/pages/careers/interest-form.tsx
@@ -68,6 +68,7 @@ type CareersFieldName = keyof CareersInterestFormValues
 
 interface CareersInterestFormProps {
   defaultDepartment?: string
+  jobSlug?: string
 }
 
 const formDefaultValues: CareersInterestFormValues = {
@@ -223,6 +224,7 @@ function CareersTextareaField({
 
 function CareersInterestForm({
   defaultDepartment = "",
+  jobSlug,
 }: CareersInterestFormProps) {
   const [submitted, setSubmitted] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
@@ -254,6 +256,9 @@ function CareersInterestForm({
       formData.append("remoteAsyncExperience", values.remoteAsyncExperience)
       formData.append("personalNote", values.personalNote)
       formData.append("department", values.department)
+      if (jobSlug) {
+        formData.append("jobSlug", jobSlug)
+      }
       formData.append(HONEYPOT_FIELD_NAME, honeypotRef.current?.value || "")
       formData.append("cv", values.cv[0])
 

--- a/src/components/pages/careers/interest-form.tsx
+++ b/src/components/pages/careers/interest-form.tsx
@@ -1,7 +1,11 @@
 "use client"
 
 import { useRef, useState } from "react"
-import { CAREER_DEPARTMENTS, isCareerDepartment } from "@/constants/careers"
+import {
+  CAREER_DEPARTMENTS,
+  EMPTY_CV_ERROR_MESSAGE,
+  isCareerDepartment,
+} from "@/constants/careers"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { ChevronDown } from "lucide-react"
 import { useForm } from "react-hook-form"
@@ -58,7 +62,13 @@ const formSchema = z.object({
     .min(2, "Please enter your city and country.")
     .max(120, "Location is too long."),
   remoteAsyncExperience: z.string(),
-  cv: z.any().refine((files) => files?.length === 1, "Please attach your CV."),
+  cv: z
+    .any()
+    .refine((files) => files?.length === 1, "Please attach your CV.")
+    .refine(
+      (files) => !files?.length || files[0]?.size > 0,
+      EMPTY_CV_ERROR_MESSAGE
+    ),
   personalNote: z.string().max(2000, "Personal note is too long."),
   department: z.string(),
 })

--- a/src/components/pages/careers/interest-form.tsx
+++ b/src/components/pages/careers/interest-form.tsx
@@ -143,22 +143,35 @@ function CareersFileField({
     <FormField
       control={control}
       name={name}
-      render={({ field: { onChange, ref, name } }) => (
-        <FormItem>
-          <FormLabel className={labelClassName}>{label}</FormLabel>
-          <FormControl>
-            <Input
-              ref={ref}
-              name={name}
-              type="file"
-              accept=".pdf,.doc,.docx"
-              required={required}
-              onChange={(event) => onChange(event.target.files)}
-            />
-          </FormControl>
-          <FormMessage />
-        </FormItem>
-      )}
+      render={({ field: { onChange, ref, name, value } }) => {
+        const fileName = value?.[0]?.name
+
+        return (
+          <FormItem>
+            <FormLabel className={labelClassName}>{label}</FormLabel>
+            <div className="relative">
+              <FormControl>
+                <Input
+                  ref={ref}
+                  name={name}
+                  type="file"
+                  accept=".pdf,.doc,.docx"
+                  className="peer absolute inset-0 z-10 h-full cursor-pointer opacity-0"
+                  required={required}
+                  onChange={(event) => onChange(event.target.files)}
+                />
+              </FormControl>
+              <div
+                className="pointer-events-none flex h-11 w-full items-center rounded-md border border-border bg-background px-3.5 py-2.5 text-base leading-snug tracking-tight transition-colors duration-300 peer-focus-visible:border-accent-foreground"
+                aria-hidden="true"
+              >
+                <span className="truncate">{fileName || "Choose file"}</span>
+              </div>
+            </div>
+            <FormMessage />
+          </FormItem>
+        )
+      }}
     />
   )
 }

--- a/src/components/pages/careers/job-page.tsx
+++ b/src/components/pages/careers/job-page.tsx
@@ -119,7 +119,10 @@ function CareerJobPage({ job }: CareerJobPageProps) {
             >
               Apply for This Position
             </h2>
-            <CareersInterestForm defaultDepartment={job.department} />
+            <CareersInterestForm
+              defaultDepartment={job.department}
+              jobSlug={job.slug}
+            />
           </section>
         </div>
       </article>

--- a/src/constants/careers.ts
+++ b/src/constants/careers.ts
@@ -9,6 +9,9 @@ export const CAREER_DEPARTMENTS = [
   "Other",
 ] as const
 
+export const EMPTY_CV_ERROR_MESSAGE =
+  "The selected CV file is empty. Please choose a non-empty PDF, DOC, or DOCX file."
+
 export type CareerDepartment = (typeof CAREER_DEPARTMENTS)[number]
 
 export function isCareerDepartment(value: unknown): value is CareerDepartment {

--- a/src/lib/notion/careers.ts
+++ b/src/lib/notion/careers.ts
@@ -10,6 +10,7 @@ import {
 
 const NOTION_VERSION = "2026-03-11"
 const NOTION_API_BASE_URL = "https://api.notion.com/v1"
+const NOTION_REQUEST_TIMEOUT = 8000
 
 type NotionRichText = {
   plain_text?: string
@@ -94,10 +95,16 @@ async function notionFetch<T>(
   headers.set("Authorization", `Bearer ${apiKey}`)
   headers.set("Notion-Version", NOTION_VERSION)
 
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), NOTION_REQUEST_TIMEOUT)
+
   const response = await fetch(`${NOTION_API_BASE_URL}${path}`, {
     ...init,
     headers,
+    signal: controller.signal,
     next: { tags: ["careers"] },
+  }).finally(() => {
+    clearTimeout(timeoutId)
   })
   const data = await response.json()
 
@@ -473,7 +480,7 @@ export async function getOpenCareerJobs() {
     .sort((a, b) => b.publishedAt.localeCompare(a.publishedAt))
 }
 
-export async function getCareerJobBySlug(slug: string) {
+async function getCareerPageAndJobBySlug(slug: string) {
   const jobIdNumber = getJobIdNumberFromSlug(slug)
 
   if (jobIdNumber === null) {
@@ -496,11 +503,35 @@ export async function getCareerJobBySlug(slug: string) {
     return null
   }
 
-  const blocks = await getPageContentBlocks(page.id)
+  return { job, page }
+}
+
+export async function getCareerJobReferenceBySlug(slug: string) {
+  const result = await getCareerPageAndJobBySlug(slug)
+
+  if (!result) {
+    return null
+  }
+
+  return {
+    id: result.page.id,
+    title: result.job.title,
+    slug: result.job.slug,
+  }
+}
+
+export async function getCareerJobBySlug(slug: string) {
+  const result = await getCareerPageAndJobBySlug(slug)
+
+  if (!result) {
+    return null
+  }
+
+  const blocks = await getPageContentBlocks(result.page.id)
   const content = mapBlocksToCareerContent(blocks)
 
   return {
-    ...job,
+    ...result.job,
     content,
     plainContent: getPlainContent(content),
   } satisfies ICareerJobDetail


### PR DESCRIPTION
**Summary**

- Pass the job slug when submitting an application from a specific career page
- Resolve and validate the job server-side against the open roles stored in Notion
- Reject applications referencing a missing, closed, or mismatched job
- Store the source job in filterable Notion database properties:
  - `Applied for` — relation to the source entry in `Open roles list`
  - `Job URL` — link to the public career page
- Keep general applications submitted from `/careers` unchanged
- Reject empty CV files with a clear validation message on both the client and server

**Validation**
[preview](https://website-new-git-feat-add-job-source-novuhq.vercel.app/careers/marketing-operations-lead-3/)
