### PR TITLE
Reuse feature video previews on channel pages

### DIFF
--- a/src/app/(website)/(connect-footer)/page.tsx
+++ b/src/app/(website)/(connect-footer)/page.tsx
@@ -2,6 +2,10 @@ import type { Metadata } from "next"
 import { ROUTE } from "@/constants/routes"
 import { SEO_DATA } from "@/constants/seo-data"
 import {
+  CHANNEL_PREVIEW_COMPANIES,
+  CHANNEL_PREVIEW_VIDEOS,
+} from "@/data/pages/channel-previews"
+import {
   HOME_CHANNELS,
   HOME_CLI_SLUGS,
   HOME_COMPLIANCE,
@@ -325,59 +329,6 @@ export default async function HomePage() {
   const LIVE_CHANNELS = new Set<string>(HOME_LIVE_CHANNEL_KEYS)
   const cliSlugs = HOME_CLI_SLUGS
 
-  const clientFacingVideos: Record<
-    string,
-    {
-      webm: string
-      mp4: string
-      poster: string
-      displaySize?: { width: number; height: number }
-    }
-  > = {
-    slack: {
-      webm: "/videos/pages/home/features/slack-client-facing.webm",
-      mp4: "/videos/pages/home/features/slack-client-facing.mp4",
-      poster: "/videos/pages/home/features/slack-client-facing-poster.webp",
-      displaySize: { width: 504, height: 348 },
-    },
-    whatsapp: {
-      webm: "/videos/pages/home/features/whatsapp-client-facing.webm",
-      mp4: "/videos/pages/home/features/whatsapp-client-facing.mp4",
-      poster: "/videos/pages/home/features/whatsapp-client-facing-poster.webp",
-      displaySize: { width: 504, height: 348 },
-    },
-    telegram: {
-      webm: "/videos/pages/home/features/telegram-client-facing.webm",
-      mp4: "/videos/pages/home/features/telegram-client-facing.mp4",
-      poster: "/videos/pages/home/features/telegram-client-facing-poster.webp",
-      displaySize: { width: 504, height: 436 },
-    },
-    email: {
-      webm: "/videos/pages/home/features/email-client-facing.webm",
-      mp4: "/videos/pages/home/features/email-client-facing.mp4",
-      poster: "/videos/pages/home/features/email-client-facing-poster.webp",
-      displaySize: { width: 504, height: 414 },
-    },
-    teams: {
-      webm: "/videos/pages/home/features/teams-client-facing.webm",
-      mp4: "/videos/pages/home/features/teams-client-facing.mp4",
-      poster: "/videos/pages/home/features/teams-client-facing-poster.webp",
-      displaySize: { width: 504, height: 332 },
-    },
-    imessage: {
-      webm: "/videos/pages/home/features/imessage-client-facing.webm",
-      mp4: "/videos/pages/home/features/imessage-client-facing.mp4",
-      poster: "/videos/pages/home/features/imessage-client-facing-poster.webp",
-      displaySize: { width: 504, height: 332 },
-    },
-    inbox: {
-      webm: "/videos/pages/home/features/inbox-client-facing.webm",
-      mp4: "/videos/pages/home/features/inbox-client-facing.mp4",
-      poster: "/videos/pages/home/features/inbox-client-facing-poster.webp",
-      displaySize: { width: 425, height: 373 },
-    },
-  }
-
   // Per-channel static preview image; falls back to the shared placeholder
   // until a channel-specific still is added.
   const clientFacingImages: Record<string, typeof clientFacingPreview> = {
@@ -462,95 +413,13 @@ export default async function HomePage() {
     "google-chat": "Coming Soon",
   }
 
-  // 2-sentence company + use-case blurb, shown on hover over the company in each demo.
-  // Shown on hover over the company in each demo: the name once, then a short
-  // "what the company is" line and a separate "what the agent does" line.
-  const companyInfo: Record<
-    string,
-    { name: string; about: string; useCase: string }
-  > = {
-    slack: {
-      name: "Helix",
-      about:
-        "A data-pipeline platform that keeps its customers' analytics flowing.",
-      useCase:
-        "Its support agent works in shared Slack Connect channels, diagnosing sync failures and fixing them once the customer approves.",
-    },
-    whatsapp: {
-      name: "Fernweh",
-      about: "A direct-to-consumer travel-gear brand.",
-      useCase:
-        "Its agent handles orders and delivery changes over WhatsApp, so a shopper can reroute a package in a few taps.",
-    },
-    telegram: {
-      name: "Lumen",
-      about: "A developer API platform.",
-      useCase:
-        "Its agent answers usage and billing questions in Telegram, showing real limits and upgrading a plan on request.",
-    },
-    teams: {
-      name: "Vesta",
-      about: "An enterprise security and compliance vendor.",
-      useCase:
-        "Its agent works with client IT admins in Microsoft Teams, provisioning access with the approvals enterprises require.",
-    },
-    email: {
-      name: "Brightledger",
-      about: "A billing and finance platform.",
-      useCase:
-        "Its agent resolves invoice questions over email, explaining charges and issuing credits through secure action links.",
-    },
-    imessage: {
-      name: "Cedar House",
-      about: "A restaurant group.",
-      useCase:
-        "Its agent manages reservations over iMessage, moving bookings and confirming details in the customer's Messages app.",
-    },
-    github: {
-      name: "Corewave",
-      about: "An open-source developer tool.",
-      useCase:
-        "Its agent triages bug reports inside GitHub issues, references the fix, and closes the thread when it ships.",
-    },
-    zoom: {
-      name: "Loopwork",
-      about: "A coaching and enablement platform.",
-      useCase:
-        "Its agent follows up after sessions in Zoom Team Chat, sharing recaps and booking the next meeting.",
-    },
-    linear: {
-      name: "Tideline",
-      about: "A product company.",
-      useCase:
-        "Its agent turns customer feature requests into triaged Linear issues, setting status and sharing a roadmap ETA.",
-    },
-    discord: {
-      name: "Pixelforge",
-      about: "A game studio.",
-      useCase:
-        "Its agent supports players in the community Discord, checking access and granting roles without leaving the channel.",
-    },
-    messenger: {
-      name: "Lark & Loom",
-      about: "A home-goods brand.",
-      useCase:
-        "Its agent helps shoppers reorder over Facebook Messenger, surfacing past orders as product cards.",
-    },
-    "google-chat": {
-      name: "Kepler",
-      about: "A design and build agency.",
-      useCase:
-        "Its agent answers client project questions in Google Chat spaces, sharing status cards and staging links.",
-    },
-  }
-
   const featureItems = contentData.features.items.map((item) => {
     const slug = cliSlugs[item.key]
     const imagePresentation = clientFacingImagePresentation[item.key]
 
     return {
       ...item,
-      company: companyInfo[item.key],
+      company: CHANNEL_PREVIEW_COMPANIES[item.key],
       availability: LIVE_CHANNELS.has(item.key)
         ? ("live" as const)
         : ("upcoming" as const),
@@ -564,7 +433,7 @@ export default async function HomePage() {
         clientFacingUnderlayVideos[
           item.key as keyof typeof clientFacingUnderlayVideos
         ],
-      clientFacingVideo: clientFacingVideos[item.key],
+      clientFacingVideo: CHANNEL_PREVIEW_VIDEOS[item.key],
       implementationCode: featureImplementationCode,
       implementationHighlightedHtml: featureImplementationHighlightedHtml,
     }

--- a/src/components/pages/channels/channel-use-case.tsx
+++ b/src/components/pages/channels/channel-use-case.tsx
@@ -1,14 +1,15 @@
-import Image from "next/image"
+import {
+  CHANNEL_PREVIEW_COMPANIES,
+  CHANNEL_PREVIEW_VIDEOS,
+} from "@/data/pages/channel-previews"
 import featuresBackground from "@/images/pages/home/features/bg.jpg"
 
 import type { IChannelPageData } from "@/types/channel"
+import Preview from "@/components/pages/home/features/preview"
 
 function ChannelUseCase({ channel }: { channel: IChannelPageData }) {
-  const clientFacingVideo = {
-    webm: `/videos/channels/${channel.cliSlug}-client-facing.webm`,
-    mp4: `/videos/channels/${channel.cliSlug}-client-facing.hevc.mp4`,
-    poster: `/videos/channels/${channel.cliSlug}-client-facing-poster.png`,
-  }
+  const clientFacingVideo = CHANNEL_PREVIEW_VIDEOS[channel.cliSlug]
+  const company = CHANNEL_PREVIEW_COMPANIES[channel.cliSlug]
 
   return (
     <section className="safe-paddings mt-24">
@@ -22,33 +23,14 @@ function ChannelUseCase({ channel }: { channel: IChannelPageData }) {
           </p>
         </div>
 
-        <div className="relative mt-8 aspect-703/432 overflow-hidden rounded-[0.625rem] border border-gray-20">
-          <Image
-            className="object-cover"
-            src={featuresBackground}
-            alt=""
-            fill
-            sizes="(min-width: 768px) 704px, calc(100vw - 40px)"
-            quality={100}
-            loading="eager"
-            aria-hidden
+        <div className="relative mt-8 aspect-10/11 overflow-hidden rounded-[0.625rem] border border-gray-20 sm:aspect-5/4 lg:aspect-[640/536]">
+          <Preview
+            backgroundImage={featuresBackground}
+            channelLabel={channel.channelName}
+            clientFacingVideo={clientFacingVideo}
+            company={company}
+            isActive
           />
-          <video
-            className="absolute top-1/2 left-1/2 h-[87%] w-[72.5%] -translate-1/2 rounded-[0.9375rem] object-contain"
-            poster={clientFacingVideo.poster}
-            autoPlay
-            loop
-            muted
-            playsInline
-            preload="metadata"
-            aria-label={`${channel.channelName} client-facing preview`}
-          >
-            <source src={clientFacingVideo.webm} type="video/webm" />
-            <source
-              src={clientFacingVideo.mp4}
-              type='video/mp4; codecs="hvc1"'
-            />
-          </video>
         </div>
       </div>
     </section>

--- a/src/components/pages/home/features/company-tooltip.tsx
+++ b/src/components/pages/home/features/company-tooltip.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import { useRef, useState, type MouseEvent, type PointerEvent } from "react"
+
 import {
   Tooltip,
   TooltipContent,
@@ -55,12 +57,54 @@ function TooltipTip() {
 }
 
 function CompanyTooltip({ company }: { company: IFeatureCompany }) {
+  const [open, setOpen] = useState(false)
+  const isPinnedRef = useRef(false)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+
+  const pinTooltip = () => {
+    isPinnedRef.current = true
+    setOpen(true)
+  }
+
+  const closeTooltip = () => {
+    isPinnedRef.current = false
+    setOpen(false)
+  }
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen && isPinnedRef.current) return
+
+    setOpen(nextOpen)
+  }
+
+  const handlePointerDown = (event: PointerEvent<HTMLButtonElement>) => {
+    event.preventDefault()
+
+    if (event.pointerType === "touch" && isPinnedRef.current) {
+      closeTooltip()
+      return
+    }
+
+    pinTooltip()
+  }
+
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault()
+
+    if (event.detail === 0) {
+      pinTooltip()
+    }
+  }
+
   return (
-    <Tooltip>
+    <Tooltip open={open} onOpenChange={handleOpenChange}>
       <TooltipTrigger asChild>
         <button
+          ref={triggerRef}
           aria-label={`About ${company.name}`}
           className="absolute top-5 right-5 z-20 flex size-7 cursor-pointer items-center justify-center overflow-hidden rounded border border-gray-12 bg-[#101114] text-gray-60 shadow-[0_0_6px_2px_rgba(0,0,0,0.15)] backdrop-blur-[3.5px] transition-colors hover:border-gray-20 hover:bg-[#0B0C0E] hover:text-white focus-visible:border-gray-20 focus-visible:bg-[#0B0C0E] focus-visible:text-white focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none data-[state=delayed-open]:border-gray-20 data-[state=delayed-open]:bg-[#0B0C0E] data-[state=delayed-open]:text-white data-[state=instant-open]:border-gray-20 data-[state=instant-open]:bg-[#0B0C0E] data-[state=instant-open]:text-white"
+          onClick={handleClick}
+          onPointerDown={handlePointerDown}
           type="button"
         >
           <ChatBotIcon />
@@ -70,6 +114,28 @@ function CompanyTooltip({ company }: { company: IFeatureCompany }) {
         align="end"
         avoidCollisions={false}
         className="block w-[23.1875rem] max-w-[calc(100vw-2rem)] rounded-md border-gray-20 bg-[#0B0C0E] p-0 font-inter text-pretty shadow-none drop-shadow-[0_2px_2.5px_rgba(0,0,0,0.25)] before:hidden after:hidden [&>span]:block [&>span]:w-full"
+        onEscapeKeyDown={(event) => {
+          if (
+            isPinnedRef.current ||
+            triggerRef.current === document.activeElement
+          ) {
+            closeTooltip()
+            return
+          }
+
+          event.preventDefault()
+        }}
+        onPointerDownOutside={(event) => {
+          if (
+            event.target instanceof Node &&
+            triggerRef.current?.contains(event.target)
+          ) {
+            event.preventDefault()
+            return
+          }
+
+          closeTooltip()
+        }}
         side="top"
         sideOffset={12}
       >

--- a/src/components/pages/home/features/preview.tsx
+++ b/src/components/pages/home/features/preview.tsx
@@ -9,7 +9,7 @@ import CompanyTooltip, { type IFeatureCompany } from "./company-tooltip"
 
 export interface IPreviewData {
   backgroundImage: StaticImageData | string
-  clientFacingImage: StaticImageData | string
+  clientFacingImage?: StaticImageData | string
   clientFacingImageClassName?: string
   clientFacingImageSizes?: string
   clientFacingLabel?: string
@@ -79,7 +79,7 @@ function Preview({
         draggable={false}
       />
 
-      {clientFacingImageClassName && !clientFacingVideo ? (
+      {clientFacingImageClassName && clientFacingImage && !clientFacingVideo ? (
         <div className={cn("absolute z-10", clientFacingImageClassName)}>
           {clientFacingUnderlayVideo ? (
             <video
@@ -160,7 +160,7 @@ function Preview({
                   <source src={clientFacingVideo.webm} type="video/webm" />
                 </video>
               </div>
-            ) : (
+            ) : clientFacingImage ? (
               <Image
                 className="size-full object-contain"
                 src={clientFacingImage}
@@ -169,7 +169,7 @@ function Preview({
                 quality={100}
                 draggable={false}
               />
-            )}
+            ) : null}
           </div>
         </div>
       )}

--- a/src/data/pages/channel-previews.ts
+++ b/src/data/pages/channel-previews.ts
@@ -1,0 +1,137 @@
+export interface IChannelPreviewVideo {
+  webm: string
+  mp4: string
+  poster: string
+  displaySize?: {
+    width: number
+    height: number
+  }
+}
+
+export interface IChannelPreviewCompany {
+  name: string
+  about: string
+  useCase: string
+}
+
+export const CHANNEL_PREVIEW_VIDEOS: Record<string, IChannelPreviewVideo> = {
+  slack: {
+    webm: "/videos/pages/home/features/slack-client-facing.webm",
+    mp4: "/videos/pages/home/features/slack-client-facing.mp4",
+    poster: "/videos/pages/home/features/slack-client-facing-poster.webp",
+    displaySize: { width: 504, height: 348 },
+  },
+  whatsapp: {
+    webm: "/videos/pages/home/features/whatsapp-client-facing.webm",
+    mp4: "/videos/pages/home/features/whatsapp-client-facing.mp4",
+    poster: "/videos/pages/home/features/whatsapp-client-facing-poster.webp",
+    displaySize: { width: 504, height: 348 },
+  },
+  telegram: {
+    webm: "/videos/pages/home/features/telegram-client-facing.webm",
+    mp4: "/videos/pages/home/features/telegram-client-facing.mp4",
+    poster: "/videos/pages/home/features/telegram-client-facing-poster.webp",
+    displaySize: { width: 504, height: 436 },
+  },
+  email: {
+    webm: "/videos/pages/home/features/email-client-facing.webm",
+    mp4: "/videos/pages/home/features/email-client-facing.mp4",
+    poster: "/videos/pages/home/features/email-client-facing-poster.webp",
+    displaySize: { width: 504, height: 414 },
+  },
+  teams: {
+    webm: "/videos/pages/home/features/teams-client-facing.webm",
+    mp4: "/videos/pages/home/features/teams-client-facing.mp4",
+    poster: "/videos/pages/home/features/teams-client-facing-poster.webp",
+    displaySize: { width: 504, height: 332 },
+  },
+  imessage: {
+    webm: "/videos/pages/home/features/imessage-client-facing.webm",
+    mp4: "/videos/pages/home/features/imessage-client-facing.mp4",
+    poster: "/videos/pages/home/features/imessage-client-facing-poster.webp",
+    displaySize: { width: 504, height: 332 },
+  },
+  inbox: {
+    webm: "/videos/pages/home/features/inbox-client-facing.webm",
+    mp4: "/videos/pages/home/features/inbox-client-facing.mp4",
+    poster: "/videos/pages/home/features/inbox-client-facing-poster.webp",
+    displaySize: { width: 425, height: 373 },
+  },
+}
+
+export const CHANNEL_PREVIEW_COMPANIES: Record<string, IChannelPreviewCompany> =
+  {
+    slack: {
+      name: "Helix",
+      about:
+        "A data-pipeline platform that keeps its customers' analytics flowing.",
+      useCase:
+        "Its support agent works in shared Slack Connect channels, diagnosing sync failures and fixing them once the customer approves.",
+    },
+    whatsapp: {
+      name: "Fernweh",
+      about: "A direct-to-consumer travel-gear brand.",
+      useCase:
+        "Its agent handles orders and delivery changes over WhatsApp, so a shopper can reroute a package in a few taps.",
+    },
+    telegram: {
+      name: "Lumen",
+      about: "A developer API platform.",
+      useCase:
+        "Its agent answers usage and billing questions in Telegram, showing real limits and upgrading a plan on request.",
+    },
+    teams: {
+      name: "Vesta",
+      about: "An enterprise security and compliance vendor.",
+      useCase:
+        "Its agent works with client IT admins in Microsoft Teams, provisioning access with the approvals enterprises require.",
+    },
+    email: {
+      name: "Brightledger",
+      about: "A billing and finance platform.",
+      useCase:
+        "Its agent resolves invoice questions over email, explaining charges and issuing credits through secure action links.",
+    },
+    imessage: {
+      name: "Cedar House",
+      about: "A restaurant group.",
+      useCase:
+        "Its agent manages reservations over iMessage, moving bookings and confirming details in the customer's Messages app.",
+    },
+    github: {
+      name: "Corewave",
+      about: "An open-source developer tool.",
+      useCase:
+        "Its agent triages bug reports inside GitHub issues, references the fix, and closes the thread when it ships.",
+    },
+    zoom: {
+      name: "Loopwork",
+      about: "A coaching and enablement platform.",
+      useCase:
+        "Its agent follows up after sessions in Zoom Team Chat, sharing recaps and booking the next meeting.",
+    },
+    linear: {
+      name: "Tideline",
+      about: "A product company.",
+      useCase:
+        "Its agent turns customer feature requests into triaged Linear issues, setting status and sharing a roadmap ETA.",
+    },
+    discord: {
+      name: "Pixelforge",
+      about: "A game studio.",
+      useCase:
+        "Its agent supports players in the community Discord, checking access and granting roles without leaving the channel.",
+    },
+    messenger: {
+      name: "Lark & Loom",
+      about: "A home-goods brand.",
+      useCase:
+        "Its agent helps shoppers reorder over Facebook Messenger, surfacing past orders as product cards.",
+    },
+    "google-chat": {
+      name: "Kepler",
+      about: "A design and build agency.",
+      useCase:
+        "Its agent answers client project questions in Google Chat spaces, sharing status cards and staging links.",
+    },
+  }


### PR DESCRIPTION
## Summary

- Reuse the home Features videos and preview styling on `/channels/[channel]` pages.
- Share channel preview media and company metadata between the home and channel pages.
- Support mobile tooltip taps and pinned desktop tooltips with predictable outside-click and Escape behavior.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- Desktop and mobile browser checks