### PR TITLE
refactor(prompts): restore short copy with agents.md suffix (fixes MRK-1918)

### DIFF
--- a/src/app/(website)/(connect-footer)/channels/[channel]/page.tsx
+++ b/src/app/(website)/(connect-footer)/channels/[channel]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation"
 import { ROUTE } from "@/constants/routes"
 import { getAllChannelSlugs, getChannelBySlug } from "@/data/pages/channels"
 
+import { DEFAULT_CONNECT_PROMPT } from "@/lib/connect-prompt"
 import { getMetadata } from "@/lib/get-metadata"
 import { safeJsonLdStringify } from "@/lib/json-ld"
 import { absoluteUrl, toCanonicalPathname } from "@/lib/site-url"
@@ -169,7 +170,7 @@ async function ChannelPage({ params }: PageProps) {
       />
       <CTA
         title="Give your agent a voice, anywhere your users are"
-        description="Pro tip: paste 'Add an agent to my app https://novu.co/agents.md' into your coding agent, or run npx novu connect. One agent, every channel, one conversation."
+        description={`Pro tip: paste '${DEFAULT_CONNECT_PROMPT}' into your coding agent, or run npx novu connect. One agent, every channel, one conversation.`}
         actions={[
           {
             kind: "primary-button",

--- a/src/components/pages/aci/aci-cta-actions.tsx
+++ b/src/components/pages/aci/aci-cta-actions.tsx
@@ -9,13 +9,8 @@ import useCopyToClipboard from "@/hooks/use-copy-to-clipboard"
 import { Button } from "@/components/ui/button"
 
 const CONNECT_COMMAND = "npx novu connect"
-const ACI_PROMPT = `Connect this project's AI agent to customer channels (Slack, Microsoft Teams, WhatsApp, Telegram, Email, or iMessage) with Novu Connect.
-
-Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci\`).
-
-Inspect the repo first. Ask me which channel to connect if it is not clear. Detect the framework/runtime from the project, or ask once. Then run one connect command per agents.md (bridge vs managed, keyless vs dashboard OAuth).
-
-Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md says that channel requires it (e.g. iMessage/Sendblue).`
+const ACI_PROMPT =
+  "Add an agent to my app using instructions from https://novu.co/agents.md"
 const CLAUDE_PROMPT_URL = `https://claude.ai/new?q=${encodeURIComponent(ACI_PROMPT)}`
 
 function AciCtaActions() {

--- a/src/components/pages/aci/aci-cta-actions.tsx
+++ b/src/components/pages/aci/aci-cta-actions.tsx
@@ -5,13 +5,12 @@ import NextLink from "next/link"
 import claudeIcon from "@/images/pages/aci/aci-cta/claude-logo.svg"
 import { Check } from "lucide-react"
 
+import { DEFAULT_CONNECT_PROMPT } from "@/lib/connect-prompt"
 import useCopyToClipboard from "@/hooks/use-copy-to-clipboard"
 import { Button } from "@/components/ui/button"
 
 const CONNECT_COMMAND = "npx novu connect"
-const ACI_PROMPT =
-  "Add an agent to my app using instructions from https://novu.co/agents.md"
-const CLAUDE_PROMPT_URL = `https://claude.ai/new?q=${encodeURIComponent(ACI_PROMPT)}`
+const CLAUDE_PROMPT_URL = `https://claude.ai/new?q=${encodeURIComponent(DEFAULT_CONNECT_PROMPT)}`
 
 function AciCtaActions() {
   const { isCopied, handleCopy } = useCopyToClipboard(3000)

--- a/src/components/pages/aci/hero-actions.tsx
+++ b/src/components/pages/aci/hero-actions.tsx
@@ -7,13 +7,8 @@ import { Check, Copy } from "lucide-react"
 import useCopyToClipboard from "@/hooks/use-copy-to-clipboard"
 import { Button } from "@/components/ui/button"
 
-const ACI_PROMPT = `Connect this project's AI agent to customer channels (Slack, Microsoft Teams, WhatsApp, Telegram, Email, or iMessage) with Novu Connect.
-
-Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci\`).
-
-Inspect the repo first. Ask me which channel to connect if it is not clear. Detect the framework/runtime from the project, or ask once. Then run one connect command per agents.md (bridge vs managed, keyless vs dashboard OAuth).
-
-Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md says that channel requires it (e.g. iMessage/Sendblue).`
+const ACI_PROMPT =
+  "Add an agent to my app using instructions from https://novu.co/agents.md"
 
 function HeroActions() {
   const { isCopied, handleCopy } = useCopyToClipboard(3000)

--- a/src/components/pages/aci/hero-actions.tsx
+++ b/src/components/pages/aci/hero-actions.tsx
@@ -4,11 +4,9 @@ import NextLink from "next/link"
 import { ROUTE } from "@/constants/routes"
 import { Check, Copy } from "lucide-react"
 
+import { DEFAULT_CONNECT_PROMPT } from "@/lib/connect-prompt"
 import useCopyToClipboard from "@/hooks/use-copy-to-clipboard"
 import { Button } from "@/components/ui/button"
-
-const ACI_PROMPT =
-  "Add an agent to my app using instructions from https://novu.co/agents.md"
 
 function HeroActions() {
   const { isCopied, handleCopy } = useCopyToClipboard(3000)
@@ -54,7 +52,7 @@ function HeroActions() {
         <button
           type="button"
           className="inline-flex items-center gap-1 text-lagune-3 transition-colors hover:text-lagune-1 focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-lagune-3/50 focus-visible:outline-none"
-          onClick={() => handleCopy(ACI_PROMPT)}
+          onClick={() => handleCopy(DEFAULT_CONNECT_PROMPT)}
           disabled={isCopied}
           aria-label={isCopied ? "Prompt copied" : "Copy prompt to Claude"}
           data-click-location="aci_hero"

--- a/src/components/pages/channels/framework-connect.tsx
+++ b/src/components/pages/channels/framework-connect.tsx
@@ -68,7 +68,7 @@ function FrameworkConnect({ combo }: { combo: IChannelFrameworkCombo }) {
           <h3 className="text-base leading-none tracking-tighter text-white">
             Prompt for your coding agent
           </h3>
-          <p className="text-base leading-normal font-normal tracking-tighter whitespace-pre-line text-gray-70">
+          <p className="text-base leading-normal font-normal tracking-tighter text-gray-70">
             {fillTemplate(framework.promptTemplate, combo)}
           </p>
         </div>

--- a/src/components/pages/channels/framework-connect.tsx
+++ b/src/components/pages/channels/framework-connect.tsx
@@ -6,6 +6,7 @@ import {
   getFrameworkCommands,
 } from "@/data/pages/channel-frameworks"
 
+import { buildFrameworkChannelConnectPrompt } from "@/lib/connect-prompt"
 import CliCommand from "@/components/pages/home/features/cli-command"
 
 import FrameworkCommandPicker from "./framework-command-picker"
@@ -16,6 +17,11 @@ function FrameworkConnect({ combo }: { combo: IChannelFrameworkCombo }) {
   const { channel, framework } = combo
   const docsUrl = `${DOCS_URL}${framework.docsPath}`
   const allCommands = getFrameworkCommands(framework.slug)
+  const prompt = buildFrameworkChannelConnectPrompt({
+    frameworkName: framework.name,
+    channelName: channel.channelName,
+    connectPath: framework.connectPath,
+  })
 
   return (
     <section className="safe-paddings mt-18">
@@ -69,7 +75,7 @@ function FrameworkConnect({ combo }: { combo: IChannelFrameworkCombo }) {
             Prompt for your coding agent
           </h3>
           <p className="text-base leading-normal font-normal tracking-tighter text-gray-70">
-            {fillTemplate(framework.promptTemplate, combo)}
+            {prompt}
           </p>
         </div>
 

--- a/src/components/pages/connect/prompt-copy-line.tsx
+++ b/src/components/pages/connect/prompt-copy-line.tsx
@@ -5,13 +5,8 @@ import checkIcon from "@/svgs/icons/check.svg"
 
 import useCopyToClipboard from "@/hooks/use-copy-to-clipboard"
 
-const CONNECT_PROMPT_PLACEHOLDER = `Connect this project's AI agent to customer channels (Slack, Microsoft Teams, WhatsApp, Telegram, Email, or iMessage) with Novu Connect.
-
-Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci\`).
-
-Inspect the repo first. Ask me which channel to connect if it is not clear. Detect the framework/runtime from the project, or ask once. Then run one connect command per agents.md (bridge vs managed, keyless vs dashboard OAuth).
-
-Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md says that channel requires it (e.g. iMessage/Sendblue).`
+const CONNECT_PROMPT_PLACEHOLDER =
+  "Add an agent to my app using instructions from https://novu.co/agents.md"
 const COPY_ICON_SRC = copyIcon.src
 const CHECK_ICON_SRC = checkIcon.src
 

--- a/src/components/pages/connect/prompt-copy-line.tsx
+++ b/src/components/pages/connect/prompt-copy-line.tsx
@@ -3,10 +3,9 @@
 import copyIcon from "@/images/pages/connect/hero/copy.svg"
 import checkIcon from "@/svgs/icons/check.svg"
 
+import { DEFAULT_CONNECT_PROMPT } from "@/lib/connect-prompt"
 import useCopyToClipboard from "@/hooks/use-copy-to-clipboard"
 
-const CONNECT_PROMPT_PLACEHOLDER =
-  "Add an agent to my app using instructions from https://novu.co/agents.md"
 const COPY_ICON_SRC = copyIcon.src
 const CHECK_ICON_SRC = checkIcon.src
 
@@ -20,7 +19,7 @@ function ConnectPromptCopyLine() {
       <button
         type="button"
         className="mr-1 inline-flex items-center gap-1 rounded-sm text-lagune-3 transition-colors duration-200 hover:text-lagune-2 focus-visible:ring-2 focus-visible:ring-lagune-3/40 focus-visible:outline-none"
-        onClick={() => handleCopy(CONNECT_PROMPT_PLACEHOLDER)}
+        onClick={() => handleCopy(DEFAULT_CONNECT_PROMPT)}
         aria-label={isCopied ? "Prompt copied" : "Copy prompt to Claude"}
         data-click-location="connect_hero"
         data-click-text="copy_prompt"

--- a/src/components/pages/home/connect-stack.tsx
+++ b/src/components/pages/home/connect-stack.tsx
@@ -15,6 +15,7 @@ import telegramIcon from "@/svgs/pages/home/stack/telegram.svg"
 import whatsappIcon from "@/svgs/pages/home/stack/whatsapp.svg"
 import * as SelectPrimitive from "@radix-ui/react-select"
 
+import { buildFrameworkChannelConnectPrompt } from "@/lib/connect-prompt"
 import { cn } from "@/lib/utils"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
@@ -22,10 +23,10 @@ import CopyPromptButton from "./copy-prompt-button"
 
 export interface IStackOption {
   cliSlug?: string
+  connectPath?: "bridge" | "managed"
   icon?: StaticImageData | string
   label: string
   promptLabel?: string
-  promptTemplate?: string
   value: string
 }
 
@@ -77,45 +78,35 @@ const DEFAULT_FRAMEWORKS: IStackOption[] = [
     value: "ai-sdk",
     label: "Vercel AI SDK",
     icon: chatSdkIcon,
-    promptTemplate:
-      "Connect this project's Vercel AI SDK agent to [SELECTED_CHANNEL] with Novu using instructions from https://novu.co/agents.md",
   },
   {
     value: "langchain",
     label: "LangChain",
     icon: langChainIcon,
-    promptTemplate:
-      "Connect this project's LangChain agent to [SELECTED_CHANNEL] with Novu using instructions from https://novu.co/agents.md",
   },
   {
     value: "custom-code",
     label: "Custom code",
     icon: customCodeIcon,
-    promptTemplate:
-      "Connect this project's custom code agent to [SELECTED_CHANNEL] with Novu using instructions from https://novu.co/agents.md",
   },
   {
     value: "chat-sdk",
     label: "Chat SDK",
     icon: chatSdkIcon,
-    promptTemplate:
-      "Connect this project's Chat SDK agent to [SELECTED_CHANNEL] with Novu using instructions from https://novu.co/agents.md",
   },
   {
     value: "claude-managed-agent",
     label: "Claude Managed Agent",
     icon: claudeIcon,
     cliSlug: "claude",
-    promptTemplate:
-      "Connect a Claude Managed Agent to [SELECTED_CHANNEL] with Novu using instructions from https://novu.co/agents.md",
+    connectPath: "managed",
   },
   {
     value: "aws-claude-managed-agent",
     label: "AWS Claude Managed Agent",
     icon: awsIcon,
     cliSlug: "claude-aws",
-    promptTemplate:
-      "Connect a Claude Managed Agent on AWS to [SELECTED_CHANNEL] with Novu using instructions from https://novu.co/agents.md",
+    connectPath: "managed",
   },
 ]
 
@@ -259,12 +250,11 @@ function ConnectStack({
   const channelLabel = channel.promptLabel ?? channel.label
   const channelSlug = channel.cliSlug ?? channel.value
   const command = `npx novu connect --channel ${channelSlug} --runtime ${framework.cliSlug ?? framework.value}`
-  const defaultPrompt = `Connect this project's ${frameworkLabel} agent to ${channelLabel} with Novu using instructions from https://novu.co/agents.md`
-  const prompt = framework.promptTemplate
-    ? framework.promptTemplate
-        .replaceAll("[SELECTED_CHANNEL]", channelLabel)
-        .replaceAll("[CHANNEL_SLUG]", channelSlug)
-    : defaultPrompt
+  const prompt = buildFrameworkChannelConnectPrompt({
+    frameworkName: frameworkLabel,
+    channelName: channelLabel,
+    connectPath: framework.connectPath,
+  })
 
   return (
     <section

--- a/src/components/pages/home/connect-stack.tsx
+++ b/src/components/pages/home/connect-stack.tsx
@@ -77,109 +77,45 @@ const DEFAULT_FRAMEWORKS: IStackOption[] = [
     value: "ai-sdk",
     label: "Vercel AI SDK",
     icon: chatSdkIcon,
-    promptTemplate: `Connect this project's Vercel AI SDK agent to [SELECTED_CHANNEL] with Novu Connect.
-
-Follow https://novu.co/agents.md end to end (custom code bridge path). Default to the non-interactive CLI (\`--ci\`).
-
-Inspect the repo (agent entry point, how Vercel AI SDK is used, package manager, env conventions). Do not modify anything yet.
-
-Prefer a connect command shaped like:
-
-npx novu@latest connect --ci --runtime ai-sdk --channel [CHANNEL_SLUG]
-
-(Omit --keyless: bridge uses dashboard OAuth. Adjust flags only as agents.md allows for this runtime.)
-
-Prefer the secure setup links the CLI prints. After connect, finish any bridge wiring from the requirements file agents.md describes. Do not invent setup steps or ask for secrets in chat unless agents.md requires it.`,
+    promptTemplate:
+      "Connect this project's Vercel AI SDK agent to [SELECTED_CHANNEL] with Novu using instructions from https://novu.co/agents.md",
   },
   {
     value: "langchain",
     label: "LangChain",
     icon: langChainIcon,
-    promptTemplate: `Connect this project's LangChain agent to [SELECTED_CHANNEL] with Novu Connect.
-
-Follow https://novu.co/agents.md end to end (custom code bridge path). Default to the non-interactive CLI (\`--ci\`).
-
-Inspect the repo (agent entry point, how LangChain is used, package manager, env conventions). Do not modify anything yet.
-
-Prefer a connect command shaped like:
-
-npx novu@latest connect --ci --runtime langchain --channel [CHANNEL_SLUG]
-
-(Omit --keyless: bridge uses dashboard OAuth. Adjust flags only as agents.md allows for this runtime.)
-
-Prefer the secure setup links the CLI prints. After connect, finish any bridge wiring from the requirements file agents.md describes. Do not invent setup steps or ask for secrets in chat unless agents.md requires it.`,
+    promptTemplate:
+      "Connect this project's LangChain agent to [SELECTED_CHANNEL] with Novu using instructions from https://novu.co/agents.md",
   },
   {
     value: "custom-code",
     label: "Custom code",
     icon: customCodeIcon,
-    promptTemplate: `Connect this project's custom code agent to [SELECTED_CHANNEL] with Novu Connect.
-
-Follow https://novu.co/agents.md end to end (custom code bridge path). Default to the non-interactive CLI (\`--ci\`).
-
-Inspect the repo (agent entry point, how custom code is used, package manager, env conventions). Do not modify anything yet.
-
-Prefer a connect command shaped like:
-
-npx novu@latest connect --ci --runtime custom-code --channel [CHANNEL_SLUG]
-
-(Omit --keyless: bridge uses dashboard OAuth. Adjust flags only as agents.md allows for this runtime.)
-
-Prefer the secure setup links the CLI prints. After connect, finish any bridge wiring from the requirements file agents.md describes. Do not invent setup steps or ask for secrets in chat unless agents.md requires it.`,
+    promptTemplate:
+      "Connect this project's custom code agent to [SELECTED_CHANNEL] with Novu using instructions from https://novu.co/agents.md",
   },
   {
     value: "chat-sdk",
     label: "Chat SDK",
     icon: chatSdkIcon,
-    promptTemplate: `Connect this project's Chat SDK agent to [SELECTED_CHANNEL] with Novu Connect.
-
-Follow https://novu.co/agents.md end to end (custom code bridge path). Default to the non-interactive CLI (\`--ci\`).
-
-Inspect the repo (agent entry point, how Chat SDK is used, package manager, env conventions). Do not modify anything yet.
-
-Prefer a connect command shaped like:
-
-npx novu@latest connect --ci --runtime chat-sdk --channel [CHANNEL_SLUG]
-
-(Omit --keyless: bridge uses dashboard OAuth. Adjust flags only as agents.md allows for this runtime.)
-
-Prefer the secure setup links the CLI prints. After connect, finish any bridge wiring from the requirements file agents.md describes. Do not invent setup steps or ask for secrets in chat unless agents.md requires it.`,
+    promptTemplate:
+      "Connect this project's Chat SDK agent to [SELECTED_CHANNEL] with Novu using instructions from https://novu.co/agents.md",
   },
   {
     value: "claude-managed-agent",
     label: "Claude Managed Agent",
     icon: claudeIcon,
     cliSlug: "claude",
-    promptTemplate: `Connect a Claude Managed Agent to [SELECTED_CHANNEL] with Novu Connect.
-
-Follow https://novu.co/agents.md end to end (managed agent path). Default to the non-interactive CLI (\`--ci\`).
-
-Infer a short agent description from the project, confirm it with me once, then prefer a connect command shaped like:
-
-export NOVU_AGENT_DESCRIPTION='…'
-npx novu@latest connect "$NOVU_AGENT_DESCRIPTION" --ci --keyless --channel [CHANNEL_SLUG] --runtime claude
-
-(Omit --keyless if I am already signed in to the Novu dashboard. Never combine --keyless with --channel teams; follow agents.md.)
-
-Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md requires it.`,
+    promptTemplate:
+      "Connect a Claude Managed Agent to [SELECTED_CHANNEL] with Novu using instructions from https://novu.co/agents.md",
   },
   {
     value: "aws-claude-managed-agent",
     label: "AWS Claude Managed Agent",
     icon: awsIcon,
     cliSlug: "claude-aws",
-    promptTemplate: `Connect a Claude Managed Agent on AWS to [SELECTED_CHANNEL] with Novu Connect.
-
-Follow https://novu.co/agents.md end to end (managed agent path). Default to the non-interactive CLI (\`--ci\`).
-
-Infer a short agent description from the project, confirm it with me once, then prefer a connect command shaped like:
-
-export NOVU_AGENT_DESCRIPTION='…'
-npx novu@latest connect "$NOVU_AGENT_DESCRIPTION" --ci --keyless --channel [CHANNEL_SLUG] --runtime claude-aws
-
-(Omit --keyless if I am already signed in to the Novu dashboard. Never combine --keyless with --channel teams; follow agents.md.)
-
-Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md requires it.`,
+    promptTemplate:
+      "Connect a Claude Managed Agent on AWS to [SELECTED_CHANNEL] with Novu using instructions from https://novu.co/agents.md",
   },
 ]
 
@@ -323,13 +259,7 @@ function ConnectStack({
   const channelLabel = channel.promptLabel ?? channel.label
   const channelSlug = channel.cliSlug ?? channel.value
   const command = `npx novu connect --channel ${channelSlug} --runtime ${framework.cliSlug ?? framework.value}`
-  const defaultPrompt = `Connect this project's AI agent to ${channelLabel} with Novu Connect.
-
-Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci --channel ${channelSlug}\`).
-
-Inspect the repo. Detect the runtime from the project (AI SDK / LangChain / etc.), or ask once. Then run one connect command for ${channelLabel} per agents.md.
-
-Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md requires it for this channel.`
+  const defaultPrompt = `Connect this project's ${frameworkLabel} agent to ${channelLabel} with Novu using instructions from https://novu.co/agents.md`
   const prompt = framework.promptTemplate
     ? framework.promptTemplate
         .replaceAll("[SELECTED_CHANNEL]", channelLabel)

--- a/src/components/pages/home/cta.tsx
+++ b/src/components/pages/home/cta.tsx
@@ -16,13 +16,8 @@ interface ICTAProps {
   title: string
 }
 
-const DEFAULT_PROMPT = `Connect this project's AI agent to customer channels (Slack, Microsoft Teams, WhatsApp, Telegram, Email, or iMessage) with Novu Connect.
-
-Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci\`).
-
-Inspect the repo first. Ask me which channel to connect if it is not clear. Detect the framework/runtime from the project, or ask once. Then run one connect command per agents.md (bridge vs managed, keyless vs dashboard OAuth).
-
-Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md says that channel requires it (e.g. iMessage/Sendblue).`
+const DEFAULT_PROMPT =
+  "Connect my app or AI agent to customers with Novu using instructions from https://novu.co/agents.md"
 
 function Cta({
   actions,

--- a/src/components/pages/home/cta.tsx
+++ b/src/components/pages/home/cta.tsx
@@ -1,4 +1,5 @@
 import type { TSectionAction } from "@/types/common"
+import { DEFAULT_CONNECT_PROMPT } from "@/lib/connect-prompt"
 import { cn } from "@/lib/utils"
 import ActionGroup from "@/components/ui/action-group"
 import { CopyCommand } from "@/components/ui/copy-command"
@@ -16,16 +17,13 @@ interface ICTAProps {
   title: string
 }
 
-const DEFAULT_PROMPT =
-  "Connect my app or AI agent to customers with Novu using instructions from https://novu.co/agents.md"
-
 function Cta({
   actions,
   className,
   title,
   description,
   command = "npx novu connect",
-  prompt = DEFAULT_PROMPT,
+  prompt = DEFAULT_CONNECT_PROMPT,
 }: ICTAProps) {
   return (
     <section

--- a/src/components/pages/home/hero.tsx
+++ b/src/components/pages/home/hero.tsx
@@ -16,6 +16,7 @@ import teamsIcon from "@/svgs/pages/connect/channels/teams.png"
 import telegramIcon from "@/svgs/pages/connect/channels/telegram.svg"
 import whatsappIcon from "@/svgs/pages/connect/channels/whatsapp.svg"
 
+import { DEFAULT_CONNECT_PROMPT } from "@/lib/connect-prompt"
 import { cn } from "@/lib/utils"
 import { CopyCommand } from "@/components/ui/copy-command"
 import Logos from "@/components/ui/logos"
@@ -28,9 +29,6 @@ import {
 } from "./channel-navigation"
 import CopyPromptButton from "./copy-prompt-button"
 import HeroGlobe from "./hero-globe"
-
-const DEFAULT_PROMPT =
-  "Connect my AI agent to customers across their preferred channels with Novu using instructions from https://novu.co/agents.md"
 
 const CHANNEL_HOVER_STYLES = {
   telegram: {
@@ -218,7 +216,7 @@ function Hero({
   title,
   description,
   command = "npx novu connect",
-  prompt = DEFAULT_PROMPT,
+  prompt = DEFAULT_CONNECT_PROMPT,
   className,
 }: IHeroProps) {
   return (

--- a/src/components/pages/home/hero.tsx
+++ b/src/components/pages/home/hero.tsx
@@ -29,13 +29,8 @@ import {
 import CopyPromptButton from "./copy-prompt-button"
 import HeroGlobe from "./hero-globe"
 
-const DEFAULT_PROMPT = `Connect this project's AI agent to customer channels (Slack, Microsoft Teams, WhatsApp, Telegram, Email, or iMessage) with Novu Connect.
-
-Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci\`).
-
-Inspect the repo first. Ask me which channel to connect if it is not clear. Detect the framework/runtime from the project, or ask once. Then run one connect command per agents.md (bridge vs managed, keyless vs dashboard OAuth).
-
-Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md says that channel requires it (e.g. iMessage/Sendblue).`
+const DEFAULT_PROMPT =
+  "Connect my AI agent to customers across their preferred channels with Novu using instructions from https://novu.co/agents.md"
 
 const CHANNEL_HOVER_STYLES = {
   telegram: {

--- a/src/components/pages/home/novu-connect.tsx
+++ b/src/components/pages/home/novu-connect.tsx
@@ -2,6 +2,7 @@ import Image, { type StaticImageData } from "next/image"
 import NextLink from "next/link"
 import { ROUTE } from "@/constants/routes"
 
+import { DEFAULT_CONNECT_PROMPT } from "@/lib/connect-prompt"
 import { cn } from "@/lib/utils"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -33,16 +34,13 @@ export interface INovuConnectProps {
   title: string
 }
 
-const DEFAULT_PROMPT =
-  "Connect my AI agent to customers with Novu Connect using instructions from https://novu.co/agents.md"
-
 function NovuConnect({
   className,
   label,
   title,
   description,
   items,
-  prompt = DEFAULT_PROMPT,
+  prompt = DEFAULT_CONNECT_PROMPT,
 }: INovuConnectProps) {
   if (!items || items.length === 0) {
     return null

--- a/src/components/pages/home/novu-connect.tsx
+++ b/src/components/pages/home/novu-connect.tsx
@@ -33,13 +33,8 @@ export interface INovuConnectProps {
   title: string
 }
 
-const DEFAULT_PROMPT = `Connect this project's AI agent to customer channels (Slack, Microsoft Teams, WhatsApp, Telegram, Email, or iMessage) with Novu Connect.
-
-Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci\`).
-
-Inspect the repo first. Ask me which channel to connect if it is not clear. Detect the framework/runtime from the project, or ask once. Then run one connect command per agents.md (bridge vs managed, keyless vs dashboard OAuth).
-
-Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md says that channel requires it (e.g. iMessage/Sendblue).`
+const DEFAULT_PROMPT =
+  "Connect my AI agent to customers with Novu Connect using instructions from https://novu.co/agents.md"
 
 function NovuConnect({
   className,

--- a/src/data/pages/channels/email.tsx
+++ b/src/data/pages/channels/email.tsx
@@ -1,6 +1,7 @@
 import emailIcon from "@/svgs/pages/connect/channels/email.svg"
 
 import type { IChannelPageData } from "@/types/channel"
+import { buildChannelConnectPrompt } from "@/lib/connect-prompt"
 
 export const emailChannelData: IChannelPageData = {
   slug: "email",
@@ -57,8 +58,7 @@ export const emailChannelData: IChannelPageData = {
     "High-deliverability routing",
     "Secure action links for approvals",
   ],
-  prompt:
-    "Connect my AI agent to Email with Novu using instructions from https://novu.co/agents.md",
+  prompt: buildChannelConnectPrompt("Email"),
   onRamp: {
     type: "keyless",
     note: "Email works in the keyless quickstart. Run npx novu connect --channel email to get a managed agent sending email, no account needed for the first few replies.",

--- a/src/data/pages/channels/email.tsx
+++ b/src/data/pages/channels/email.tsx
@@ -57,13 +57,8 @@ export const emailChannelData: IChannelPageData = {
     "High-deliverability routing",
     "Secure action links for approvals",
   ],
-  prompt: `Connect this project's AI agent to Email with Novu Connect.
-
-Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci --channel email\`).
-
-Inspect the repo. Detect the runtime from the project (AI SDK / LangChain / etc.), or ask once. Then run one connect command for Email per agents.md.
-
-Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md requires it for this channel.`,
+  prompt:
+    "Connect my AI agent to Email with Novu using instructions from https://novu.co/agents.md",
   onRamp: {
     type: "keyless",
     note: "Email works in the keyless quickstart. Run npx novu connect --channel email to get a managed agent sending email, no account needed for the first few replies.",

--- a/src/data/pages/channels/imessage.tsx
+++ b/src/data/pages/channels/imessage.tsx
@@ -1,6 +1,7 @@
 import imessageIcon from "@/svgs/pages/connect/channels/imessage.svg"
 
 import type { IChannelPageData } from "@/types/channel"
+import { buildChannelConnectPrompt } from "@/lib/connect-prompt"
 
 export const imessageChannelData: IChannelPageData = {
   slug: "imessage",
@@ -57,8 +58,7 @@ export const imessageChannelData: IChannelPageData = {
     "Live typing indicators",
     "Reply-based action and MCP approvals",
   ],
-  prompt:
-    "Connect my AI agent to iMessage with Novu using instructions from https://novu.co/agents.md",
+  prompt: buildChannelConnectPrompt("iMessage"),
   onRamp: {
     type: "oauth",
     note: "iMessage connects through Sendblue. Run npx novu connect --channel sendblue, enter your Sendblue credentials in the CLI, and reply to the test iMessage to go live.",

--- a/src/data/pages/channels/imessage.tsx
+++ b/src/data/pages/channels/imessage.tsx
@@ -58,7 +58,7 @@ export const imessageChannelData: IChannelPageData = {
     "Reply-based action and MCP approvals",
   ],
   prompt:
-    "Connect this project to iMessage with Novu Connect (Sendblue). Inspect the repo for the existing agent and framework, then have me run npx novu connect --channel sendblue from the project root, appending the matching --runtime if you detect one. I will enter Sendblue credentials in the CLI and reply to the test iMessage. Prefer the CLI prompts over chat for secrets. Do not invent setup steps. Stop after giving me the command.",
+    "Connect my AI agent to iMessage with Novu using instructions from https://novu.co/agents.md",
   onRamp: {
     type: "oauth",
     note: "iMessage connects through Sendblue. Run npx novu connect --channel sendblue, enter your Sendblue credentials in the CLI, and reply to the test iMessage to go live.",

--- a/src/data/pages/channels/microsoft-teams.tsx
+++ b/src/data/pages/channels/microsoft-teams.tsx
@@ -1,6 +1,7 @@
 import teamsIcon from "@/svgs/pages/connect/channels/teams.png"
 
 import type { IChannelPageData } from "@/types/channel"
+import { buildChannelConnectPrompt } from "@/lib/connect-prompt"
 
 export const microsoftTeamsChannelData: IChannelPageData = {
   slug: "microsoft-teams",
@@ -57,8 +58,7 @@ export const microsoftTeamsChannelData: IChannelPageData = {
     "Reliable team notifications",
     "Native Adaptive Cards and approval prompts",
   ],
-  prompt:
-    "Connect my AI agent to Microsoft Teams with Novu using instructions from https://novu.co/agents.md",
+  prompt: buildChannelConnectPrompt("Microsoft Teams"),
   onRamp: {
     type: "oauth",
     note: "Microsoft Teams connects from the Novu dashboard. Authenticate your workspace once, and Novu Connect manages delivery, identity, and two-way routing after that.",

--- a/src/data/pages/channels/microsoft-teams.tsx
+++ b/src/data/pages/channels/microsoft-teams.tsx
@@ -57,13 +57,8 @@ export const microsoftTeamsChannelData: IChannelPageData = {
     "Reliable team notifications",
     "Native Adaptive Cards and approval prompts",
   ],
-  prompt: `Connect this project's AI agent to Microsoft Teams with Novu Connect.
-
-Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci --channel teams\`). Note: Teams cannot use keyless mode; follow agents.md for dashboard OAuth / dashboard redirect rules.
-
-Inspect the repo. Detect the runtime from the project (AI SDK / LangChain / etc.), or ask once. Then run one connect command for Microsoft Teams per agents.md.
-
-Prefer the secure setup links or dashboard handoffs the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md requires it for this channel.`,
+  prompt:
+    "Connect my AI agent to Microsoft Teams with Novu using instructions from https://novu.co/agents.md",
   onRamp: {
     type: "oauth",
     note: "Microsoft Teams connects from the Novu dashboard. Authenticate your workspace once, and Novu Connect manages delivery, identity, and two-way routing after that.",

--- a/src/data/pages/channels/slack.tsx
+++ b/src/data/pages/channels/slack.tsx
@@ -1,6 +1,7 @@
 import slackIcon from "@/svgs/pages/connect/channels/slack.svg"
 
 import type { IChannelPageData } from "@/types/channel"
+import { buildChannelConnectPrompt } from "@/lib/connect-prompt"
 
 export const slackChannelData: IChannelPageData = {
   slug: "slack",
@@ -58,8 +59,7 @@ export const slackChannelData: IChannelPageData = {
     "Reliable delivery with retries",
     "Native Block Kit messages and tool-approval prompts",
   ],
-  prompt:
-    "Connect my AI agent to Slack with Novu using instructions from https://novu.co/agents.md",
+  prompt: buildChannelConnectPrompt("Slack"),
   onRamp: {
     type: "keyless",
     note: "Slack works in the keyless quickstart. Run npx novu connect --channel slack and you get a managed agent on Slack, no account needed for the first few replies.",

--- a/src/data/pages/channels/slack.tsx
+++ b/src/data/pages/channels/slack.tsx
@@ -58,13 +58,8 @@ export const slackChannelData: IChannelPageData = {
     "Reliable delivery with retries",
     "Native Block Kit messages and tool-approval prompts",
   ],
-  prompt: `Connect this project's AI agent to Slack with Novu Connect.
-
-Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci --channel slack\`).
-
-Inspect the repo. Detect the runtime from the project (AI SDK / LangChain / etc.), or ask once. Then run one connect command for Slack per agents.md.
-
-Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md requires it for this channel.`,
+  prompt:
+    "Connect my AI agent to Slack with Novu using instructions from https://novu.co/agents.md",
   onRamp: {
     type: "keyless",
     note: "Slack works in the keyless quickstart. Run npx novu connect --channel slack and you get a managed agent on Slack, no account needed for the first few replies.",

--- a/src/data/pages/channels/telegram.tsx
+++ b/src/data/pages/channels/telegram.tsx
@@ -57,13 +57,8 @@ export const telegramChannelData: IChannelPageData = {
     "Inline keyboards for quick actions",
     "Replies routed to the right context",
   ],
-  prompt: `Connect this project's AI agent to Telegram with Novu Connect.
-
-Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci --channel telegram\`).
-
-Inspect the repo. Detect the runtime from the project (AI SDK / LangChain / etc.), or ask once. Then run one connect command for Telegram per agents.md.
-
-Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md requires it for this channel.`,
+  prompt:
+    "Connect my AI agent to Telegram with Novu using instructions from https://novu.co/agents.md",
   onRamp: {
     type: "keyless",
     note: "Telegram works in the keyless quickstart. Run npx novu connect --channel telegram to get a managed agent on Telegram, no account needed for the first few replies.",

--- a/src/data/pages/channels/telegram.tsx
+++ b/src/data/pages/channels/telegram.tsx
@@ -1,6 +1,7 @@
 import telegramIcon from "@/svgs/pages/connect/channels/telegram.svg"
 
 import type { IChannelPageData } from "@/types/channel"
+import { buildChannelConnectPrompt } from "@/lib/connect-prompt"
 
 export const telegramChannelData: IChannelPageData = {
   slug: "telegram",
@@ -57,8 +58,7 @@ export const telegramChannelData: IChannelPageData = {
     "Inline keyboards for quick actions",
     "Replies routed to the right context",
   ],
-  prompt:
-    "Connect my AI agent to Telegram with Novu using instructions from https://novu.co/agents.md",
+  prompt: buildChannelConnectPrompt("Telegram"),
   onRamp: {
     type: "keyless",
     note: "Telegram works in the keyless quickstart. Run npx novu connect --channel telegram to get a managed agent on Telegram, no account needed for the first few replies.",

--- a/src/data/pages/channels/whatsapp.tsx
+++ b/src/data/pages/channels/whatsapp.tsx
@@ -1,6 +1,7 @@
 import whatsappIcon from "@/svgs/pages/connect/channels/whatsapp.svg"
 
 import type { IChannelPageData } from "@/types/channel"
+import { buildChannelConnectPrompt } from "@/lib/connect-prompt"
 
 export const whatsappChannelData: IChannelPageData = {
   slug: "whatsapp",
@@ -62,8 +63,7 @@ export const whatsappChannelData: IChannelPageData = {
     "Attachments and delivery receipts",
     "Embedded WhatsApp Business signup (official Meta Business Partner)",
   ],
-  prompt:
-    "Connect my AI agent to WhatsApp with Novu using instructions from https://novu.co/agents.md",
+  prompt: buildChannelConnectPrompt("WhatsApp"),
   onRamp: {
     type: "oauth",
     note: "WhatsApp connects from the Novu dashboard with embedded signup: log in with your business account, pick your WhatsApp number, and you are working in about 5 minutes.",

--- a/src/data/pages/channels/whatsapp.tsx
+++ b/src/data/pages/channels/whatsapp.tsx
@@ -62,13 +62,8 @@ export const whatsappChannelData: IChannelPageData = {
     "Attachments and delivery receipts",
     "Embedded WhatsApp Business signup (official Meta Business Partner)",
   ],
-  prompt: `Connect this project's AI agent to WhatsApp with Novu Connect.
-
-Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci --channel whatsapp\`).
-
-Inspect the repo. Detect the runtime from the project (AI SDK / LangChain / etc.), or ask once. Then run one connect command for WhatsApp per agents.md.
-
-Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md requires it for this channel.`,
+  prompt:
+    "Connect my AI agent to WhatsApp with Novu using instructions from https://novu.co/agents.md",
   onRamp: {
     type: "oauth",
     note: "WhatsApp connects from the Novu dashboard with embedded signup: log in with your business account, pick your WhatsApp number, and you are working in about 5 minutes.",

--- a/src/data/pages/frameworks/ai-sdk.tsx
+++ b/src/data/pages/frameworks/ai-sdk.tsx
@@ -38,8 +38,6 @@ export const aiSdkFrameworkData: IAgentFrameworkData = {
       body: "Sign in to keep the agent live, then run your dev server. Your AI SDK agent now holds a two-way conversation in {channelName}, and the same agent can reach every other channel from one thread.",
     },
   ],
-  promptTemplate:
-    "Connect this project's Vercel AI SDK agent to {channelName} with Novu using instructions from https://novu.co/agents.md",
   faq: [
     {
       question: "Do I have to rewrite my AI SDK agent to add {channelName}?",

--- a/src/data/pages/frameworks/ai-sdk.tsx
+++ b/src/data/pages/frameworks/ai-sdk.tsx
@@ -38,19 +38,8 @@ export const aiSdkFrameworkData: IAgentFrameworkData = {
       body: "Sign in to keep the agent live, then run your dev server. Your AI SDK agent now holds a two-way conversation in {channelName}, and the same agent can reach every other channel from one thread.",
     },
   ],
-  promptTemplate: `Connect this project's Vercel AI SDK agent to {channelName} with Novu Connect.
-
-Follow https://novu.co/agents.md end to end (custom code bridge path). Default to the non-interactive CLI (\`--ci\`).
-
-Inspect the repo (agent entry point, how Vercel AI SDK is used, package manager, env conventions). Do not modify anything yet.
-
-Prefer a connect command shaped like:
-
-npx novu@latest connect --ci --runtime ai-sdk --channel {cliSlug}
-
-(Omit --keyless: bridge uses dashboard OAuth. Adjust flags only as agents.md allows for this runtime.)
-
-Prefer the secure setup links the CLI prints. After connect, finish any bridge wiring from the requirements file agents.md describes. Do not invent setup steps or ask for secrets in chat unless agents.md requires it.`,
+  promptTemplate:
+    "Connect this project's Vercel AI SDK agent to {channelName} with Novu using instructions from https://novu.co/agents.md",
   faq: [
     {
       question: "Do I have to rewrite my AI SDK agent to add {channelName}?",

--- a/src/data/pages/frameworks/chat-sdk.tsx
+++ b/src/data/pages/frameworks/chat-sdk.tsx
@@ -38,19 +38,8 @@ export const chatSdkFrameworkData: IAgentFrameworkData = {
       body: "Sign in to keep the agent live, then run your dev server. Your Chat SDK agent now holds a two-way conversation in {channelName}, and the same agent can reach every other channel from one thread.",
     },
   ],
-  promptTemplate: `Connect this project's Chat SDK agent to {channelName} with Novu Connect.
-
-Follow https://novu.co/agents.md end to end (custom code bridge path). Default to the non-interactive CLI (\`--ci\`).
-
-Inspect the repo (agent entry point, how Chat SDK is used, package manager, env conventions). Do not modify anything yet.
-
-Prefer a connect command shaped like:
-
-npx novu@latest connect --ci --runtime chat-sdk --channel {cliSlug}
-
-(Omit --keyless: bridge uses dashboard OAuth. Adjust flags only as agents.md allows for this runtime.)
-
-Prefer the secure setup links the CLI prints. After connect, finish any bridge wiring from the requirements file agents.md describes. Do not invent setup steps or ask for secrets in chat unless agents.md requires it.`,
+  promptTemplate:
+    "Connect this project's Chat SDK agent to {channelName} with Novu using instructions from https://novu.co/agents.md",
   faq: [
     {
       question: "Do I have to rewrite my Chat SDK app to add {channelName}?",

--- a/src/data/pages/frameworks/chat-sdk.tsx
+++ b/src/data/pages/frameworks/chat-sdk.tsx
@@ -38,8 +38,6 @@ export const chatSdkFrameworkData: IAgentFrameworkData = {
       body: "Sign in to keep the agent live, then run your dev server. Your Chat SDK agent now holds a two-way conversation in {channelName}, and the same agent can reach every other channel from one thread.",
     },
   ],
-  promptTemplate:
-    "Connect this project's Chat SDK agent to {channelName} with Novu using instructions from https://novu.co/agents.md",
   faq: [
     {
       question: "Do I have to rewrite my Chat SDK app to add {channelName}?",

--- a/src/data/pages/frameworks/claude-aws.tsx
+++ b/src/data/pages/frameworks/claude-aws.tsx
@@ -38,8 +38,6 @@ export const claudeAwsFrameworkData: IAgentFrameworkData = {
       body: "The guided flow connects {channelName}. Your agent now holds a two-way conversation there, and the same agent can reach every other channel from one thread.",
     },
   ],
-  promptTemplate:
-    "Connect a Claude Managed Agent on AWS to {channelName} with Novu using instructions from https://novu.co/agents.md",
   faq: [
     {
       question: "How is this different from the standard Claude Managed Agent?",

--- a/src/data/pages/frameworks/claude-aws.tsx
+++ b/src/data/pages/frameworks/claude-aws.tsx
@@ -38,18 +38,8 @@ export const claudeAwsFrameworkData: IAgentFrameworkData = {
       body: "The guided flow connects {channelName}. Your agent now holds a two-way conversation there, and the same agent can reach every other channel from one thread.",
     },
   ],
-  promptTemplate: `Connect a Claude Managed Agent on AWS to {channelName} with Novu Connect.
-
-Follow https://novu.co/agents.md end to end (managed agent path). Default to the non-interactive CLI (\`--ci\`).
-
-Infer a short agent description from the project, confirm it with me once, then prefer a connect command shaped like:
-
-export NOVU_AGENT_DESCRIPTION='…'
-npx novu@latest connect "$NOVU_AGENT_DESCRIPTION" --ci --keyless --channel {cliSlug} --runtime claude-aws
-
-(Omit --keyless if I am already signed in to the Novu dashboard. Never combine --keyless with --channel teams; follow agents.md.)
-
-Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md requires it.`,
+  promptTemplate:
+    "Connect a Claude Managed Agent on AWS to {channelName} with Novu using instructions from https://novu.co/agents.md",
   faq: [
     {
       question: "How is this different from the standard Claude Managed Agent?",

--- a/src/data/pages/frameworks/claude.tsx
+++ b/src/data/pages/frameworks/claude.tsx
@@ -38,8 +38,6 @@ export const claudeFrameworkData: IAgentFrameworkData = {
       body: "The guided flow connects {channelName}. Your agent now holds a two-way conversation there, and the same agent can reach every other channel from one thread.",
     },
   ],
-  promptTemplate:
-    "Connect a Claude Managed Agent to {channelName} with Novu using instructions from https://novu.co/agents.md",
   faq: [
     {
       question:

--- a/src/data/pages/frameworks/claude.tsx
+++ b/src/data/pages/frameworks/claude.tsx
@@ -38,18 +38,8 @@ export const claudeFrameworkData: IAgentFrameworkData = {
       body: "The guided flow connects {channelName}. Your agent now holds a two-way conversation there, and the same agent can reach every other channel from one thread.",
     },
   ],
-  promptTemplate: `Connect a Claude Managed Agent to {channelName} with Novu Connect.
-
-Follow https://novu.co/agents.md end to end (managed agent path). Default to the non-interactive CLI (\`--ci\`).
-
-Infer a short agent description from the project, confirm it with me once, then prefer a connect command shaped like:
-
-export NOVU_AGENT_DESCRIPTION='…'
-npx novu@latest connect "$NOVU_AGENT_DESCRIPTION" --ci --keyless --channel {cliSlug} --runtime claude
-
-(Omit --keyless if I am already signed in to the Novu dashboard. Never combine --keyless with --channel teams; follow agents.md.)
-
-Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md requires it.`,
+  promptTemplate:
+    "Connect a Claude Managed Agent to {channelName} with Novu using instructions from https://novu.co/agents.md",
   faq: [
     {
       question:

--- a/src/data/pages/frameworks/custom-code.tsx
+++ b/src/data/pages/frameworks/custom-code.tsx
@@ -38,8 +38,6 @@ export const customCodeFrameworkData: IAgentFrameworkData = {
       body: "Sign in to keep the agent live, then run your dev server. Your agent now holds a two-way conversation in {channelName}, and the same agent can reach every other channel from one thread.",
     },
   ],
-  promptTemplate:
-    "Connect this project's custom code agent to {channelName} with Novu using instructions from https://novu.co/agents.md",
   faq: [
     {
       question:

--- a/src/data/pages/frameworks/custom-code.tsx
+++ b/src/data/pages/frameworks/custom-code.tsx
@@ -38,19 +38,8 @@ export const customCodeFrameworkData: IAgentFrameworkData = {
       body: "Sign in to keep the agent live, then run your dev server. Your agent now holds a two-way conversation in {channelName}, and the same agent can reach every other channel from one thread.",
     },
   ],
-  promptTemplate: `Connect this project's custom code agent to {channelName} with Novu Connect.
-
-Follow https://novu.co/agents.md end to end (custom code bridge path). Default to the non-interactive CLI (\`--ci\`).
-
-Inspect the repo (agent entry point, how custom code is used, package manager, env conventions). Do not modify anything yet.
-
-Prefer a connect command shaped like:
-
-npx novu@latest connect --ci --runtime custom-code --channel {cliSlug}
-
-(Omit --keyless: bridge uses dashboard OAuth. Adjust flags only as agents.md allows for this runtime.)
-
-Prefer the secure setup links the CLI prints. After connect, finish any bridge wiring from the requirements file agents.md describes. Do not invent setup steps or ask for secrets in chat unless agents.md requires it.`,
+  promptTemplate:
+    "Connect this project's custom code agent to {channelName} with Novu using instructions from https://novu.co/agents.md",
   faq: [
     {
       question:

--- a/src/data/pages/frameworks/langchain.tsx
+++ b/src/data/pages/frameworks/langchain.tsx
@@ -38,8 +38,6 @@ export const langchainFrameworkData: IAgentFrameworkData = {
       body: "Sign in to keep the agent live, then run your dev server. Your LangChain agent now holds a two-way conversation in {channelName}, and the same agent can reach every other channel from one thread.",
     },
   ],
-  promptTemplate:
-    "Connect this project's LangChain agent to {channelName} with Novu using instructions from https://novu.co/agents.md",
   faq: [
     {
       question: "Do I have to rewrite my LangChain agent to add {channelName}?",

--- a/src/data/pages/frameworks/langchain.tsx
+++ b/src/data/pages/frameworks/langchain.tsx
@@ -38,19 +38,8 @@ export const langchainFrameworkData: IAgentFrameworkData = {
       body: "Sign in to keep the agent live, then run your dev server. Your LangChain agent now holds a two-way conversation in {channelName}, and the same agent can reach every other channel from one thread.",
     },
   ],
-  promptTemplate: `Connect this project's LangChain agent to {channelName} with Novu Connect.
-
-Follow https://novu.co/agents.md end to end (custom code bridge path). Default to the non-interactive CLI (\`--ci\`).
-
-Inspect the repo (agent entry point, how LangChain is used, package manager, env conventions). Do not modify anything yet.
-
-Prefer a connect command shaped like:
-
-npx novu@latest connect --ci --runtime langchain --channel {cliSlug}
-
-(Omit --keyless: bridge uses dashboard OAuth. Adjust flags only as agents.md allows for this runtime.)
-
-Prefer the secure setup links the CLI prints. After connect, finish any bridge wiring from the requirements file agents.md describes. Do not invent setup steps or ask for secrets in chat unless agents.md requires it.`,
+  promptTemplate:
+    "Connect this project's LangChain agent to {channelName} with Novu using instructions from https://novu.co/agents.md",
   faq: [
     {
       question: "Do I have to rewrite my LangChain agent to add {channelName}?",

--- a/src/data/pages/home.ts
+++ b/src/data/pages/home.ts
@@ -58,13 +58,8 @@ export const HOME_CHANNELS = [
     title: "Connect your AI agent to Slack",
     description:
       "Reach teams where work happens with rich, actionable messages, threads, and reliable delivery routing.",
-    prompt: `Connect this project's AI agent to Slack with Novu Connect.
-
-Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci --channel slack\`).
-
-Inspect the repo. Detect the runtime from the project (AI SDK / LangChain / etc.), or ask once. Then run one connect command for Slack per agents.md.
-
-Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md requires it for this channel.`,
+    prompt:
+      "Connect my AI agent to Slack with Novu using instructions from https://novu.co/agents.md",
     features: [
       "Two-way threaded conversations",
       "Team and user identity mapping",
@@ -78,13 +73,8 @@ Prefer the secure setup links the CLI prints. Do not invent setup steps or ask f
     title: "Connect your AI agent to WhatsApp",
     description:
       "Start secure two-way customer conversations with templates, attachments, and delivery receipts.",
-    prompt: `Connect this project's AI agent to WhatsApp with Novu Connect.
-
-Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci --channel whatsapp\`).
-
-Inspect the repo. Detect the runtime from the project (AI SDK / LangChain / etc.), or ask once. Then run one connect command for WhatsApp per agents.md.
-
-Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md requires it for this channel.`,
+    prompt:
+      "Connect my AI agent to WhatsApp with Novu using instructions from https://novu.co/agents.md",
     features: [
       "Secure two-way conversations",
       "Approved message templates",
@@ -98,13 +88,8 @@ Prefer the secure setup links the CLI prints. Do not invent setup steps or ask f
     title: "Connect your AI agent to Telegram",
     description:
       "Reach users with fast, conversational updates, rich media, and replies inside Telegram.",
-    prompt: `Connect this project's AI agent to Telegram with Novu Connect.
-
-Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci --channel telegram\`).
-
-Inspect the repo. Detect the runtime from the project (AI SDK / LangChain / etc.), or ask once. Then run one connect command for Telegram per agents.md.
-
-Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md requires it for this channel.`,
+    prompt:
+      "Connect my AI agent to Telegram with Novu using instructions from https://novu.co/agents.md",
     features: [
       "Fast conversational delivery",
       "Rich messages and media",
@@ -118,13 +103,8 @@ Prefer the secure setup links the CLI prints. Do not invent setup steps or ask f
     title: "Connect your AI agent to Microsoft Teams",
     description:
       "Bring agent updates and human handoffs into the channels your organization already uses.",
-    prompt: `Connect this project's AI agent to Microsoft Teams with Novu Connect.
-
-Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci --channel teams\`). Note: Teams cannot use keyless mode; follow agents.md for dashboard OAuth / dashboard redirect rules.
-
-Inspect the repo. Detect the runtime from the project (AI SDK / LangChain / etc.), or ask once. Then run one connect command for Microsoft Teams per agents.md.
-
-Prefer the secure setup links or dashboard handoffs the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md requires it for this channel.`,
+    prompt:
+      "Connect my AI agent to Microsoft Teams with Novu using instructions from https://novu.co/agents.md",
     features: [
       "Channel and thread awareness",
       "Human handoff workflows",
@@ -138,13 +118,8 @@ Prefer the secure setup links or dashboard handoffs the CLI prints. Do not inven
     title: "Connect your AI agent to Email",
     description:
       "Reach users directly in their inbox with rich, actionable notifications. Support for templates, attachments, and high-deliverability routing.",
-    prompt: `Connect this project's AI agent to Email with Novu Connect.
-
-Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci --channel email\`).
-
-Inspect the repo. Detect the runtime from the project (AI SDK / LangChain / etc.), or ask once. Then run one connect command for Email per agents.md.
-
-Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md requires it for this channel.`,
+    prompt:
+      "Connect my AI agent to Email with Novu using instructions from https://novu.co/agents.md",
     features: [
       "Responsive message templates",
       "Attachments and rich content",
@@ -158,13 +133,8 @@ Prefer the secure setup links the CLI prints. Do not invent setup steps or ask f
     title: "Connect your AI agent to iMessage",
     description:
       "Bring agent conversations and timely updates into the native messaging experience customers already use.",
-    prompt: `Connect this project's AI agent to iMessage with Novu Connect.
-
-Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci --channel sendblue\`).
-
-Inspect the repo. Detect the runtime from the project (AI SDK / LangChain / etc.), or ask once. Collect the Sendblue inputs agents.md requires before running connect, then run one command for iMessage.
-
-Do not invent setup steps. For Sendblue, agents.md allows collecting credentials in chat (no secure setup page): warn once, then continue.`,
+    prompt:
+      "Connect my AI agent to iMessage with Novu using instructions from https://novu.co/agents.md",
     features: [
       "Native messaging experience",
       "Secure two-way conversations",

--- a/src/data/pages/home.ts
+++ b/src/data/pages/home.ts
@@ -1,6 +1,7 @@
 import { ROUTE } from "@/constants/routes"
 
 import type { IFaqSection } from "@/types/common"
+import { buildChannelConnectPrompt } from "@/lib/connect-prompt"
 
 // Single source of truth for homepage copy. The homepage
 // (app/(website)/(connect-footer)/page.tsx), the /index.md markdown alternate
@@ -58,8 +59,7 @@ export const HOME_CHANNELS = [
     title: "Connect your AI agent to Slack",
     description:
       "Reach teams where work happens with rich, actionable messages, threads, and reliable delivery routing.",
-    prompt:
-      "Connect my AI agent to Slack with Novu using instructions from https://novu.co/agents.md",
+    prompt: buildChannelConnectPrompt("Slack"),
     features: [
       "Two-way threaded conversations",
       "Team and user identity mapping",
@@ -73,8 +73,7 @@ export const HOME_CHANNELS = [
     title: "Connect your AI agent to WhatsApp",
     description:
       "Start secure two-way customer conversations with templates, attachments, and delivery receipts.",
-    prompt:
-      "Connect my AI agent to WhatsApp with Novu using instructions from https://novu.co/agents.md",
+    prompt: buildChannelConnectPrompt("WhatsApp"),
     features: [
       "Secure two-way conversations",
       "Approved message templates",
@@ -88,8 +87,7 @@ export const HOME_CHANNELS = [
     title: "Connect your AI agent to Telegram",
     description:
       "Reach users with fast, conversational updates, rich media, and replies inside Telegram.",
-    prompt:
-      "Connect my AI agent to Telegram with Novu using instructions from https://novu.co/agents.md",
+    prompt: buildChannelConnectPrompt("Telegram"),
     features: [
       "Fast conversational delivery",
       "Rich messages and media",
@@ -103,8 +101,7 @@ export const HOME_CHANNELS = [
     title: "Connect your AI agent to Microsoft Teams",
     description:
       "Bring agent updates and human handoffs into the channels your organization already uses.",
-    prompt:
-      "Connect my AI agent to Microsoft Teams with Novu using instructions from https://novu.co/agents.md",
+    prompt: buildChannelConnectPrompt("Microsoft Teams"),
     features: [
       "Channel and thread awareness",
       "Human handoff workflows",
@@ -118,8 +115,7 @@ export const HOME_CHANNELS = [
     title: "Connect your AI agent to Email",
     description:
       "Reach users directly in their inbox with rich, actionable notifications. Support for templates, attachments, and high-deliverability routing.",
-    prompt:
-      "Connect my AI agent to Email with Novu using instructions from https://novu.co/agents.md",
+    prompt: buildChannelConnectPrompt("Email"),
     features: [
       "Responsive message templates",
       "Attachments and rich content",
@@ -133,8 +129,7 @@ export const HOME_CHANNELS = [
     title: "Connect your AI agent to iMessage",
     description:
       "Bring agent conversations and timely updates into the native messaging experience customers already use.",
-    prompt:
-      "Connect my AI agent to iMessage with Novu using instructions from https://novu.co/agents.md",
+    prompt: buildChannelConnectPrompt("iMessage"),
     features: [
       "Native messaging experience",
       "Secure two-way conversations",

--- a/src/lib/connect-prompt.ts
+++ b/src/lib/connect-prompt.ts
@@ -1,0 +1,56 @@
+/**
+ * Single source of truth for copy-paste coding-agent prompts that point at
+ * https://novu.co/agents.md. Keep prompts short; agents.md owns setup detail.
+ */
+
+export const AGENTS_MD_URL = "https://novu.co/agents.md"
+
+type BuildConnectPromptOptions = {
+  /**
+   * Subject being connected.
+   * Defaults to "my agent".
+   * Examples: "this project's LangChain agent", "a Claude Managed Agent"
+   */
+  agent?: string
+  /** What the agent connects to. Defaults to "customers". */
+  target?: string
+}
+
+export function buildConnectPrompt({
+  agent = "my agent",
+  target = "customers",
+}: BuildConnectPromptOptions = {}): string {
+  return `Connect ${agent} to ${target} with Novu using instructions from ${AGENTS_MD_URL}`
+}
+
+/** Default homepage, /connect, and /aci prompt. */
+export const DEFAULT_CONNECT_PROMPT = buildConnectPrompt()
+
+/** Channel-only prompt, e.g. Slack landing page or homepage channel card. */
+export function buildChannelConnectPrompt(channelName: string): string {
+  return buildConnectPrompt({ target: channelName })
+}
+
+type FrameworkConnectPath = "bridge" | "managed"
+
+/**
+ * Framework × channel prompt.
+ * Bridge: "Connect this project's LangChain agent to Slack with Novu ..."
+ * Managed: "Connect a Claude Managed Agent to Slack with Novu ..."
+ */
+export function buildFrameworkChannelConnectPrompt({
+  frameworkName,
+  channelName,
+  connectPath = "bridge",
+}: {
+  frameworkName: string
+  channelName: string
+  connectPath?: FrameworkConnectPath
+}): string {
+  const agent =
+    connectPath === "managed"
+      ? `${/^[aeiou]/i.test(frameworkName) ? "an" : "a"} ${frameworkName}`
+      : `this project's ${frameworkName} agent`
+
+  return buildConnectPrompt({ agent, target: channelName })
+}

--- a/src/lib/markdown/pages/aci.ts
+++ b/src/lib/markdown/pages/aci.ts
@@ -2,6 +2,7 @@ import { ROUTE } from "@/constants/routes"
 import { SEO_DATA } from "@/constants/seo-data"
 
 import type { IFaqSection } from "@/types/common"
+import { DEFAULT_CONNECT_PROMPT } from "@/lib/connect-prompt"
 
 import {
   escapeMarkdownTableCell,
@@ -12,10 +13,8 @@ import { bulletList, faqMarkdown, pageFromSeo } from "../page-utils"
 import type { MarkdownPage } from "../types"
 
 const CONNECT_COMMAND = "npx novu connect"
-const ACI_PROMPT =
-  "Add an agent to my app using instructions from https://novu.co/agents.md"
 const CLAUDE_PROMPT_URL = `https://claude.ai/new?q=${encodeURIComponent(
-  ACI_PROMPT
+  DEFAULT_CONNECT_PROMPT
 )}`
 const GITHUB_REPO_URL = "https://github.com/novuhq/novu"
 const PRODUCT_HUNT_LAUNCH_URL =
@@ -174,7 +173,7 @@ export async function getAci(pathname: string): Promise<MarkdownPage | null> {
       ]
         .map((item) => `- ${item}`)
         .join("\n"),
-      `Prompt for Claude:\n\n${formatCodeFence(ACI_PROMPT, "text")}`,
+      `Prompt for Claude:\n\n${formatCodeFence(DEFAULT_CONNECT_PROMPT, "text")}`,
       `Featured on ${formatMarkdownLink("Product Hunt", PRODUCT_HUNT_LAUNCH_URL)}`,
     ].join("\n\n"),
     [

--- a/src/lib/markdown/pages/aci.ts
+++ b/src/lib/markdown/pages/aci.ts
@@ -12,13 +12,8 @@ import { bulletList, faqMarkdown, pageFromSeo } from "../page-utils"
 import type { MarkdownPage } from "../types"
 
 const CONNECT_COMMAND = "npx novu connect"
-const ACI_PROMPT = `Connect this project's AI agent to customer channels (Slack, Microsoft Teams, WhatsApp, Telegram, Email, or iMessage) with Novu Connect.
-
-Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci\`).
-
-Inspect the repo first. Ask me which channel to connect if it is not clear. Detect the framework/runtime from the project, or ask once. Then run one connect command per agents.md (bridge vs managed, keyless vs dashboard OAuth).
-
-Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md says that channel requires it (e.g. iMessage/Sendblue).`
+const ACI_PROMPT =
+  "Add an agent to my app using instructions from https://novu.co/agents.md"
 const CLAUDE_PROMPT_URL = `https://claude.ai/new?q=${encodeURIComponent(
   ACI_PROMPT
 )}`

--- a/src/lib/markdown/pages/channel-frameworks.ts
+++ b/src/lib/markdown/pages/channel-frameworks.ts
@@ -4,7 +4,7 @@ import {
   getConnectCommand,
 } from "@/data/pages/channel-frameworks"
 
-import { escapeMarkdownText, formatCodeFence } from "../markdown-format"
+import { escapeMarkdownText } from "../markdown-format"
 import { bulletList } from "../page-utils"
 import type { MarkdownPage } from "../types"
 
@@ -50,8 +50,7 @@ export async function getChannelFrameworks(
     bulletList(framework.strengths),
     `## How to connect ${escapeMarkdownText(framework.name)} to ${escapeMarkdownText(channel.channelName)}`,
     steps,
-    "Prompt for your coding agent:",
-    formatCodeFence(fillTemplate(framework.promptTemplate, combo), "text"),
+    `Prompt for your coding agent: ${escapeMarkdownText(fillTemplate(framework.promptTemplate, combo))}`,
     `## ${escapeMarkdownText(framework.name)} and ${escapeMarkdownText(channel.channelName)}, common questions`,
     faq,
   ]

--- a/src/lib/markdown/pages/channel-frameworks.ts
+++ b/src/lib/markdown/pages/channel-frameworks.ts
@@ -4,6 +4,8 @@ import {
   getConnectCommand,
 } from "@/data/pages/channel-frameworks"
 
+import { buildFrameworkChannelConnectPrompt } from "@/lib/connect-prompt"
+
 import { escapeMarkdownText } from "../markdown-format"
 import { bulletList } from "../page-utils"
 import type { MarkdownPage } from "../types"
@@ -41,6 +43,12 @@ export async function getChannelFrameworks(
     )
     .join("\n\n")
 
+  const prompt = buildFrameworkChannelConnectPrompt({
+    frameworkName: framework.name,
+    channelName: channel.channelName,
+    connectPath: framework.connectPath,
+  })
+
   const body = [
     `${escapeMarkdownText(framework.tagline)} Novu Connect gives it a voice in ${escapeMarkdownText(channel.channelName)}.`,
     escapeMarkdownText(fillTemplate(framework.connectIntro, combo)),
@@ -50,7 +58,7 @@ export async function getChannelFrameworks(
     bulletList(framework.strengths),
     `## How to connect ${escapeMarkdownText(framework.name)} to ${escapeMarkdownText(channel.channelName)}`,
     steps,
-    `Prompt for your coding agent: ${escapeMarkdownText(fillTemplate(framework.promptTemplate, combo))}`,
+    `Prompt for your coding agent: ${escapeMarkdownText(prompt)}`,
     `## ${escapeMarkdownText(framework.name)} and ${escapeMarkdownText(channel.channelName)}, common questions`,
     faq,
   ]

--- a/src/lib/markdown/pages/channels.ts
+++ b/src/lib/markdown/pages/channels.ts
@@ -1,6 +1,6 @@
 import { getChannelBySlug } from "@/data/pages/channels"
 
-import { escapeMarkdownText, formatCodeFence } from "../markdown-format"
+import { escapeMarkdownText } from "../markdown-format"
 import { bulletList } from "../page-utils"
 import type { MarkdownPage } from "../types"
 
@@ -39,8 +39,7 @@ export async function getChannels(
     transcript,
     `## How to connect`,
     escapeMarkdownText(channel.onRamp.note),
-    "Prompt for your coding agent:",
-    formatCodeFence(channel.prompt, "text"),
+    `Prompt for your coding agent: ${escapeMarkdownText(channel.prompt)}`,
     `## ${escapeMarkdownText(channel.channelName)} and Novu Connect, common questions`,
     faq,
   ]

--- a/src/lib/markdown/pages/connect.ts
+++ b/src/lib/markdown/pages/connect.ts
@@ -15,13 +15,8 @@ import type { MarkdownPage } from "../types"
 import { absoluteUrl, toCanonicalPathname } from "../url"
 
 const CONNECT_COMMAND = "npx novu connect"
-const CONNECT_PROMPT = `Connect this project's AI agent to customer channels (Slack, Microsoft Teams, WhatsApp, Telegram, Email, or iMessage) with Novu Connect.
-
-Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci\`).
-
-Inspect the repo first. Ask me which channel to connect if it is not clear. Detect the framework/runtime from the project, or ask once. Then run one connect command per agents.md (bridge vs managed, keyless vs dashboard OAuth).
-
-Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md says that channel requires it (e.g. iMessage/Sendblue).`
+const CONNECT_PROMPT =
+  "Add an agent to my app using instructions from https://novu.co/agents.md"
 const PRODUCT_HUNT_LAUNCH_URL =
   "https://www.producthunt.com/products/novu/launches/novu-connect"
 

--- a/src/lib/markdown/pages/connect.ts
+++ b/src/lib/markdown/pages/connect.ts
@@ -1,6 +1,7 @@
 import { ROUTE } from "@/constants/routes"
 import { SEO_DATA } from "@/constants/seo-data"
 
+import { DEFAULT_CONNECT_PROMPT } from "@/lib/connect-prompt"
 import { getAgentTemplatesSection } from "@/lib/templates"
 import { getAgentTemplateUrl } from "@/lib/templates/url"
 import { CONNECT_FAQ } from "@/components/pages/connect/faq-data"
@@ -15,8 +16,6 @@ import type { MarkdownPage } from "../types"
 import { absoluteUrl, toCanonicalPathname } from "../url"
 
 const CONNECT_COMMAND = "npx novu connect"
-const CONNECT_PROMPT =
-  "Add an agent to my app using instructions from https://novu.co/agents.md"
 const PRODUCT_HUNT_LAUNCH_URL =
   "https://www.producthunt.com/products/novu/launches/novu-connect"
 
@@ -219,7 +218,7 @@ export async function getConnect(
       SEO_DATA.connect.description,
       formatCodeFence(CONNECT_COMMAND, "bash"),
       formatMarkdownLink("Sign Up", ROUTE.dashboardV2AgentsSignUp),
-      `Prompt for Claude:\n\n${formatCodeFence(CONNECT_PROMPT, "text")}`,
+      `Prompt for Claude:\n\n${formatCodeFence(DEFAULT_CONNECT_PROMPT, "text")}`,
       `Featured on ${formatMarkdownLink("Product Hunt", PRODUCT_HUNT_LAUNCH_URL)}`,
     ].join("\n\n"),
     "## Novu is trusted by leading teams worldwide",

--- a/src/types/framework.ts
+++ b/src/types/framework.ts
@@ -49,11 +49,6 @@ export interface IAgentFrameworkData {
   connectIntro: string
   /** Ordered how-to steps. Placeholders substituted at render. */
   steps: IFrameworkStep[]
-  /**
-   * Copy-paste prompt for a coding agent. `{channelName}` and `{cliSlug}`
-   * are substituted at render.
-   */
-  promptTemplate: string
   /** Framework-specific FAQ. `{channelName}` substituted at render. */
   faq: IFrameworkFaqItem[]
   /** Path under docs.novu.co for the framework's connect guide. */

--- a/tests/critical-flows/contracts.ts
+++ b/tests/critical-flows/contracts.ts
@@ -70,19 +70,8 @@ export const connectStackContract = {
   channel: "MS Teams",
   framework: "LangChain",
   command: "npx novu connect --channel teams --runtime langchain",
-  prompt: `Connect this project's LangChain agent to MS Teams with Novu Connect.
-
-Follow https://novu.co/agents.md end to end (custom code bridge path). Default to the non-interactive CLI (\`--ci\`).
-
-Inspect the repo (agent entry point, how LangChain is used, package manager, env conventions). Do not modify anything yet.
-
-Prefer a connect command shaped like:
-
-npx novu@latest connect --ci --runtime langchain --channel teams
-
-(Omit --keyless: bridge uses dashboard OAuth. Adjust flags only as agents.md allows for this runtime.)
-
-Prefer the secure setup links the CLI prints. After connect, finish any bridge wiring from the requirements file agents.md describes. Do not invent setup steps or ask for secrets in chat unless agents.md requires it.`,
+  prompt:
+    "Connect this project's LangChain agent to MS Teams with Novu using instructions from https://novu.co/agents.md",
 } as const
 
 export const channelPagesContract = {
@@ -137,13 +126,8 @@ export const connectContract = {
   route: destinations.connect,
   heading: "Connect your agent to any channel",
   command: "npx novu connect",
-  prompt: `Connect this project's AI agent to customer channels (Slack, Microsoft Teams, WhatsApp, Telegram, Email, or iMessage) with Novu Connect.
-
-Follow https://novu.co/agents.md end to end. Default to the non-interactive CLI (\`npx novu@latest connect … --ci\`).
-
-Inspect the repo first. Ask me which channel to connect if it is not clear. Detect the framework/runtime from the project, or ask once. Then run one connect command per agents.md (bridge vs managed, keyless vs dashboard OAuth).
-
-Prefer the secure setup links the CLI prints. Do not invent setup steps or ask for secrets in chat unless agents.md says that channel requires it (e.g. iMessage/Sendblue).`,
+  prompt:
+    "Add an agent to my app using instructions from https://novu.co/agents.md",
   signUpDestination: destinations.agentsSignUp,
   connectAppDestination: destinations.connectApp,
 } as const

--- a/tests/critical-flows/contracts.ts
+++ b/tests/critical-flows/contracts.ts
@@ -127,7 +127,7 @@ export const connectContract = {
   heading: "Connect your agent to any channel",
   command: "npx novu connect",
   prompt:
-    "Add an agent to my app using instructions from https://novu.co/agents.md",
+    "Connect my agent to customers with Novu using instructions from https://novu.co/agents.md",
   signUpDestination: destinations.agentsSignUp,
   connectAppDestination: destinations.connectApp,
 } as const


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reverts the verbose multiline coding-agent prompts introduced in #145 and restores short one-line prompts that point agents at `https://novu.co/agents.md` for full setup instructions.

Prompts are now built from a single helper in `src/lib/connect-prompt.ts` so homepage, /connect, /aci, channel pages, and framework combos cannot drift.

## Pattern

Default:
```
Connect my agent to customers with Novu using instructions from https://novu.co/agents.md
```

Channel:
```
Connect my agent to Slack with Novu using instructions from https://novu.co/agents.md
```

Framework × channel:
```
Connect this project's LangChain agent to MS Teams with Novu using instructions from https://novu.co/agents.md
```

## Surfaces

- Homepage hero, CTA, one-engine section, channel cards, connect-stack picker
- `/connect` and `/aci` (UI + markdown mirrors)
- Channel landing pages (including iMessage)
- Framework × channel combo pages
- Critical-flow contracts (`TC-HOME-003`, `TC-CONNECT-001`)

## Notes

- CLI flag / keyless / OAuth detail lives in `agents.md`, not in the pasted prompt
- Framework `promptTemplate` fields removed; prompts are derived via `buildFrameworkChannelConnectPrompt`
- GitHub homepage card prompt left unchanged (was out of scope in #145)

Fixes MRK-1918
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9001f41e-0ba6-401c-a1eb-50c9c065bc9b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9001f41e-0ba6-401c-a1eb-50c9c065bc9b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

