### PR TITLE
feat(prompts): align every coding-agent prompt with the agents.md prompt spec

### DIFF
--- a/src/components/pages/aci/aci-cta-actions.tsx
+++ b/src/components/pages/aci/aci-cta-actions.tsx
@@ -9,8 +9,13 @@ import useCopyToClipboard from "@/hooks/use-copy-to-clipboard"
 import { Button } from "@/components/ui/button"
 
 const CONNECT_COMMAND = "npx novu connect"
-const ACI_PROMPT =
-  "Add an agent to my app using instructions from https://novu.co/agents.md"
+const ACI_PROMPT = `Connect this project's AI agent to customer channels (Slack, Microsoft Teams, WhatsApp, Telegram, Email, or iMessage) with Novu Connect.
+
+Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci\`).
+
+Inspect the repo first. Ask me which channel to connect if it is not clear. Detect the framework/runtime from the project, or ask once. Then run one connect command per agents.md (bridge vs managed, keyless vs dashboard OAuth).
+
+Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md says that channel requires it (e.g. iMessage/Sendblue).`
 const CLAUDE_PROMPT_URL = `https://claude.ai/new?q=${encodeURIComponent(ACI_PROMPT)}`
 
 function AciCtaActions() {

--- a/src/components/pages/aci/hero-actions.tsx
+++ b/src/components/pages/aci/hero-actions.tsx
@@ -7,15 +7,20 @@ import { Check, Copy } from "lucide-react"
 import useCopyToClipboard from "@/hooks/use-copy-to-clipboard"
 import { Button } from "@/components/ui/button"
 
-const ACI_PROMPT =
-  "Add an agent to my app using instructions from https://novu.co/agents.md"
+const ACI_PROMPT = `Connect this project's AI agent to customer channels (Slack, Microsoft Teams, WhatsApp, Telegram, Email, or iMessage) with Novu Connect.
+
+Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci\`).
+
+Inspect the repo first. Ask me which channel to connect if it is not clear. Detect the framework/runtime from the project, or ask once. Then run one connect command per agents.md (bridge vs managed, keyless vs dashboard OAuth).
+
+Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md says that channel requires it (e.g. iMessage/Sendblue).`
 
 function HeroActions() {
   const { isCopied, handleCopy } = useCopyToClipboard(3000)
 
   return (
     <div className="flex w-full max-w-79.25 flex-col items-center lg:items-start">
-      <div className="flex w-full gap-3 flex-row sm:gap-5">
+      <div className="flex w-full flex-row gap-3 sm:gap-5">
         <Button
           variant="default"
           size="lg"

--- a/src/components/pages/channels/framework-connect.tsx
+++ b/src/components/pages/channels/framework-connect.tsx
@@ -68,7 +68,7 @@ function FrameworkConnect({ combo }: { combo: IChannelFrameworkCombo }) {
           <h3 className="text-base leading-none tracking-tighter text-white">
             Prompt for your coding agent
           </h3>
-          <p className="text-base leading-normal font-normal tracking-tighter text-gray-70">
+          <p className="text-base leading-normal font-normal tracking-tighter whitespace-pre-line text-gray-70">
             {fillTemplate(framework.promptTemplate, combo)}
           </p>
         </div>

--- a/src/components/pages/connect/prompt-copy-line.tsx
+++ b/src/components/pages/connect/prompt-copy-line.tsx
@@ -5,8 +5,13 @@ import checkIcon from "@/svgs/icons/check.svg"
 
 import useCopyToClipboard from "@/hooks/use-copy-to-clipboard"
 
-const CONNECT_PROMPT_PLACEHOLDER =
-  "Add an agent to my app https://novu.co/agents.md"
+const CONNECT_PROMPT_PLACEHOLDER = `Connect this project's AI agent to customer channels (Slack, Microsoft Teams, WhatsApp, Telegram, Email, or iMessage) with Novu Connect.
+
+Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci\`).
+
+Inspect the repo first. Ask me which channel to connect if it is not clear. Detect the framework/runtime from the project, or ask once. Then run one connect command per agents.md (bridge vs managed, keyless vs dashboard OAuth).
+
+Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md says that channel requires it (e.g. iMessage/Sendblue).`
 const COPY_ICON_SRC = copyIcon.src
 const CHECK_ICON_SRC = checkIcon.src
 

--- a/src/components/pages/home/connect-stack.tsx
+++ b/src/components/pages/home/connect-stack.tsx
@@ -77,51 +77,109 @@ const DEFAULT_FRAMEWORKS: IStackOption[] = [
     value: "ai-sdk",
     label: "Vercel AI SDK",
     icon: chatSdkIcon,
+    promptTemplate: `Connect this project's Vercel AI SDK agent to [SELECTED_CHANNEL] with Novu Connect.
+
+Follow https://novu.co/agents.md end to end (custom code bridge path). Default to the non-interactive CLI (\`--ci\`).
+
+Inspect the repo (agent entry point, how Vercel AI SDK is used, package manager, env conventions). Do not modify anything yet.
+
+Prefer a connect command shaped like:
+
+npx novu@latest connect --ci --runtime ai-sdk --channel [CHANNEL_SLUG]
+
+(Omit --keyless: bridge uses dashboard OAuth. Adjust flags only as agents.md allows for this runtime.)
+
+Prefer the secure setup links the CLI prints. After connect, finish any bridge wiring from the requirements file agents.md describes. Do not invent setup steps or ask for secrets in chat unless agents.md requires it.`,
   },
   {
     value: "langchain",
     label: "LangChain",
     icon: langChainIcon,
+    promptTemplate: `Connect this project's LangChain agent to [SELECTED_CHANNEL] with Novu Connect.
+
+Follow https://novu.co/agents.md end to end (custom code bridge path). Default to the non-interactive CLI (\`--ci\`).
+
+Inspect the repo (agent entry point, how LangChain is used, package manager, env conventions). Do not modify anything yet.
+
+Prefer a connect command shaped like:
+
+npx novu@latest connect --ci --runtime langchain --channel [CHANNEL_SLUG]
+
+(Omit --keyless: bridge uses dashboard OAuth. Adjust flags only as agents.md allows for this runtime.)
+
+Prefer the secure setup links the CLI prints. After connect, finish any bridge wiring from the requirements file agents.md describes. Do not invent setup steps or ask for secrets in chat unless agents.md requires it.`,
   },
   {
     value: "custom-code",
     label: "Custom code",
     icon: customCodeIcon,
+    promptTemplate: `Connect this project's custom code agent to [SELECTED_CHANNEL] with Novu Connect.
+
+Follow https://novu.co/agents.md end to end (custom code bridge path). Default to the non-interactive CLI (\`--ci\`).
+
+Inspect the repo (agent entry point, how custom code is used, package manager, env conventions). Do not modify anything yet.
+
+Prefer a connect command shaped like:
+
+npx novu@latest connect --ci --runtime custom-code --channel [CHANNEL_SLUG]
+
+(Omit --keyless: bridge uses dashboard OAuth. Adjust flags only as agents.md allows for this runtime.)
+
+Prefer the secure setup links the CLI prints. After connect, finish any bridge wiring from the requirements file agents.md describes. Do not invent setup steps or ask for secrets in chat unless agents.md requires it.`,
   },
   {
     value: "chat-sdk",
     label: "Chat SDK",
     icon: chatSdkIcon,
+    promptTemplate: `Connect this project's Chat SDK agent to [SELECTED_CHANNEL] with Novu Connect.
+
+Follow https://novu.co/agents.md end to end (custom code bridge path). Default to the non-interactive CLI (\`--ci\`).
+
+Inspect the repo (agent entry point, how Chat SDK is used, package manager, env conventions). Do not modify anything yet.
+
+Prefer a connect command shaped like:
+
+npx novu@latest connect --ci --runtime chat-sdk --channel [CHANNEL_SLUG]
+
+(Omit --keyless: bridge uses dashboard OAuth. Adjust flags only as agents.md allows for this runtime.)
+
+Prefer the secure setup links the CLI prints. After connect, finish any bridge wiring from the requirements file agents.md describes. Do not invent setup steps or ask for secrets in chat unless agents.md requires it.`,
   },
   {
     value: "claude-managed-agent",
     label: "Claude Managed Agent",
     icon: claudeIcon,
     cliSlug: "claude",
-    promptTemplate: `Create a Claude Managed Agent with Novu and connect it to [SELECTED_CHANNEL].
+    promptTemplate: `Connect a Claude Managed Agent to [SELECTED_CHANNEL] with Novu Connect.
 
-Run this command:
+Follow https://novu.co/agents.md end to end (managed agent path). Default to the non-interactive CLI (\`--ci\`).
 
-npx novu connect --channel [CHANNEL_SLUG] --runtime claude
+Infer a short agent description from the project, confirm it with me once, then prefer a connect command shaped like:
 
-The Novu CLI will guide you through the complete setup. Follow the prompts to connect your Anthropic credentials, describe the agent you want to create, review the skills and tools Novu adds, preview the agent, create it, and connect [SELECTED_CHANNEL].
+export NOVU_AGENT_DESCRIPTION='…'
+npx novu@latest connect "$NOVU_AGENT_DESCRIPTION" --ci --keyless --channel [CHANNEL_SLUG] --runtime claude
 
-You do not need to scaffold a project or modify application code for this setup.`,
+(Omit --keyless if I am already signed in to the Novu dashboard. Never combine --keyless with --channel teams; follow agents.md.)
+
+Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md requires it.`,
   },
   {
     value: "aws-claude-managed-agent",
     label: "AWS Claude Managed Agent",
     icon: awsIcon,
     cliSlug: "claude-aws",
-    promptTemplate: `Create a Claude Managed Agent on AWS with Novu and connect it to [SELECTED_CHANNEL].
+    promptTemplate: `Connect a Claude Managed Agent on AWS to [SELECTED_CHANNEL] with Novu Connect.
 
-Run this command:
+Follow https://novu.co/agents.md end to end (managed agent path). Default to the non-interactive CLI (\`--ci\`).
 
-npx novu connect --channel [CHANNEL_SLUG] --runtime claude-aws
+Infer a short agent description from the project, confirm it with me once, then prefer a connect command shaped like:
 
-The Novu CLI will guide you through the complete setup. Follow the prompts to complete the required credential flow, describe the agent you want to create, review the skills and tools Novu adds, preview the agent, create it, and connect [SELECTED_CHANNEL].
+export NOVU_AGENT_DESCRIPTION='…'
+npx novu@latest connect "$NOVU_AGENT_DESCRIPTION" --ci --keyless --channel [CHANNEL_SLUG] --runtime claude-aws
 
-You do not need to scaffold a project or modify application code for this setup.`,
+(Omit --keyless if I am already signed in to the Novu dashboard. Never combine --keyless with --channel teams; follow agents.md.)
+
+Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md requires it.`,
   },
 ]
 
@@ -265,11 +323,13 @@ function ConnectStack({
   const channelLabel = channel.promptLabel ?? channel.label
   const channelSlug = channel.cliSlug ?? channel.value
   const command = `npx novu connect --channel ${channelSlug} --runtime ${framework.cliSlug ?? framework.value}`
-  const defaultPrompt = `Connect this project's ${frameworkLabel} agent to ${channelLabel} with Novu Connect. Inspect the repo (agent entry point, how ${frameworkLabel} is used, package manager, model provider, env conventions). Do not modify anything yet. Then have me run from the project root:
+  const defaultPrompt = `Connect this project's AI agent to ${channelLabel} with Novu Connect.
 
-${command}
+Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci --channel ${channelSlug}\`).
 
-I will complete the interactive CLI and approve dependency installs when asked. When the CLI copies a follow-up prompt, ask me to paste that here and continue. Do not invent setup steps, supervise each CLI screen, or ask for secrets in chat. Stop after giving me the command.`
+Inspect the repo. Detect the runtime from the project (AI SDK / LangChain / etc.), or ask once. Then run one connect command for ${channelLabel} per agents.md.
+
+Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md requires it for this channel.`
   const prompt = framework.promptTemplate
     ? framework.promptTemplate
         .replaceAll("[SELECTED_CHANNEL]", channelLabel)

--- a/src/components/pages/home/cta.tsx
+++ b/src/components/pages/home/cta.tsx
@@ -16,8 +16,13 @@ interface ICTAProps {
   title: string
 }
 
-const DEFAULT_PROMPT =
-  "Connect my app or AI agent to customers with Novu. Set up reliable delivery, channel routing, and user preferences."
+const DEFAULT_PROMPT = `Connect this project's AI agent to customer channels (Slack, Microsoft Teams, WhatsApp, Telegram, Email, or iMessage) with Novu Connect.
+
+Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci\`).
+
+Inspect the repo first. Ask me which channel to connect if it is not clear. Detect the framework/runtime from the project, or ask once. Then run one connect command per agents.md (bridge vs managed, keyless vs dashboard OAuth).
+
+Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md says that channel requires it (e.g. iMessage/Sendblue).`
 
 function Cta({
   actions,

--- a/src/components/pages/home/hero.tsx
+++ b/src/components/pages/home/hero.tsx
@@ -29,8 +29,13 @@ import {
 import CopyPromptButton from "./copy-prompt-button"
 import HeroGlobe from "./hero-globe"
 
-const DEFAULT_PROMPT =
-  "Connect my AI agent to customers across their preferred channels with Novu."
+const DEFAULT_PROMPT = `Connect this project's AI agent to customer channels (Slack, Microsoft Teams, WhatsApp, Telegram, Email, or iMessage) with Novu Connect.
+
+Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci\`).
+
+Inspect the repo first. Ask me which channel to connect if it is not clear. Detect the framework/runtime from the project, or ask once. Then run one connect command per agents.md (bridge vs managed, keyless vs dashboard OAuth).
+
+Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md says that channel requires it (e.g. iMessage/Sendblue).`
 
 const CHANNEL_HOVER_STYLES = {
   telegram: {

--- a/src/components/pages/home/novu-connect.tsx
+++ b/src/components/pages/home/novu-connect.tsx
@@ -33,8 +33,13 @@ export interface INovuConnectProps {
   title: string
 }
 
-const DEFAULT_PROMPT =
-  "Connect my AI agent to customers with Novu Connect. Configure secure two-way messaging, user identity, delivery status, and replies across the customer's preferred communication channel."
+const DEFAULT_PROMPT = `Connect this project's AI agent to customer channels (Slack, Microsoft Teams, WhatsApp, Telegram, Email, or iMessage) with Novu Connect.
+
+Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci\`).
+
+Inspect the repo first. Ask me which channel to connect if it is not clear. Detect the framework/runtime from the project, or ask once. Then run one connect command per agents.md (bridge vs managed, keyless vs dashboard OAuth).
+
+Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md says that channel requires it (e.g. iMessage/Sendblue).`
 
 function NovuConnect({
   className,

--- a/src/data/pages/channels/email.tsx
+++ b/src/data/pages/channels/email.tsx
@@ -57,8 +57,13 @@ export const emailChannelData: IChannelPageData = {
     "High-deliverability routing",
     "Secure action links for approvals",
   ],
-  prompt:
-    "Connect my AI agent to Email with Novu using a responsive template, attachments, and delivery tracking. Route each customer's replies back to the same thread.",
+  prompt: `Connect this project's AI agent to Email with Novu Connect.
+
+Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci --channel email\`).
+
+Inspect the repo. Detect the runtime from the project (AI SDK / LangChain / etc.), or ask once. Then run one connect command for Email per agents.md.
+
+Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md requires it for this channel.`,
   onRamp: {
     type: "keyless",
     note: "Email works in the keyless quickstart. Run npx novu connect --channel email to get a managed agent sending email, no account needed for the first few replies.",

--- a/src/data/pages/channels/microsoft-teams.tsx
+++ b/src/data/pages/channels/microsoft-teams.tsx
@@ -57,8 +57,13 @@ export const microsoftTeamsChannelData: IChannelPageData = {
     "Reliable team notifications",
     "Native Adaptive Cards and approval prompts",
   ],
-  prompt:
-    "Connect my AI agent to Microsoft Teams with Novu and include a human handoff workflow. Keep channel and thread context, and route replies back to the same conversation.",
+  prompt: `Connect this project's AI agent to Microsoft Teams with Novu Connect.
+
+Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci --channel teams\`). Note: Teams cannot use keyless mode; follow agents.md for dashboard OAuth / dashboard redirect rules.
+
+Inspect the repo. Detect the runtime from the project (AI SDK / LangChain / etc.), or ask once. Then run one connect command for Microsoft Teams per agents.md.
+
+Prefer the secure setup links or dashboard handoffs the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md requires it for this channel.`,
   onRamp: {
     type: "oauth",
     note: "Microsoft Teams connects from the Novu dashboard. Authenticate your workspace once, and Novu Connect manages delivery, identity, and two-way routing after that.",

--- a/src/data/pages/channels/slack.tsx
+++ b/src/data/pages/channels/slack.tsx
@@ -58,8 +58,13 @@ export const slackChannelData: IChannelPageData = {
     "Reliable delivery with retries",
     "Native Block Kit messages and tool-approval prompts",
   ],
-  prompt:
-    "Connect my AI agent to Slack with Novu, including threaded replies and delivery status handling. Identify each user and route agent replies back to the same Slack conversation.",
+  prompt: `Connect this project's AI agent to Slack with Novu Connect.
+
+Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci --channel slack\`).
+
+Inspect the repo. Detect the runtime from the project (AI SDK / LangChain / etc.), or ask once. Then run one connect command for Slack per agents.md.
+
+Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md requires it for this channel.`,
   onRamp: {
     type: "keyless",
     note: "Slack works in the keyless quickstart. Run npx novu connect --channel slack and you get a managed agent on Slack, no account needed for the first few replies.",

--- a/src/data/pages/channels/telegram.tsx
+++ b/src/data/pages/channels/telegram.tsx
@@ -57,8 +57,13 @@ export const telegramChannelData: IChannelPageData = {
     "Inline keyboards for quick actions",
     "Replies routed to the right context",
   ],
-  prompt:
-    "Connect my AI agent to Telegram with Novu and configure rich messages, user identity, and two-way replies. Route each user's replies back to the same conversation.",
+  prompt: `Connect this project's AI agent to Telegram with Novu Connect.
+
+Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci --channel telegram\`).
+
+Inspect the repo. Detect the runtime from the project (AI SDK / LangChain / etc.), or ask once. Then run one connect command for Telegram per agents.md.
+
+Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md requires it for this channel.`,
   onRamp: {
     type: "keyless",
     note: "Telegram works in the keyless quickstart. Run npx novu connect --channel telegram to get a managed agent on Telegram, no account needed for the first few replies.",

--- a/src/data/pages/channels/whatsapp.tsx
+++ b/src/data/pages/channels/whatsapp.tsx
@@ -62,8 +62,13 @@ export const whatsappChannelData: IChannelPageData = {
     "Attachments and delivery receipts",
     "Embedded WhatsApp Business signup (official Meta Business Partner)",
   ],
-  prompt:
-    "Connect my AI agent to WhatsApp with Novu and configure approved templates plus two-way replies. Identify each user and route their messages back to the same conversation.",
+  prompt: `Connect this project's AI agent to WhatsApp with Novu Connect.
+
+Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci --channel whatsapp\`).
+
+Inspect the repo. Detect the runtime from the project (AI SDK / LangChain / etc.), or ask once. Then run one connect command for WhatsApp per agents.md.
+
+Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md requires it for this channel.`,
   onRamp: {
     type: "oauth",
     note: "WhatsApp connects from the Novu dashboard with embedded signup: log in with your business account, pick your WhatsApp number, and you are working in about 5 minutes.",

--- a/src/data/pages/frameworks/ai-sdk.tsx
+++ b/src/data/pages/frameworks/ai-sdk.tsx
@@ -38,8 +38,19 @@ export const aiSdkFrameworkData: IAgentFrameworkData = {
       body: "Sign in to keep the agent live, then run your dev server. Your AI SDK agent now holds a two-way conversation in {channelName}, and the same agent can reach every other channel from one thread.",
     },
   ],
-  promptTemplate:
-    "Connect this project's Vercel AI SDK agent to {channelName} with Novu Connect. Inspect the repo to see how the AI SDK is used, then have me run npx novu connect --channel {cliSlug} --runtime ai-sdk from the project root. I will complete the interactive CLI. When the CLI copies a follow-up prompt, ask me to paste it here and continue. Do not invent setup steps or ask for secrets in chat. Stop after giving me the command.",
+  promptTemplate: `Connect this project's Vercel AI SDK agent to {channelName} with Novu Connect.
+
+Follow https://novu.co/agents.md end to end (custom code bridge path). Default to the non-interactive CLI (\`--ci\`).
+
+Inspect the repo (agent entry point, how Vercel AI SDK is used, package manager, env conventions). Do not modify anything yet.
+
+Prefer a connect command shaped like:
+
+npx novu@latest connect --ci --runtime ai-sdk --channel {cliSlug}
+
+(Omit --keyless: bridge uses dashboard OAuth. Adjust flags only as agents.md allows for this runtime.)
+
+Prefer the secure setup links the CLI prints. After connect, finish any bridge wiring from the requirements file agents.md describes. Do not invent setup steps or ask for secrets in chat unless agents.md requires it.`,
   faq: [
     {
       question: "Do I have to rewrite my AI SDK agent to add {channelName}?",

--- a/src/data/pages/frameworks/chat-sdk.tsx
+++ b/src/data/pages/frameworks/chat-sdk.tsx
@@ -38,8 +38,19 @@ export const chatSdkFrameworkData: IAgentFrameworkData = {
       body: "Sign in to keep the agent live, then run your dev server. Your Chat SDK agent now holds a two-way conversation in {channelName}, and the same agent can reach every other channel from one thread.",
     },
   ],
-  promptTemplate:
-    "Connect this project's Chat SDK agent to {channelName} with Novu Connect. Inspect the repo to see how Chat SDK is used, then have me run npx novu connect --channel {cliSlug} --runtime chat-sdk from the project root. I will complete the interactive CLI. When the CLI copies a follow-up prompt, ask me to paste it here and continue. Do not invent setup steps or ask for secrets in chat. Stop after giving me the command.",
+  promptTemplate: `Connect this project's Chat SDK agent to {channelName} with Novu Connect.
+
+Follow https://novu.co/agents.md end to end (custom code bridge path). Default to the non-interactive CLI (\`--ci\`).
+
+Inspect the repo (agent entry point, how Chat SDK is used, package manager, env conventions). Do not modify anything yet.
+
+Prefer a connect command shaped like:
+
+npx novu@latest connect --ci --runtime chat-sdk --channel {cliSlug}
+
+(Omit --keyless: bridge uses dashboard OAuth. Adjust flags only as agents.md allows for this runtime.)
+
+Prefer the secure setup links the CLI prints. After connect, finish any bridge wiring from the requirements file agents.md describes. Do not invent setup steps or ask for secrets in chat unless agents.md requires it.`,
   faq: [
     {
       question: "Do I have to rewrite my Chat SDK app to add {channelName}?",
@@ -52,7 +63,8 @@ export const chatSdkFrameworkData: IAgentFrameworkData = {
         "No. Novu Connect is the communication layer, the ACI, Agent Communication Infrastructure, bridge between your agent and {channelName}. You own the reasoning and the tools. We never run your brain, that is the whole point.",
     },
     {
-      question: "Do users in {channelName} get the same agent as my in-app chat?",
+      question:
+        "Do users in {channelName} get the same agent as my in-app chat?",
       answer:
         "Yes. The bridge points at the same agent loop that powers your Chat SDK app, so one agent serves your product and {channelName}, with conversation context kept per user.",
     },

--- a/src/data/pages/frameworks/claude-aws.tsx
+++ b/src/data/pages/frameworks/claude-aws.tsx
@@ -38,8 +38,18 @@ export const claudeAwsFrameworkData: IAgentFrameworkData = {
       body: "The guided flow connects {channelName}. Your agent now holds a two-way conversation there, and the same agent can reach every other channel from one thread.",
     },
   ],
-  promptTemplate:
-    "Create a Claude Managed Agent on AWS with Novu and connect it to {channelName}. Run this command: npx novu connect --channel {cliSlug} --runtime claude-aws. The Novu CLI will guide you through the complete setup. Follow the prompts to complete the required credential flow, describe the agent you want to create, review the skills and tools Novu adds, preview the agent, create it, and connect {channelName}. You do not need to scaffold a project or modify application code for this setup.",
+  promptTemplate: `Connect a Claude Managed Agent on AWS to {channelName} with Novu Connect.
+
+Follow https://novu.co/agents.md end to end (managed agent path). Default to the non-interactive CLI (\`--ci\`).
+
+Infer a short agent description from the project, confirm it with me once, then prefer a connect command shaped like:
+
+export NOVU_AGENT_DESCRIPTION='…'
+npx novu@latest connect "$NOVU_AGENT_DESCRIPTION" --ci --keyless --channel {cliSlug} --runtime claude-aws
+
+(Omit --keyless if I am already signed in to the Novu dashboard. Never combine --keyless with --channel teams; follow agents.md.)
+
+Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md requires it.`,
   faq: [
     {
       question: "How is this different from the standard Claude Managed Agent?",

--- a/src/data/pages/frameworks/claude.tsx
+++ b/src/data/pages/frameworks/claude.tsx
@@ -38,11 +38,22 @@ export const claudeFrameworkData: IAgentFrameworkData = {
       body: "The guided flow connects {channelName}. Your agent now holds a two-way conversation there, and the same agent can reach every other channel from one thread.",
     },
   ],
-  promptTemplate:
-    "Create a Claude Managed Agent with Novu and connect it to {channelName}. Run this command: npx novu connect --channel {cliSlug} --runtime claude. The Novu CLI will guide you through the complete setup. Follow the prompts to connect your Anthropic credentials, describe the agent you want to create, review the skills and tools Novu adds, preview the agent, create it, and connect {channelName}. You do not need to scaffold a project or modify application code for this setup.",
+  promptTemplate: `Connect a Claude Managed Agent to {channelName} with Novu Connect.
+
+Follow https://novu.co/agents.md end to end (managed agent path). Default to the non-interactive CLI (\`--ci\`).
+
+Infer a short agent description from the project, confirm it with me once, then prefer a connect command shaped like:
+
+export NOVU_AGENT_DESCRIPTION='…'
+npx novu@latest connect "$NOVU_AGENT_DESCRIPTION" --ci --keyless --channel {cliSlug} --runtime claude
+
+(Omit --keyless if I am already signed in to the Novu dashboard. Never combine --keyless with --channel teams; follow agents.md.)
+
+Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md requires it.`,
   faq: [
     {
-      question: "Do I need to host anything to put a Claude Managed Agent in {channelName}?",
+      question:
+        "Do I need to host anything to put a Claude Managed Agent in {channelName}?",
       answer:
         "No. There is no agent server and no bridge code. You bring Anthropic credentials, Claude does the reasoning, and Novu keeps the conversation running in {channelName}.",
     },

--- a/src/data/pages/frameworks/custom-code.tsx
+++ b/src/data/pages/frameworks/custom-code.tsx
@@ -38,11 +38,23 @@ export const customCodeFrameworkData: IAgentFrameworkData = {
       body: "Sign in to keep the agent live, then run your dev server. Your agent now holds a two-way conversation in {channelName}, and the same agent can reach every other channel from one thread.",
     },
   ],
-  promptTemplate:
-    "Connect this project's custom code agent to {channelName} with Novu Connect. Inspect the repo to find the agent entry point, then have me run npx novu connect --channel {cliSlug} --runtime custom-code from the project root. I will complete the interactive CLI. When the CLI copies a follow-up prompt, ask me to paste it here and continue. Do not invent setup steps or ask for secrets in chat. Stop after giving me the command.",
+  promptTemplate: `Connect this project's custom code agent to {channelName} with Novu Connect.
+
+Follow https://novu.co/agents.md end to end (custom code bridge path). Default to the non-interactive CLI (\`--ci\`).
+
+Inspect the repo (agent entry point, how custom code is used, package manager, env conventions). Do not modify anything yet.
+
+Prefer a connect command shaped like:
+
+npx novu@latest connect --ci --runtime custom-code --channel {cliSlug}
+
+(Omit --keyless: bridge uses dashboard OAuth. Adjust flags only as agents.md allows for this runtime.)
+
+Prefer the secure setup links the CLI prints. After connect, finish any bridge wiring from the requirements file agents.md describes. Do not invent setup steps or ask for secrets in chat unless agents.md requires it.`,
   faq: [
     {
-      question: "My agent uses no framework at all. Does that work with {channelName}?",
+      question:
+        "My agent uses no framework at all. Does that work with {channelName}?",
       answer:
         "Yes. That is what the custom-code runtime is for. The bridge is a plain handler: Novu passes in each {channelName} message with its conversation context, and whatever you return goes back to the user.",
     },

--- a/src/data/pages/frameworks/langchain.tsx
+++ b/src/data/pages/frameworks/langchain.tsx
@@ -38,8 +38,19 @@ export const langchainFrameworkData: IAgentFrameworkData = {
       body: "Sign in to keep the agent live, then run your dev server. Your LangChain agent now holds a two-way conversation in {channelName}, and the same agent can reach every other channel from one thread.",
     },
   ],
-  promptTemplate:
-    "Connect this project's LangChain agent to {channelName} with Novu Connect. Inspect the repo to see how LangChain is used, then have me run npx novu connect --channel {cliSlug} --runtime langchain from the project root. I will complete the interactive CLI. When the CLI copies a follow-up prompt, ask me to paste it here and continue. Do not invent setup steps or ask for secrets in chat. Stop after giving me the command.",
+  promptTemplate: `Connect this project's LangChain agent to {channelName} with Novu Connect.
+
+Follow https://novu.co/agents.md end to end (custom code bridge path). Default to the non-interactive CLI (\`--ci\`).
+
+Inspect the repo (agent entry point, how LangChain is used, package manager, env conventions). Do not modify anything yet.
+
+Prefer a connect command shaped like:
+
+npx novu@latest connect --ci --runtime langchain --channel {cliSlug}
+
+(Omit --keyless: bridge uses dashboard OAuth. Adjust flags only as agents.md allows for this runtime.)
+
+Prefer the secure setup links the CLI prints. After connect, finish any bridge wiring from the requirements file agents.md describes. Do not invent setup steps or ask for secrets in chat unless agents.md requires it.`,
   faq: [
     {
       question: "Do I have to rewrite my LangChain agent to add {channelName}?",

--- a/src/data/pages/home.ts
+++ b/src/data/pages/home.ts
@@ -57,8 +57,13 @@ export const HOME_CHANNELS = [
     title: "Connect your AI agent to Slack",
     description:
       "Reach teams where work happens with rich, actionable messages, threads, and reliable delivery routing.",
-    prompt:
-      "Connect my AI agent to Slack with Novu, including threaded replies and delivery status handling.",
+    prompt: `Connect this project's AI agent to Slack with Novu Connect.
+
+Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci --channel slack\`).
+
+Inspect the repo. Detect the runtime from the project (AI SDK / LangChain / etc.), or ask once. Then run one connect command for Slack per agents.md.
+
+Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md requires it for this channel.`,
     features: [
       "Two-way threaded conversations",
       "Team and user identity mapping",
@@ -72,8 +77,13 @@ export const HOME_CHANNELS = [
     title: "Connect your AI agent to WhatsApp",
     description:
       "Start secure two-way customer conversations with templates, attachments, and delivery receipts.",
-    prompt:
-      "Connect my AI agent to WhatsApp with Novu and configure approved templates plus two-way replies.",
+    prompt: `Connect this project's AI agent to WhatsApp with Novu Connect.
+
+Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci --channel whatsapp\`).
+
+Inspect the repo. Detect the runtime from the project (AI SDK / LangChain / etc.), or ask once. Then run one connect command for WhatsApp per agents.md.
+
+Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md requires it for this channel.`,
     features: [
       "Secure two-way conversations",
       "Approved message templates",
@@ -87,8 +97,13 @@ export const HOME_CHANNELS = [
     title: "Connect your AI agent to Telegram",
     description:
       "Reach users with fast, conversational updates, rich media, and replies inside Telegram.",
-    prompt:
-      "Connect my AI agent to Telegram with Novu and configure rich messages, user identity, and two-way replies.",
+    prompt: `Connect this project's AI agent to Telegram with Novu Connect.
+
+Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci --channel telegram\`).
+
+Inspect the repo. Detect the runtime from the project (AI SDK / LangChain / etc.), or ask once. Then run one connect command for Telegram per agents.md.
+
+Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md requires it for this channel.`,
     features: [
       "Fast conversational delivery",
       "Rich messages and media",
@@ -102,8 +117,13 @@ export const HOME_CHANNELS = [
     title: "Connect your AI agent to Microsoft Teams",
     description:
       "Bring agent updates and human handoffs into the channels your organization already uses.",
-    prompt:
-      "Connect my AI agent to Microsoft Teams with Novu and include a human handoff workflow.",
+    prompt: `Connect this project's AI agent to Microsoft Teams with Novu Connect.
+
+Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci --channel teams\`). Note: Teams cannot use keyless mode; follow agents.md for dashboard OAuth / dashboard redirect rules.
+
+Inspect the repo. Detect the runtime from the project (AI SDK / LangChain / etc.), or ask once. Then run one connect command for Microsoft Teams per agents.md.
+
+Prefer the secure setup links or dashboard handoffs the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md requires it for this channel.`,
     features: [
       "Channel and thread awareness",
       "Human handoff workflows",
@@ -117,8 +137,13 @@ export const HOME_CHANNELS = [
     title: "Connect your AI agent to Email",
     description:
       "Reach users directly in their inbox with rich, actionable notifications. Support for templates, attachments, and high-deliverability routing.",
-    prompt:
-      "Connect my AI agent to Email with Novu using a responsive template, attachments, and delivery tracking.",
+    prompt: `Connect this project's AI agent to Email with Novu Connect.
+
+Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci --channel email\`).
+
+Inspect the repo. Detect the runtime from the project (AI SDK / LangChain / etc.), or ask once. Then run one connect command for Email per agents.md.
+
+Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md requires it for this channel.`,
     features: [
       "Responsive message templates",
       "Attachments and rich content",
@@ -132,8 +157,13 @@ export const HOME_CHANNELS = [
     title: "Connect your AI agent to iMessage",
     description:
       "Bring agent conversations and timely updates into the native messaging experience customers already use.",
-    prompt:
-      "Connect my AI agent to iMessage with Novu and configure secure two-way conversations plus delivery tracking.",
+    prompt: `Connect this project's AI agent to iMessage with Novu Connect.
+
+Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci --channel sendblue\`).
+
+Inspect the repo. Detect the runtime from the project (AI SDK / LangChain / etc.), or ask once. Collect the Sendblue inputs agents.md requires before running connect, then run one command for iMessage.
+
+Do not invent setup steps. For Sendblue, agents.md allows collecting credentials in chat (no secure setup page): warn once, then continue.`,
     features: [
       "Native messaging experience",
       "Secure two-way conversations",

--- a/src/lib/markdown/pages/aci.ts
+++ b/src/lib/markdown/pages/aci.ts
@@ -12,8 +12,13 @@ import { bulletList, faqMarkdown, pageFromSeo } from "../page-utils"
 import type { MarkdownPage } from "../types"
 
 const CONNECT_COMMAND = "npx novu connect"
-const ACI_PROMPT =
-  "Add an agent to my app using instructions from https://novu.co/agents.md"
+const ACI_PROMPT = `Connect this project's AI agent to customer channels (Slack, Microsoft Teams, WhatsApp, Telegram, Email, or iMessage) with Novu Connect.
+
+Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci\`).
+
+Inspect the repo first. Ask me which channel to connect if it is not clear. Detect the framework/runtime from the project, or ask once. Then run one connect command per agents.md (bridge vs managed, keyless vs dashboard OAuth).
+
+Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md says that channel requires it (e.g. iMessage/Sendblue).`
 const CLAUDE_PROMPT_URL = `https://claude.ai/new?q=${encodeURIComponent(
   ACI_PROMPT
 )}`

--- a/src/lib/markdown/pages/channel-frameworks.ts
+++ b/src/lib/markdown/pages/channel-frameworks.ts
@@ -4,7 +4,7 @@ import {
   getConnectCommand,
 } from "@/data/pages/channel-frameworks"
 
-import { escapeMarkdownText } from "../markdown-format"
+import { escapeMarkdownText, formatCodeFence } from "../markdown-format"
 import { bulletList } from "../page-utils"
 import type { MarkdownPage } from "../types"
 
@@ -50,7 +50,8 @@ export async function getChannelFrameworks(
     bulletList(framework.strengths),
     `## How to connect ${escapeMarkdownText(framework.name)} to ${escapeMarkdownText(channel.channelName)}`,
     steps,
-    `Prompt for your coding agent: ${escapeMarkdownText(fillTemplate(framework.promptTemplate, combo))}`,
+    "Prompt for your coding agent:",
+    formatCodeFence(fillTemplate(framework.promptTemplate, combo), "text"),
     `## ${escapeMarkdownText(framework.name)} and ${escapeMarkdownText(channel.channelName)}, common questions`,
     faq,
   ]

--- a/src/lib/markdown/pages/channels.ts
+++ b/src/lib/markdown/pages/channels.ts
@@ -1,6 +1,6 @@
 import { getChannelBySlug } from "@/data/pages/channels"
 
-import { escapeMarkdownText } from "../markdown-format"
+import { escapeMarkdownText, formatCodeFence } from "../markdown-format"
 import { bulletList } from "../page-utils"
 import type { MarkdownPage } from "../types"
 
@@ -39,7 +39,8 @@ export async function getChannels(
     transcript,
     `## How to connect`,
     escapeMarkdownText(channel.onRamp.note),
-    `Prompt for your coding agent: ${escapeMarkdownText(channel.prompt)}`,
+    "Prompt for your coding agent:",
+    formatCodeFence(channel.prompt, "text"),
     `## ${escapeMarkdownText(channel.channelName)} and Novu Connect, common questions`,
     faq,
   ]

--- a/src/lib/markdown/pages/connect.ts
+++ b/src/lib/markdown/pages/connect.ts
@@ -15,7 +15,13 @@ import type { MarkdownPage } from "../types"
 import { absoluteUrl, toCanonicalPathname } from "../url"
 
 const CONNECT_COMMAND = "npx novu connect"
-const CONNECT_PROMPT = "Add an agent to my app https://novu.co/agents.md"
+const CONNECT_PROMPT = `Connect this project's AI agent to customer channels (Slack, Microsoft Teams, WhatsApp, Telegram, Email, or iMessage) with Novu Connect.
+
+Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci\`).
+
+Inspect the repo first. Ask me which channel to connect if it is not clear. Detect the framework/runtime from the project, or ask once. Then run one connect command per agents.md (bridge vs managed, keyless vs dashboard OAuth).
+
+Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md says that channel requires it (e.g. iMessage/Sendblue).`
 const PRODUCT_HUNT_LAUNCH_URL =
   "https://www.producthunt.com/products/novu/launches/novu-connect"
 

--- a/tests/critical-flows/contracts.ts
+++ b/tests/critical-flows/contracts.ts
@@ -62,11 +62,19 @@ export const connectStackContract = {
   channel: "MS Teams",
   framework: "LangChain",
   command: "npx novu connect --channel teams --runtime langchain",
-  prompt: `Connect this project's LangChain agent to MS Teams with Novu Connect. Inspect the repo (agent entry point, how LangChain is used, package manager, model provider, env conventions). Do not modify anything yet. Then have me run from the project root:
+  prompt: `Connect this project's LangChain agent to MS Teams with Novu Connect.
 
-npx novu connect --channel teams --runtime langchain
+Follow https://novu.co/agents.md end to end (custom code bridge path). Default to the non-interactive CLI (\`--ci\`).
 
-I will complete the interactive CLI and approve dependency installs when asked. When the CLI copies a follow-up prompt, ask me to paste that here and continue. Do not invent setup steps, supervise each CLI screen, or ask for secrets in chat. Stop after giving me the command.`,
+Inspect the repo (agent entry point, how LangChain is used, package manager, env conventions). Do not modify anything yet.
+
+Prefer a connect command shaped like:
+
+npx novu@latest connect --ci --runtime langchain --channel teams
+
+(Omit --keyless: bridge uses dashboard OAuth. Adjust flags only as agents.md allows for this runtime.)
+
+Prefer the secure setup links the CLI prints. After connect, finish any bridge wiring from the requirements file agents.md describes. Do not invent setup steps or ask for secrets in chat unless agents.md requires it.`,
 } as const
 
 export const channelPagesContract = {
@@ -121,7 +129,13 @@ export const connectContract = {
   route: destinations.connect,
   heading: "Connect your agent to any channel",
   command: "npx novu connect",
-  prompt: "Add an agent to my app https://novu.co/agents.md",
+  prompt: `Connect this project's AI agent to customer channels (Slack, Microsoft Teams, WhatsApp, Telegram, Email, or iMessage) with Novu Connect.
+
+Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci\`).
+
+Inspect the repo first. Ask me which channel to connect if it is not clear. Detect the framework/runtime from the project, or ask once. Then run one connect command per agents.md (bridge vs managed, keyless vs dashboard OAuth).
+
+Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md says that channel requires it (e.g. iMessage/Sendblue).`,
   signUpDestination: destinations.agentsSignUp,
   connectAppDestination: destinations.connectApp,
 } as const


### PR DESCRIPTION
## What

Replaces every copy-paste coding-agent prompt on the site with the canonical prompts from the product prompt spec ([Notion: Novu Website [Prompts]](https://app.notion.com/p/novuhq/Novu-Website-Prompts-3b2d03ad838f80e3be8fc8cce26ebbd1)). The prompts in production today do not point the agent at https://novu.co/agents.md, so a pasted prompt gives the coding agent nothing to follow. Every prompt now instructs the agent to follow agents.md end to end and to default to the non-interactive CLI (`npx novu@latest connect … --ci`).

## Surfaces updated

- **Hero prompt** (spec sections 1, 4, 5): homepage hero, homepage one-engine section, homepage bottom CTA, /connect hero copy line, /aci hero + CTA (including the claude.ai deep link), and the /connect + /aci .md mirrors
- **Per-channel prompts** (spec section 2): the six homepage channel cards and the five channel landing pages (Slack, WhatsApp, Telegram, Microsoft Teams, Email), filled with each channel's CLI slug. Teams carries the no-keyless / dashboard OAuth note; iMessage uses the `sendblue` slug and the collect-credentials-in-chat caveat
- **Framework prompts** (spec section 3): the six framework page templates and the homepage framework x channel picker, split into the bridge template (Vercel AI SDK, LangChain, custom code, Chat SDK: dashboard OAuth, omit `--keyless`) and the managed template (Claude, Claude on AWS: inferred agent description, `--keyless`, never with Teams). The picker's fallback prompt uses the channel template with runtime detection
- **.md mirrors**: multiline prompts are now emitted as fenced code blocks on the channel and framework x channel markdown pages
- **UI**: the framework page prompt box renders paragraphs (`whitespace-pre-line`); all copy buttons copy the full multiline prompt unchanged
- **Tests**: TC-CONNECT-001 and TC-HOME-003 contracts updated to the new prompts

## Notes for review

- Em dashes in the spec text were replaced with colons/semicolons per the company-wide style rule; content is otherwise verbatim
- The spec's Inbox prompt has no copyable surface on main yet (the homepage Inbox card renders an action link, not a copy button); it will land with the /notify page work
- The GitHub homepage card prompt is not covered by the spec and was left unchanged
- `next build` passes. The critical-flow Playwright specs fail identically on clean main in my local environment (hydration-ready helper timing out), so CI is the arbiter there

🤖 Generated with [Claude Code](https://claude.com/claude-code)