### PR TITLE
fix(integrations): swap tab banners and fix webhook docs link

### DIFF
--- a/src/app/(website)/(default-footer)/integrations/_components/integrations-tab-page-content.tsx
+++ b/src/app/(website)/(default-footer)/integrations/_components/integrations-tab-page-content.tsx
@@ -21,22 +21,22 @@ const BANNER_CONTENT: Record<
   }
 > = {
   channels: {
+    title: "Add Custom Webhook",
+    description:
+      "Send notifications through a custom webhook when your\nprovider is not available as a built-in integration.",
+    cta: {
+      label: "View docs",
+      href: "https://docs.novu.co/platform/integrations/tool/webhook",
+      openInNewTab: true,
+    },
+  },
+  sources: {
     title: "Use the HTTP Step",
     description:
       "Send HTTP requests from your workflow to trigger third-\nparty actions and connect external services.",
     cta: {
       label: "View docs",
       href: "https://docs.novu.co/platform/workflow/add-and-configure-steps/configure-action-steps/http-step",
-      openInNewTab: true,
-    },
-  },
-  sources: {
-    title: "Add Custom Webhook",
-    description:
-      "Send notifications through a custom webhook when your\nprovider is not available as a built-in integration.",
-    cta: {
-      label: "View docs",
-      href: "https://docs.novu.co/platform/developer/webhooks",
       openInNewTab: true,
     },
   },


### PR DESCRIPTION
## What

Fixes two issues Dima flagged on the integrations pages:

1. **Banners were on the wrong tabs.** The Sources tab (novu.co/integrations/sources) showed the "Add Custom Webhook" note ("send notifications through a custom webhook when your provider is not available as a built-in integration"). That is a providers story and does not fit the Sources content (email frameworks, AI SDKs, feature flags used in code steps). The two banner contents are now swapped: Sources gets "Use the HTTP Step", Channels gets "Add Custom Webhook".

2. **The webhook "View docs" link pointed to the wrong page.** It went to `docs.novu.co/platform/developer/webhooks`, which documents Novu's outbound developer webhooks (event notifications about workflows), not webhook-based message delivery. It now points to `docs.novu.co/platform/integrations/tool/webhook`, the webhook delivery integration. Per-channel variants also exist (`email/webhook`, `sms/sms-webhook`, `push/push-webhook`) if a different single target is preferred.

## Where

One file: `src/app/(website)/(default-footer)/integrations/_components/integrations-tab-page-content.tsx` (the `BANNER_CONTENT` map).

## Verified

- Both docs URLs checked live (200, correct content).
- Rendered locally: /integrations/sources shows the HTTP Step banner, /integrations/channels shows the Custom Webhook banner with the corrected link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)