### PR TITLE
Fix single featured post layout

### DIFF
--- a/src/components/pages/blog/category-and-date.tsx
+++ b/src/components/pages/blog/category-and-date.tsx
@@ -17,9 +17,12 @@ function CategoryAndDate({
   isFeatured = false,
 }: ICategoryAndDateProps) {
   return (
-    <div className={cn("flex items-center gap-x-2", className)}>
+    <div className={cn("flex items-baseline gap-x-2", className)}>
       <Category category={category} isFeatured={isFeatured} />
-      <div className="size-1 shrink-0 rounded-full bg-gray-5" aria-hidden />
+      <div
+        className="size-1 shrink-0 self-center rounded-full bg-gray-5"
+        aria-hidden
+      />
       <Date variant="blog" size="sm" publishedAt={publishedAt} />
     </div>
   )

--- a/src/components/pages/blog/featured-posts.tsx
+++ b/src/components/pages/blog/featured-posts.tsx
@@ -34,23 +34,20 @@ function FeaturedPost({ className, posts }: IFeaturedPostProps) {
           className={cn(
             "flex flex-col border-b border-border pb-6 md:border-b-0 md:pb-0",
             isSinglePost &&
-              "md:grid md:h-60 md:grid-cols-[minmax(0,5fr)_minmax(0,3fr)] md:gap-x-8 lg:h-64 lg:gap-x-10"
+              "md:grid md:grid-cols-[minmax(0,5fr)_minmax(0,3fr)] md:gap-x-8 lg:gap-x-10"
           )}
         >
           <Link
             className={cn(
               "shrink-0 overflow-hidden rounded-lg",
-              isSinglePost && "md:relative md:block md:h-full md:min-w-0"
+              isSinglePost && "md:block md:min-w-0"
             )}
             variant="clean"
             size="none"
             href={featuredPost.url}
           >
             <Image
-              className={cn(
-                "w-full object-cover",
-                isSinglePost && "md:absolute md:inset-0 md:h-full"
-              )}
+              className="w-full object-cover"
               src={featuredPost.cover}
               width={480}
               height={270}
@@ -90,7 +87,7 @@ function FeaturedPost({ className, posts }: IFeaturedPostProps) {
               </Link>
             </h3>
             {isSinglePost && featuredPost.caption && (
-              <p className="mt-3 hidden text-base/snug font-book tracking-tighter text-pretty text-gray-8 md:line-clamp-2 lg:line-clamp-3">
+              <p className="mt-3 line-clamp-3 text-base/snug font-book tracking-tighter text-pretty text-gray-8 md:line-clamp-2 lg:line-clamp-3">
                 {featuredPost.caption}
               </p>
             )}

--- a/src/components/pages/blog/featured-posts.tsx
+++ b/src/components/pages/blog/featured-posts.tsx
@@ -17,84 +17,131 @@ function FeaturedPost({ className, posts }: IFeaturedPostProps) {
   }
 
   const [featuredPost, ...restPosts] = posts.slice(0, 4)
+  const hasAdditionalPosts = restPosts.length > 0
+  const isSinglePost = !hasAdditionalPosts
 
   return (
     <section className={cn("featured-posts", className)}>
       <h2 className="sr-only">Featured posts</h2>
-      <div className="lg grid grid-cols-1 gap-x-16 gap-y-0 md:grid-cols-[22rem_auto] md:gap-y-12 lg:grid-cols-[26rem_auto] xl:grid-cols-[30rem_auto]">
-        <article className="flex flex-col border-b border-border pb-6 md:border-b-0 md:pb-0">
+      <div
+        className={cn(
+          "lg grid grid-cols-1 gap-x-16 gap-y-0",
+          hasAdditionalPosts &&
+            "md:grid-cols-[22rem_auto] md:gap-y-12 lg:grid-cols-[26rem_auto] xl:grid-cols-[30rem_auto]"
+        )}
+      >
+        <article
+          className={cn(
+            "flex flex-col border-b border-border pb-6 md:border-b-0 md:pb-0",
+            isSinglePost &&
+              "md:grid md:h-60 md:grid-cols-[minmax(0,5fr)_minmax(0,3fr)] md:gap-x-8 lg:h-64 lg:gap-x-10"
+          )}
+        >
           <Link
-            className="shrink-0 overflow-hidden rounded-lg"
+            className={cn(
+              "shrink-0 overflow-hidden rounded-lg",
+              isSinglePost && "md:relative md:block md:h-full md:min-w-0"
+            )}
             variant="clean"
             size="none"
             href={featuredPost.url}
           >
             <Image
-              className="w-full object-cover"
+              className={cn(
+                "w-full object-cover",
+                isSinglePost && "md:absolute md:inset-0 md:h-full"
+              )}
               src={featuredPost.cover}
               width={480}
               height={270}
               quality={100}
-              sizes="(max-width: 768px) 100vw, 960px"
+              sizes={
+                isSinglePost
+                  ? "(max-width: 767px) 100vw, (max-width: 1023px) 62vw, 520px"
+                  : "(max-width: 768px) 100vw, 960px"
+              }
               alt={featuredPost.coverAlt || featuredPost.title}
               priority
             />
           </Link>
-          <CategoryAndDate
-            className="mt-6 md:hidden"
-            category={featuredPost.category}
-            publishedAt={featuredPost.publishedAt}
-          />
-          <h3 className="mt-3 md:mt-4">
-            <Link
-              className="line-clamp-3 text-2xl/dense font-medium text-pretty hover:text-gray-9 md:text-[1.75rem] lg:line-clamp-2 lg:text-[2rem]"
-              variant="white"
-              href={featuredPost.url}
-            >
-              {featuredPost.title}
-            </Link>
-          </h3>
-          <Authors
-            className="mt-4 shrink-0 md:hidden"
-            authors={featuredPost.authors}
-            size="sm"
-          />
-        </article>
-        <div className="flex flex-col gap-y-0 md:gap-y-8">
-          {restPosts.map(
-            ({ title, category, publishedAt, url, authors }, index) => (
-              <article
-                className="flex flex-col border-b border-border py-6 md:border-b-0 md:py-0"
-                key={index}
+          <div
+            className={cn(
+              "flex flex-col",
+              isSinglePost && "md:h-full md:min-w-0 md:overflow-hidden"
+            )}
+          >
+            <CategoryAndDate
+              className={isSinglePost ? "mt-6 md:mt-0" : "mt-6 md:hidden"}
+              category={featuredPost.category}
+              publishedAt={featuredPost.publishedAt}
+            />
+            <h3 className="mt-3 md:mt-4">
+              <Link
+                className={cn(
+                  "line-clamp-3 text-2xl/dense font-medium text-pretty hover:text-gray-9",
+                  isSinglePost
+                    ? "md:text-2xl/tight"
+                    : "md:text-[1.75rem] lg:line-clamp-2 lg:text-[2rem]"
+                )}
+                variant="white"
+                href={featuredPost.url}
               >
-                <CategoryAndDate
-                  className="hidden md:flex"
-                  category={category}
-                  publishedAt={publishedAt}
-                />
-                <CategoryAndDate
-                  className="md:hidden"
-                  category={category}
-                  publishedAt={publishedAt}
-                />
-                <h3 className="mt-3">
-                  <Link
-                    className="tracking-dense line-clamp-2 text-2xl/dense font-medium text-pretty hover:text-gray-9 md:text-xl/snug"
-                    variant="white"
-                    href={url}
-                  >
-                    {title}
-                  </Link>
-                </h3>
-                <Authors
-                  className="mt-4 shrink-0 md:mt-3 md:hidden"
-                  authors={authors}
-                  size="sm"
-                />
-              </article>
-            )
-          )}
-        </div>
+                {featuredPost.title}
+              </Link>
+            </h3>
+            {isSinglePost && featuredPost.caption && (
+              <p className="mt-3 hidden text-base/snug font-book tracking-tighter text-pretty text-gray-8 md:line-clamp-2 lg:line-clamp-3">
+                {featuredPost.caption}
+              </p>
+            )}
+            <Authors
+              className={
+                isSinglePost
+                  ? "mt-4 shrink-0 md:mt-auto"
+                  : "mt-4 shrink-0 md:hidden"
+              }
+              authors={featuredPost.authors}
+              size="sm"
+            />
+          </div>
+        </article>
+        {hasAdditionalPosts && (
+          <div className="flex flex-col gap-y-0 md:gap-y-8">
+            {restPosts.map(
+              ({ title, category, publishedAt, url, authors }, index) => (
+                <article
+                  className="flex flex-col border-b border-border py-6 md:border-b-0 md:py-0"
+                  key={index}
+                >
+                  <CategoryAndDate
+                    className="hidden md:flex"
+                    category={category}
+                    publishedAt={publishedAt}
+                  />
+                  <CategoryAndDate
+                    className="md:hidden"
+                    category={category}
+                    publishedAt={publishedAt}
+                  />
+                  <h3 className="mt-3">
+                    <Link
+                      className="tracking-dense line-clamp-2 text-2xl/dense font-medium text-pretty hover:text-gray-9 md:text-xl/snug"
+                      variant="white"
+                      href={url}
+                    >
+                      {title}
+                    </Link>
+                  </h3>
+                  <Authors
+                    className="mt-4 shrink-0 md:mt-3 md:hidden"
+                    authors={authors}
+                    size="sm"
+                  />
+                </article>
+              )
+            )}
+          </div>
+        )}
       </div>
     </section>
   )


### PR DESCRIPTION
Updates the blog featured-posts section when Sanity returns a single post. The image now uses roughly 60% of the width and matches the content column height, while the multi-post and mobile layouts remain unchanged.

Validated with lint, typecheck, production build, unit tests, and responsive browser QA.