### PR TITLE
feat(notify): Novu Notify landing page at /notify

### DIFF
--- a/src/app/(website)/(connect-footer)/notify/page.tsx
+++ b/src/app/(website)/(connect-footer)/notify/page.tsx
@@ -1,10 +1,7 @@
 import type { Metadata } from "next"
 import { ROUTE } from "@/constants/routes"
 import { SEO_DATA } from "@/constants/seo-data"
-import {
-  HOME_COMPLIANCE,
-  HOME_FEATURED_CUSTOMERS,
-} from "@/data/pages/home"
+import { HOME_COMPLIANCE, HOME_FEATURED_CUSTOMERS } from "@/data/pages/home"
 import {
   NOTIFY_COMMAND,
   NOTIFY_CTA,
@@ -219,11 +216,7 @@ export default async function NotifyPage() {
         variant="minimal"
         defaultOpenFirst
       />
-      <Cta
-        {...NOTIFY_CTA}
-        command={NOTIFY_COMMAND}
-        prompt={NOTIFY_PROMPT}
-      />
+      <Cta {...NOTIFY_CTA} command={NOTIFY_COMMAND} prompt={NOTIFY_PROMPT} />
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{

--- a/src/app/(website)/(connect-footer)/notify/page.tsx
+++ b/src/app/(website)/(connect-footer)/notify/page.tsx
@@ -1,0 +1,235 @@
+import type { Metadata } from "next"
+import { ROUTE } from "@/constants/routes"
+import { SEO_DATA } from "@/constants/seo-data"
+import {
+  HOME_COMPLIANCE,
+  HOME_FEATURED_CUSTOMERS,
+} from "@/data/pages/home"
+import {
+  NOTIFY_COMMAND,
+  NOTIFY_CTA,
+  NOTIFY_EXPLORE,
+  NOTIFY_FAQ,
+  NOTIFY_FEATURE_SECTIONS,
+  NOTIFY_HERO,
+  NOTIFY_INBOX_PROMPT,
+  NOTIFY_INBOX_SECTION,
+  NOTIFY_PROMPT,
+  NOTIFY_PROVIDERS_SECTION,
+} from "@/data/pages/notify"
+import notifyFeaturedBackground from "@/images/pages/home/bento-notify-featured-bg.png"
+import notifyDigestGraphic from "@/images/pages/home/novu-notify/digest.jpg"
+import notifyPreferencesGraphic from "@/images/pages/home/novu-notify/preferences.jpg"
+import notifyWorkflowGraphic from "@/images/pages/home/novu-notify/workflow.jpg"
+import nextjsIcon from "@/svgs/pages/home/inbox/nextjs.svg"
+import reactIcon from "@/svgs/pages/home/inbox/react.svg"
+import remixIcon from "@/svgs/pages/home/inbox/remix.svg"
+
+import { getMetadata } from "@/lib/get-metadata"
+import { getIntegrationsByTab } from "@/lib/integrations"
+import { safeJsonLdStringify } from "@/lib/json-ld"
+import { highlightEchoCode } from "@/lib/shiki"
+import { absoluteUrl, toCanonicalPathname } from "@/lib/site-url"
+import FAQ from "@/components/pages/faq"
+import Compliance from "@/components/pages/home/compliance"
+import Cta from "@/components/pages/home/cta"
+import FeaturedCustomers from "@/components/pages/home/featured-customers"
+import ExploreLinks from "@/components/pages/notify/explore-links"
+import NotifyFeatureSplit from "@/components/pages/notify/feature-split"
+import NotifyHero from "@/components/pages/notify/hero"
+import InboxSection from "@/components/pages/notify/inbox-section"
+import ProvidersSection from "@/components/pages/notify/providers-section"
+import SectionWithLogosAnimated from "@/components/section-with-logos-animated"
+
+const notifyCodeTabs = [
+  {
+    title: "Next.js",
+    code: `import React from 'react';
+import { Inbox } from '@novu/nextjs';
+
+export function NotificationInbox() {
+  return (
+    <Inbox />
+  );
+}`,
+    icon: nextjsIcon,
+  },
+  {
+    title: "Remix",
+    code: `import React from 'react';
+import { Inbox } from '@novu/react';
+
+export function NotificationInbox() {
+  return (
+    <Inbox />
+  );
+}`,
+    icon: remixIcon,
+  },
+  {
+    title: "React",
+    code: `import React from 'react';
+import { Inbox } from '@novu/react';
+
+export function NotificationInbox() {
+  return (
+    <Inbox />
+  );
+}`,
+    icon: reactIcon,
+  },
+]
+
+const featureSectionImages = {
+  digest: notifyDigestGraphic,
+  preferences: notifyPreferencesGraphic,
+  workflows: notifyWorkflowGraphic,
+} as const
+
+export const metadata: Metadata = getMetadata(SEO_DATA.notify)
+
+const SITE_URL = absoluteUrl("/")
+const PAGE_URL = absoluteUrl(toCanonicalPathname(String(ROUTE.notify)))
+const ORGANIZATION_ID = `${SITE_URL}#organization`
+const WEBSITE_ID = `${SITE_URL}#website`
+const WEB_PAGE_ID = `${PAGE_URL}#webpage`
+const FAQ_ID = `${PAGE_URL}#faq`
+const BREADCRUMB_ID = `${PAGE_URL}#breadcrumb`
+
+const jsonLdGraph = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebPage",
+      "@id": WEB_PAGE_ID,
+      name: SEO_DATA.notify.title,
+      description: SEO_DATA.notify.description,
+      url: PAGE_URL,
+      isPartOf: { "@id": WEBSITE_ID },
+      publisher: { "@id": ORGANIZATION_ID },
+      breadcrumb: { "@id": BREADCRUMB_ID },
+      mainEntity: [{ "@id": FAQ_ID }],
+    },
+    {
+      "@type": "FAQPage",
+      "@id": FAQ_ID,
+      mainEntity: NOTIFY_FAQ.accordion.items.map((item) => ({
+        "@type": "Question",
+        name: item.question,
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: item.answer,
+        },
+      })),
+    },
+    {
+      "@type": "BreadcrumbList",
+      "@id": BREADCRUMB_ID,
+      itemListElement: [
+        {
+          "@type": "ListItem",
+          position: 1,
+          name: "Novu",
+          item: SITE_URL,
+        },
+        {
+          "@type": "ListItem",
+          position: 2,
+          name: "Novu Notify",
+          item: PAGE_URL,
+        },
+      ],
+    },
+  ],
+}
+
+export default async function NotifyPage() {
+  const [highlightedNotifyCodeTabs, channelIntegrations] = await Promise.all([
+    Promise.all(
+      notifyCodeTabs.map(async (tab) => ({
+        ...tab,
+        highlightedHtml: await highlightEchoCode(tab.code),
+      }))
+    ),
+    getIntegrationsByTab("channels"),
+  ])
+
+  const providersByCategory = channelIntegrations.reduce<
+    Record<string, typeof channelIntegrations>
+  >((acc, integration) => {
+    ;(acc[integration.category] ??= []).push(integration)
+    return acc
+  }, {})
+
+  return (
+    <div className="overflow-clip">
+      <NotifyHero
+        {...NOTIFY_HERO}
+        command={NOTIFY_COMMAND}
+        prompt={NOTIFY_PROMPT}
+        codeTabs={highlightedNotifyCodeTabs}
+        card={{
+          ...NOTIFY_INBOX_SECTION.featured,
+          backgroundImage: notifyFeaturedBackground,
+        }}
+      />
+      <SectionWithLogosAnimated
+        className="mt-16 mb-0 px-5 md:mt-20 md:mb-0 md:px-8 lg:mt-24 lg:mb-0 xl:mb-0"
+        titleHighlight="Novu"
+        title="is trusted by leading teams worldwide"
+        titleSize="sm"
+        titleClassName="leading-normal font-normal tracking-tighter"
+        rows={2}
+      />
+      <InboxSection
+        title={NOTIFY_INBOX_SECTION.title}
+        description={NOTIFY_INBOX_SECTION.description}
+        prompt={NOTIFY_INBOX_PROMPT}
+        capabilities={NOTIFY_INBOX_SECTION.capabilities}
+      />
+      {NOTIFY_FEATURE_SECTIONS.map((section, index) => (
+        <NotifyFeatureSplit
+          key={section.key}
+          label={section.label}
+          title={section.title}
+          description={section.description}
+          bullets={section.bullets}
+          links={section.links}
+          linkClickLocation={`notify_${section.key}`}
+          image={
+            featureSectionImages[
+              section.key as keyof typeof featureSectionImages
+            ]
+          }
+          reverse={index % 2 === 1}
+        />
+      ))}
+      <ProvidersSection
+        {...NOTIFY_PROVIDERS_SECTION}
+        providersByCategory={providersByCategory}
+      />
+      <FeaturedCustomers {...HOME_FEATURED_CUSTOMERS} />
+      <ExploreLinks {...NOTIFY_EXPLORE} />
+      <Compliance {...HOME_COMPLIANCE} />
+      <FAQ
+        {...NOTIFY_FAQ}
+        className="md py-20 font-inter md:py-28 lg:py-36 xl:pt-50 xl:pb-10"
+        titleClassName="tracking-plus-tight font-normal lg:text-[44px]"
+        containerClassName="max-w-3xl lg:max-w-288 gap-y-5"
+        variant="minimal"
+        defaultOpenFirst
+      />
+      <Cta
+        {...NOTIFY_CTA}
+        command={NOTIFY_COMMAND}
+        prompt={NOTIFY_PROMPT}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: safeJsonLdStringify(jsonLdGraph),
+        }}
+      />
+    </div>
+  )
+}

--- a/src/components/pages/home/notify-code-tabs.tsx
+++ b/src/components/pages/home/notify-code-tabs.tsx
@@ -71,7 +71,7 @@ function NotifyCodeTabs({ className, tabs }: INotifyCodeTabsProps) {
       </div>
 
       <button
-        className="absolute top-12 right-4 z-20 grid size-7 shrink-0 place-items-center rounded border border-gray-20 text-gray-50 transition-colors hover:border-gray-50 hover:text-foreground focus-visible:ring-2 focus-visible:ring-foreground/70 focus-visible:outline-none md:right-15 lg:max-[72rem]:right-22 xl:right-7"
+        className="absolute top-12 right-4 z-20 grid size-7 shrink-0 place-items-center rounded border border-gray-20 bg-[#0B0C0E] text-gray-50 transition-colors hover:border-gray-50 hover:text-foreground focus-visible:ring-2 focus-visible:ring-foreground/70 focus-visible:outline-none md:right-15 lg:max-[72rem]:right-22 xl:right-7"
         type="button"
         onClick={() => handleCopy(activeCode)}
         aria-label={isCopied ? "Code copied" : "Copy code"}

--- a/src/components/pages/home/notify-featured-card.tsx
+++ b/src/components/pages/home/notify-featured-card.tsx
@@ -1,0 +1,107 @@
+import Image, { type StaticImageData } from "next/image"
+
+import { cn } from "@/lib/utils"
+
+import BentoCardBackground, {
+  type BentoCardBackgroundImage,
+} from "./bento-card-background"
+import InboxComponent from "./code-with-inbox/inbox/inbox-component"
+import NotifyCodeTabs, { type INotifyCodeTab } from "./notify-code-tabs"
+
+// The "Fits perfectly into your app" bento card. Shared by the homepage
+// Novu Notify section and the /notify hero so the two cannot drift: the card
+// clips the Inbox and the code tabs to its own bounds, which is what keeps the
+// composition intact at every breakpoint.
+export interface INotifyFeaturedCardProps {
+  backgroundImage?: BentoCardBackgroundImage
+  className?: string
+  codeTabs: INotifyCodeTab[]
+  description: string
+  /** heading level for the card title, matched to the surrounding outline */
+  headingLevel?: "h2" | "h3"
+  image?: StaticImageData
+  imageClassName?: string
+  imageContainerClassName?: string
+  imageSizes?: string
+  /** render the live, interactive Inbox instead of a static screenshot */
+  liveInbox?: boolean
+  title: string
+}
+
+function NotifyFeaturedCard({
+  backgroundImage,
+  className,
+  codeTabs,
+  description,
+  headingLevel = "h3",
+  image,
+  imageClassName,
+  imageContainerClassName,
+  imageSizes,
+  liveInbox,
+  title,
+}: INotifyFeaturedCardProps) {
+  const Heading = headingLevel
+
+  return (
+    <article
+      className={cn(
+        "magic-bento-card relative flex w-full flex-col overflow-clip rounded-xl border border-gray-20 bg-[#0B0C0E] p-5 pb-0 md:block md:h-118 md:p-0",
+        className
+      )}
+    >
+      {backgroundImage && (
+        <BentoCardBackground
+          backgroundClassName="opacity-80"
+          backgroundImage={backgroundImage}
+        />
+      )}
+      <div className="relative flex min-w-0 flex-col md:contents">
+        <div className="relative z-30 max-w-[26.5625rem] md:absolute md:top-[27px] md:left-[27px]">
+          <Heading className="text-base leading-tight font-normal tracking-tighter text-foreground md:text-xl md:leading-none">
+            {title}
+          </Heading>
+          <p className="mt-2.5 text-sm leading-normal font-normal tracking-tighter text-pretty text-gray-50 md:w-80 md:text-base xl:w-114">
+            {description}
+          </p>
+        </div>
+
+        <NotifyCodeTabs
+          className="relative z-10 mt-8 h-61 md:absolute md:bottom-0 md:left-7 md:mt-0 md:h-67 md:w-110 lg:w-124 xl:w-134"
+          tabs={codeTabs}
+        />
+      </div>
+
+      {liveInbox ? (
+        <InboxComponent
+          animateEntrance={false}
+          className="notify-live-inbox absolute top-13 left-104 m-0 hidden md:block lg:right-14 lg:left-auto lg:max-[68rem]:left-112 xl:left-137"
+          themeTabsClassName="absolute top-13 left-104 m-0 hidden md:flex lg:right-14 lg:left-auto lg:max-[68rem]:left-112 xl:right-14 xl:left-auto"
+          variant="home"
+        />
+      ) : image ? (
+        <div
+          className={cn(
+            "pointer-events-none hidden md:absolute md:inset-0 md:z-20 md:block",
+            imageContainerClassName
+          )}
+          aria-hidden="true"
+        >
+          <Image
+            className={cn(
+              "absolute h-auto max-w-none active:cursor-grabbing",
+              imageClassName
+            )}
+            src={image}
+            alt=""
+            quality={100}
+            sizes={imageSizes}
+            aria-hidden="true"
+          />
+        </div>
+      ) : null}
+    </article>
+  )
+}
+
+export default NotifyFeaturedCard

--- a/src/components/pages/home/novu-notify.tsx
+++ b/src/components/pages/home/novu-notify.tsx
@@ -9,10 +9,10 @@ import { Button } from "@/components/ui/button"
 import BentoCardBackground, {
   type BentoCardBackgroundImage,
 } from "./bento-card-background"
-import InboxComponent from "./code-with-inbox/inbox/inbox-component"
 import CopyPromptButton from "./copy-prompt-button"
 import MagicBento from "./magic-bento"
-import NotifyCodeTabs, { type INotifyCodeTab } from "./notify-code-tabs"
+import type { INotifyCodeTab } from "./notify-code-tabs"
+import NotifyFeaturedCard from "./notify-featured-card"
 
 export interface INovuNotifyItem {
   backgroundImage?: BentoCardBackgroundImage
@@ -109,58 +109,7 @@ function NovuNotify({
         </header>
 
         <MagicBento className="mt-12 md:mt-16" particles={false}>
-          <article className="magic-bento-card relative flex w-full flex-col overflow-clip rounded-xl border border-gray-20 bg-[#0B0C0E] p-5 pb-0 md:block md:h-118 md:p-0">
-            {featuredItem.backgroundImage && (
-              <BentoCardBackground
-                backgroundClassName="opacity-80"
-                backgroundImage={featuredItem.backgroundImage}
-              />
-            )}
-            <div className="relative flex min-w-0 flex-col md:contents">
-              <div className="relative z-30 max-w-[26.5625rem] md:absolute md:top-[27px] md:left-[27px]">
-                <h3 className="text-base leading-tight font-normal tracking-tighter text-foreground md:text-xl md:leading-none">
-                  {featuredItem.title}
-                </h3>
-                <p className="mt-2.5 text-sm leading-normal font-normal tracking-tighter text-pretty text-gray-50 md:w-80 md:text-base xl:w-114">
-                  {featuredItem.description}
-                </p>
-              </div>
-
-              <NotifyCodeTabs
-                className="relative z-10 mt-8 h-61 md:absolute md:bottom-0 md:left-7 md:mt-0 md:h-67 md:w-110 lg:w-124 xl:w-134"
-                tabs={codeTabs}
-              />
-            </div>
-
-            {featuredItem.liveInbox ? (
-              <InboxComponent
-                animateEntrance={false}
-                className="notify-live-inbox zoom-[0.965] md:zoom-[0.9] lg:zoom-[1.111] xl:zoom-[0.98] absolute top-13 left-104 m-0 hidden md:block lg:right-14 lg:left-auto lg:max-[68rem]:left-112 xl:left-137"
-                themeTabsClassName="absolute top-13 left-104 m-0 hidden md:flex lg:right-14 lg:left-auto lg:max-[68rem]:left-112 xl:right-14 xl:left-auto"
-                variant="home"
-              />
-            ) : featuredItem.image ? (
-              <div
-                className={cn(
-                  "pointer-events-none hidden md:absolute md:inset-0 md:z-20 md:block",
-                  featuredItem.imageContainerClassName
-                )}
-                aria-hidden="true"
-              >
-                <Image
-                  className={cn(
-                    "absolute h-auto max-w-none active:cursor-grabbing",
-                    featuredItem.imageClassName
-                  )}
-                  src={featuredItem.image}
-                  alt=""
-                  quality={100}
-                  sizes={featuredItem.imageSizes}
-                  aria-hidden="true"
-                />
-              </div>
-            ) : null}
-          </article>
+          <NotifyFeaturedCard {...featuredItem} codeTabs={codeTabs} />
 
           {supportingItems.length > 0 && (
             <div className="mt-5 grid grid-cols-1 gap-5 lg:grid-cols-3">

--- a/src/components/pages/notify/explore-links.tsx
+++ b/src/components/pages/notify/explore-links.tsx
@@ -1,0 +1,106 @@
+import NextLink from "next/link"
+import { ArrowRight, ArrowUpRight } from "lucide-react"
+
+export interface IExploreLinkItem {
+  description: string
+  href: string
+  linkLabel: string
+  title: string
+}
+
+export interface IExploreDocsItem {
+  href: string
+  title: string
+}
+
+interface IExploreLinksProps {
+  description: string
+  docsItems?: IExploreDocsItem[]
+  docsTitle?: string
+  items: IExploreLinkItem[]
+  title: string
+}
+
+function ExploreLinks({
+  description,
+  docsItems,
+  docsTitle,
+  items,
+  title,
+}: IExploreLinksProps) {
+  if (!items || items.length === 0) {
+    return null
+  }
+
+  return (
+    <section className="mt-24 font-inter md:mt-28 lg:mt-32">
+      <div className="mx-auto w-full max-w-3xl px-5 md:px-8 lg:max-w-7xl">
+        <h2 className="max-w-168 text-[2rem] leading-[1.125] font-normal tracking-[-0.04em] text-balance text-foreground md:text-5xl xl:text-[3.25rem]">
+          {title}
+        </h2>
+        <p className="mt-4 max-w-161 text-base leading-normal font-normal tracking-tighter text-pretty text-gray-60 md:text-lg">
+          {description}
+        </p>
+
+        <ul className="mt-12 grid grid-cols-1 gap-5 sm:grid-cols-2 md:mt-16 lg:grid-cols-3">
+          {items.map((item) => (
+            <li key={item.title}>
+              <NextLink
+                className="group flex h-full flex-col rounded-xl border border-gray-20 bg-[#0B0C0E] p-5 transition-colors duration-300 hover:border-white/25 lg:p-6"
+                href={item.href}
+                data-click-location="notify_explore"
+                data-click-text={item.linkLabel}
+              >
+                <h3 className="text-base leading-tight font-medium tracking-tighter text-foreground md:text-lg">
+                  {item.title}
+                </h3>
+                <p className="mt-2 text-sm leading-normal font-normal tracking-tighter text-pretty text-gray-50">
+                  {item.description}
+                </p>
+                <span className="mt-auto flex items-center gap-1.5 pt-4 text-sm leading-none font-medium tracking-tighter text-blue-1">
+                  {item.linkLabel}
+                  <ArrowRight
+                    className="size-3.5 transition-transform duration-300 group-hover:translate-x-0.5"
+                    aria-hidden
+                  />
+                </span>
+              </NextLink>
+            </li>
+          ))}
+        </ul>
+
+        {docsItems && docsItems.length > 0 && (
+          <div className="mt-10 flex flex-col gap-4 md:mt-12">
+            {docsTitle && (
+              <h3 className="text-sm leading-none font-normal tracking-normal text-gray-50 uppercase">
+                {docsTitle}
+              </h3>
+            )}
+            <ul className="flex flex-wrap gap-2.5">
+              {docsItems.map((item) => (
+                <li key={item.href}>
+                  <NextLink
+                    className="group flex items-center gap-1.5 rounded-lg border border-gray-20 bg-[#0B0C0E] px-3.5 py-2.5 text-sm leading-none tracking-tighter text-gray-8 transition-colors duration-300 hover:border-white/25 hover:text-foreground"
+                    href={item.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    data-click-location="notify_explore_docs"
+                    data-click-text={item.title}
+                  >
+                    {item.title}
+                    <ArrowUpRight
+                      className="size-3.5 text-gray-50 transition-colors duration-300 group-hover:text-foreground"
+                      aria-hidden
+                    />
+                  </NextLink>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}
+
+export default ExploreLinks

--- a/src/components/pages/notify/explore-links.tsx
+++ b/src/components/pages/notify/explore-links.tsx
@@ -1,5 +1,5 @@
 import NextLink from "next/link"
-import { ArrowRight, ArrowUpRight } from "lucide-react"
+import { ArrowUpRight, ChevronRight } from "lucide-react"
 
 export interface IExploreLinkItem {
   description: string
@@ -46,7 +46,7 @@ function ExploreLinks({
           {items.map((item) => (
             <li key={item.title}>
               <NextLink
-                className="group flex h-full flex-col rounded-xl border border-gray-20 bg-[#0B0C0E] p-5 transition-colors duration-300 hover:border-white/25 lg:p-6"
+                className="group flex h-full flex-col rounded-xl border border-gray-20 bg-[#0B0C0E] p-5 transition-colors duration-300 hover:border-gray-50 lg:p-6"
                 href={item.href}
                 data-click-location="notify_explore"
                 data-click-text={item.linkLabel}
@@ -57,10 +57,10 @@ function ExploreLinks({
                 <p className="mt-2 text-sm leading-normal font-normal tracking-tighter text-pretty text-gray-50">
                   {item.description}
                 </p>
-                <span className="mt-auto flex items-center gap-1.5 pt-4 text-sm leading-none font-medium tracking-tighter text-blue-1">
+                <span className="mt-auto flex w-fit items-center gap-1.5 pt-4 text-sm leading-none font-medium tracking-normal text-white">
                   {item.linkLabel}
-                  <ArrowRight
-                    className="size-3.5 transition-transform duration-300 group-hover:translate-x-0.5"
+                  <ChevronRight
+                    className="size-4 transition-transform duration-300 group-hover:translate-x-0.5"
                     aria-hidden
                   />
                 </span>
@@ -80,7 +80,7 @@ function ExploreLinks({
               {docsItems.map((item) => (
                 <li key={item.href}>
                   <NextLink
-                    className="group flex items-center gap-1.5 rounded-lg border border-gray-20 bg-[#0B0C0E] px-3.5 py-2.5 text-sm leading-none tracking-tighter text-gray-8 transition-colors duration-300 hover:border-white/25 hover:text-foreground"
+                    className="group flex items-center gap-1.5 rounded-lg border border-gray-20 bg-[#0B0C0E] px-3.5 py-2.5 text-sm leading-none tracking-tighter text-gray-8 transition-colors duration-300 hover:border-gray-50 hover:text-foreground"
                     href={item.href}
                     target="_blank"
                     rel="noopener noreferrer"

--- a/src/components/pages/notify/feature-split.tsx
+++ b/src/components/pages/notify/feature-split.tsx
@@ -1,0 +1,119 @@
+import Image, { type StaticImageData } from "next/image"
+import NextLink from "next/link"
+import { Check } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+
+export interface INotifyFeatureLink {
+  external?: boolean
+  href: string
+  label: string
+}
+
+export interface INotifyFeatureSplitProps {
+  bullets: string[]
+  description: string
+  image: StaticImageData
+  label?: string
+  linkClickLocation?: string
+  links?: INotifyFeatureLink[]
+  reverse?: boolean
+  title: string
+}
+
+function NotifyFeatureSplit({
+  bullets,
+  description,
+  image,
+  label,
+  linkClickLocation,
+  links,
+  reverse = false,
+  title,
+}: INotifyFeatureSplitProps) {
+  return (
+    <section className="mt-24 font-inter md:mt-28 lg:mt-32">
+      <div className="mx-auto grid w-full max-w-3xl grid-cols-1 items-center gap-10 px-5 md:px-8 lg:max-w-7xl lg:grid-cols-2 lg:gap-16">
+        <div className={cn(reverse && "lg:order-2")}>
+          {label && (
+            <Badge
+              className="mb-5 flex h-6 w-fit justify-center border-blue-3/40 bg-blue-3/30 px-2.5 py-1.25 text-sm leading-none tracking-tighter whitespace-nowrap text-blue-1"
+              size="sm"
+              variant="outline-muted"
+            >
+              {label}
+            </Badge>
+          )}
+
+          <h2 className="text-[2rem] leading-[1.125] font-normal tracking-[-0.04em] text-balance text-foreground md:text-[2.5rem]">
+            {title}
+          </h2>
+
+          <p className="mt-4 text-base leading-normal font-normal tracking-tighter text-pretty text-gray-60 md:text-lg">
+            {description}
+          </p>
+
+          <ul className="mt-6 flex flex-col gap-3">
+            {bullets.map((bullet) => (
+              <li
+                className="flex items-start gap-2.5 text-sm leading-normal tracking-tighter text-gray-50 md:text-base"
+                key={bullet}
+              >
+                <Check
+                  className="mt-0.75 size-4 shrink-0 text-blue-1"
+                  aria-hidden
+                />
+                {bullet}
+              </li>
+            ))}
+          </ul>
+
+          {links && links.length > 0 && (
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:gap-4">
+              {links.map((link) => (
+                <Button
+                  className="h-11 px-5 text-base leading-none tracking-tight normal-case max-sm:w-full"
+                  variant="outline-transparent"
+                  size="none"
+                  key={link.href}
+                  asChild
+                >
+                  <NextLink
+                    href={link.href}
+                    {...(link.external
+                      ? { target: "_blank", rel: "noopener noreferrer" }
+                      : {})}
+                    data-click-location={linkClickLocation}
+                    data-click-text={link.label}
+                  >
+                    {link.label}
+                  </NextLink>
+                </Button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div
+          className={cn(
+            "relative overflow-hidden rounded-xl border border-gray-20 bg-[#0B0C0E]",
+            reverse && "lg:order-1"
+          )}
+        >
+          <Image
+            className="h-auto w-full"
+            src={image}
+            alt=""
+            sizes="(min-width: 1024px) 608px, 100vw"
+            quality={100}
+            aria-hidden="true"
+          />
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default NotifyFeatureSplit

--- a/src/components/pages/notify/feature-split.tsx
+++ b/src/components/pages/notify/feature-split.tsx
@@ -1,10 +1,11 @@
 import Image, { type StaticImageData } from "next/image"
 import NextLink from "next/link"
-import { Check } from "lucide-react"
+import { Check, ChevronRight } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Link } from "@/components/ui/link"
 
 export interface INotifyFeatureLink {
   external?: boolean
@@ -70,43 +71,64 @@ function NotifyFeatureSplit({
             ))}
           </ul>
 
+          {/* Lead action is a button, anything after it is a chevron link, so
+              two equally-weighted buttons never sit side by side. Mirrors
+              ui/action-group.tsx. */}
           {links && links.length > 0 && (
-            <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:gap-4">
-              {links.map((link) => (
-                <Button
-                  className="h-11 px-5 text-base leading-none tracking-tight normal-case max-sm:w-full"
-                  variant="outline-transparent"
-                  size="none"
-                  key={link.href}
-                  asChild
+            <div className="mt-8 flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:gap-5">
+              <Button
+                className="h-11 px-5 text-base leading-none tracking-tight normal-case max-sm:w-full"
+                variant="outline"
+                size="none"
+                asChild
+              >
+                <NextLink
+                  href={links[0].href}
+                  {...(links[0].external
+                    ? { target: "_blank", rel: "noopener noreferrer" }
+                    : {})}
+                  data-click-location={linkClickLocation}
+                  data-click-text={links[0].label}
                 >
-                  <NextLink
-                    href={link.href}
-                    {...(link.external
-                      ? { target: "_blank", rel: "noopener noreferrer" }
-                      : {})}
-                    data-click-location={linkClickLocation}
-                    data-click-text={link.label}
-                  >
-                    {link.label}
-                  </NextLink>
-                </Button>
+                  {links[0].label}
+                </NextLink>
+              </Button>
+
+              {links.slice(1).map((link) => (
+                <Link
+                  className="w-fit shrink-0 gap-x-1 text-base leading-none tracking-tight"
+                  href={link.href}
+                  size="none"
+                  variant="foreground"
+                  animation="arrow-right"
+                  key={link.href}
+                  data-click-location={linkClickLocation}
+                  data-click-text={link.label}
+                >
+                  {link.label}
+                  <ChevronRight size={16} />
+                </Link>
               ))}
             </div>
           )}
         </div>
 
+        {/* These graphics are authored for the homepage bento: the artwork sits
+            in the top-centre of the canvas and the lower third is empty, because
+            there the card's own copy sits on top of it. Crop to the artwork the
+            same way the homepage does - oversize the image and anchor it to the
+            top centre - instead of letting the empty band pad out the frame. */}
         <div
           className={cn(
-            "relative overflow-hidden rounded-xl border border-gray-20 bg-[#0B0C0E]",
+            "relative aspect-8/5 overflow-hidden rounded-xl border border-gray-20 bg-[#0B0C0E]",
             reverse && "lg:order-1"
           )}
         >
           <Image
-            className="h-auto w-full"
+            className="absolute top-0 left-1/2 h-auto w-[150%] max-w-none -translate-x-1/2"
             src={image}
             alt=""
-            sizes="(min-width: 1024px) 608px, 100vw"
+            sizes="(min-width: 1024px) 912px, 150vw"
             quality={100}
             aria-hidden="true"
           />

--- a/src/components/pages/notify/hero.tsx
+++ b/src/components/pages/notify/hero.tsx
@@ -1,0 +1,165 @@
+import NextLink from "next/link"
+import { ROUTE } from "@/constants/routes"
+import { Bell } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { CopyCommand } from "@/components/ui/copy-command"
+import AnimatedCopyCheck from "@/components/pages/home/animated-copy-check"
+import BentoCardBackground, {
+  type BentoCardBackgroundImage,
+} from "@/components/pages/home/bento-card-background"
+import InboxComponent from "@/components/pages/home/code-with-inbox/inbox/inbox-component"
+import CopyPromptButton from "@/components/pages/home/copy-prompt-button"
+import MagicBento from "@/components/pages/home/magic-bento"
+import NotifyCodeTabs, {
+  type INotifyCodeTab,
+} from "@/components/pages/home/notify-code-tabs"
+
+interface INotifyHeroCard {
+  backgroundImage: BentoCardBackgroundImage
+  description: string
+  title: string
+}
+
+interface INotifyHeroProps {
+  card: INotifyHeroCard
+  codeTabs: INotifyCodeTab[]
+  command: string
+  description: string
+  label: string
+  prompt: string
+  title: string
+}
+
+function NotifyHero({
+  card,
+  codeTabs,
+  command,
+  description,
+  label,
+  prompt,
+  title,
+}: INotifyHeroProps) {
+  return (
+    <section
+      id="notify"
+      className="relative isolate scroll-mt-25 overflow-hidden px-5 pt-16 font-inter md:px-8 md:pt-24 lg:pt-33"
+    >
+      <div className="mx-auto flex w-full max-w-210.5 flex-col items-center text-center">
+        <Badge
+          className="mb-5 flex h-6 justify-center border-blue-3/40 bg-blue-3/30 px-2.5 py-1.25 text-sm leading-none tracking-tighter whitespace-nowrap text-blue-1"
+          size="sm"
+          variant="outline-muted"
+        >
+          {label}
+        </Badge>
+
+        <h1 className="w-full text-[2.5rem] leading-[1.125] font-normal tracking-plus-tight text-balance text-foreground md:text-[3.25rem] lg:text-[4rem]">
+          {title}
+        </h1>
+
+        <p className="mt-4 max-w-151.5 text-base font-normal tracking-tighter text-balance text-gray-60 lg:text-xl/normal">
+          {description}
+        </p>
+
+        <div className="mt-8 flex w-full flex-col items-center justify-center gap-4 sm:w-auto sm:flex-row sm:gap-5">
+          <Button
+            className="h-11 w-full max-w-xs px-5 text-base leading-none font-medium tracking-[-0.025em] normal-case sm:w-auto"
+            size="none"
+            asChild
+          >
+            <NextLink
+              href={ROUTE.dashboardV2SignUp}
+              target="_blank"
+              rel="noopener noreferrer"
+              data-click-location="notify_hero"
+              data-click-text="start_for_free"
+            >
+              Start for free
+            </NextLink>
+          </Button>
+          <CopyCommand
+            className="w-full max-w-xs sm:w-70.5"
+            controlClassName="pl-3"
+            command={command}
+            variant="highlighted"
+            copiedContent={<AnimatedCopyCheck />}
+          />
+          <CopyPromptButton
+            className="h-11 w-full max-w-xs px-5 text-base leading-none font-medium tracking-[-0.4px] normal-case sm:w-39 [&_svg]:!size-3.5"
+            variant="outline-transparent"
+            size="none"
+            resetInterval={2000}
+            value={prompt}
+          />
+        </div>
+      </div>
+
+      <MagicBento
+        className="relative mx-auto mt-12 w-full max-w-3xl md:mt-16 lg:max-w-7xl lg:mb-24 xl:mb-48"
+        particles={false}
+      >
+        <article className="magic-bento-card relative flex w-full flex-col overflow-hidden rounded-xl border border-gray-20 bg-[#0B0C0E] p-5 pb-0 md:block md:h-118 md:p-0">
+          <BentoCardBackground
+            backgroundClassName="opacity-80"
+            backgroundImage={card.backgroundImage}
+          />
+          <div className="relative flex min-w-0 flex-col md:contents">
+            <div className="relative z-30 max-w-[26.5625rem] md:absolute md:top-[27px] md:left-[27px]">
+              <h2 className="text-base leading-tight font-normal tracking-tighter text-foreground md:text-xl md:leading-none">
+                {card.title}
+              </h2>
+              <p className="mt-2.5 text-sm leading-normal font-normal tracking-tighter text-pretty text-gray-50 md:w-80 md:text-base xl:w-114">
+                {card.description}
+              </p>
+            </div>
+
+            <NotifyCodeTabs
+              className="relative z-10 mt-8 h-61 md:absolute md:bottom-0 md:left-7 md:mt-0 md:h-67 md:w-110 lg:w-124 xl:w-134"
+              tabs={codeTabs}
+            />
+          </div>
+        </article>
+
+        {/* The bell breaks out of the card's top edge; the open Inbox hangs
+            below its bottom edge, like a notification popover in a real app. */}
+        <span
+          className="notify-hero-bell absolute -top-5 right-8 z-20 hidden size-11 items-center justify-center rounded-full border border-gray-20 bg-[#101114] shadow-[0_8px_24px_rgba(0,0,0,0.6)] md:flex xl:right-14"
+          aria-hidden="true"
+        >
+          <Bell className="size-5 text-foreground" />
+          <span className="absolute -top-1 -right-1 flex size-4.5 items-center justify-center rounded-full bg-[#FB3748] text-[10px] leading-none font-medium text-white">
+            6
+          </span>
+        </span>
+
+        <InboxComponent
+          animateEntrance={false}
+          className="notify-live-inbox zoom-[0.85] xl:zoom-[0.98] absolute top-10 right-8 m-0 hidden lg:block xl:right-14"
+          themeTabsClassName="absolute top-40 left-7 m-0 hidden lg:flex"
+          variant="home"
+        />
+      </MagicBento>
+
+      <style>{`
+        @media (prefers-reduced-motion: no-preference) {
+          @keyframes notify-hero-bell-ring {
+            0%, 82%, 100% { transform: rotate(0deg); }
+            85% { transform: rotate(12deg); }
+            88% { transform: rotate(-10deg); }
+            91% { transform: rotate(7deg); }
+            94% { transform: rotate(-4deg); }
+            97% { transform: rotate(2deg); }
+          }
+          .notify-hero-bell svg {
+            animation: notify-hero-bell-ring 6s ease-in-out infinite;
+            transform-origin: 50% 0%;
+          }
+        }
+      `}</style>
+    </section>
+  )
+}
+
+export default NotifyHero

--- a/src/components/pages/notify/hero.tsx
+++ b/src/components/pages/notify/hero.tsx
@@ -1,20 +1,11 @@
-import NextLink from "next/link"
-import { ROUTE } from "@/constants/routes"
-import { Bell } from "lucide-react"
-
 import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
 import { CopyCommand } from "@/components/ui/copy-command"
 import AnimatedCopyCheck from "@/components/pages/home/animated-copy-check"
-import BentoCardBackground, {
-  type BentoCardBackgroundImage,
-} from "@/components/pages/home/bento-card-background"
-import InboxComponent from "@/components/pages/home/code-with-inbox/inbox/inbox-component"
+import type { BentoCardBackgroundImage } from "@/components/pages/home/bento-card-background"
 import CopyPromptButton from "@/components/pages/home/copy-prompt-button"
 import MagicBento from "@/components/pages/home/magic-bento"
-import NotifyCodeTabs, {
-  type INotifyCodeTab,
-} from "@/components/pages/home/notify-code-tabs"
+import type { INotifyCodeTab } from "@/components/pages/home/notify-code-tabs"
+import NotifyFeaturedCard from "@/components/pages/home/notify-featured-card"
 
 interface INotifyHeroCard {
   backgroundImage: BentoCardBackgroundImage
@@ -44,120 +35,59 @@ function NotifyHero({
   return (
     <section
       id="notify"
-      className="relative isolate scroll-mt-25 overflow-hidden px-5 pt-16 font-inter md:px-8 md:pt-24 lg:pt-33"
+      className="relative isolate scroll-mt-25 overflow-hidden pt-16 font-inter md:pt-24 lg:pt-33"
     >
-      <div className="mx-auto flex w-full max-w-210.5 flex-col items-center text-center">
-        <Badge
-          className="mb-5 flex h-6 justify-center border-blue-3/40 bg-blue-3/30 px-2.5 py-1.25 text-sm leading-none tracking-tighter whitespace-nowrap text-blue-1"
-          size="sm"
-          variant="outline-muted"
-        >
-          {label}
-        </Badge>
-
-        <h1 className="w-full text-[2.5rem] leading-[1.125] font-normal tracking-plus-tight text-balance text-foreground md:text-[3.25rem] lg:text-[4rem]">
-          {title}
-        </h1>
-
-        <p className="mt-4 max-w-151.5 text-base font-normal tracking-tighter text-balance text-gray-60 lg:text-xl/normal">
-          {description}
-        </p>
-
-        <div className="mt-8 flex w-full flex-col items-center justify-center gap-4 sm:w-auto sm:flex-row sm:gap-5">
-          <Button
-            className="h-11 w-full max-w-xs px-5 text-base leading-none font-medium tracking-[-0.025em] normal-case sm:w-auto"
-            size="none"
-            asChild
+      <div className="px-5 md:px-8">
+        <div className="mx-auto flex w-full max-w-210.5 flex-col items-center text-center">
+          <Badge
+            className="mb-5 flex h-6 justify-center border-blue-3/40 bg-blue-3/30 px-2.5 py-1.25 text-sm leading-none tracking-tighter whitespace-nowrap text-blue-1"
+            size="sm"
+            variant="outline-muted"
           >
-            <NextLink
-              href={ROUTE.dashboardV2SignUp}
-              target="_blank"
-              rel="noopener noreferrer"
-              data-click-location="notify_hero"
-              data-click-text="start_for_free"
-            >
-              Start for free
-            </NextLink>
-          </Button>
-          <CopyCommand
-            className="w-full max-w-xs sm:w-70.5"
-            controlClassName="pl-3"
-            command={command}
-            variant="highlighted"
-            copiedContent={<AnimatedCopyCheck />}
-          />
-          <CopyPromptButton
-            className="h-11 w-full max-w-xs px-5 text-base leading-none font-medium tracking-[-0.4px] normal-case sm:w-39 [&_svg]:!size-3.5"
-            variant="outline-transparent"
-            size="none"
-            resetInterval={2000}
-            value={prompt}
-          />
+            {label}
+          </Badge>
+
+          <h1 className="w-full text-[2.5rem] leading-[1.125] font-normal tracking-plus-tight text-balance text-foreground md:text-[3.25rem] lg:text-[4rem]">
+            {title}
+          </h1>
+
+          <p className="mt-4 max-w-151.5 text-base font-normal tracking-tighter text-balance text-gray-60 lg:text-xl/normal">
+            {description}
+          </p>
+
+          {/* Sign-up lives in the header ("Sign up now", same ROUTE), so the
+              hero keeps the homepage pair: install command + copy prompt. */}
+          <div className="mt-8 flex w-full flex-col items-center justify-center gap-4 sm:w-auto sm:flex-row sm:gap-5">
+            <CopyCommand
+              className="w-full sm:w-70.5"
+              controlClassName="pl-3"
+              command={command}
+              variant="highlighted"
+              copiedContent={<AnimatedCopyCheck />}
+            />
+            <CopyPromptButton
+              className="h-11 w-full px-5 text-base leading-none font-medium tracking-[-0.4px] normal-case sm:w-39 [&_svg]:!size-3.5"
+              variant="outline-transparent"
+              size="none"
+              resetInterval={2000}
+              value={prompt}
+            />
+          </div>
         </div>
       </div>
 
-      <MagicBento
-        className="relative mx-auto mt-12 w-full max-w-3xl md:mt-16 lg:max-w-7xl lg:mb-24 xl:mb-48"
-        particles={false}
-      >
-        <article className="magic-bento-card relative flex w-full flex-col overflow-hidden rounded-xl border border-gray-20 bg-[#0B0C0E] p-5 pb-0 md:block md:h-118 md:p-0">
-          <BentoCardBackground
-            backgroundClassName="opacity-80"
-            backgroundImage={card.backgroundImage}
+      {/* Same container as the homepage Novu Notify section and as every
+          section below, so the card lines up with the page's content grid. */}
+      <div className="mx-auto w-full max-w-3xl px-5 md:px-8 lg:max-w-7xl">
+        <MagicBento className="mt-12 md:mt-16" particles={false}>
+          <NotifyFeaturedCard
+            {...card}
+            codeTabs={codeTabs}
+            headingLevel="h2"
+            liveInbox
           />
-          <div className="relative flex min-w-0 flex-col md:contents">
-            <div className="relative z-30 max-w-[26.5625rem] md:absolute md:top-[27px] md:left-[27px]">
-              <h2 className="text-base leading-tight font-normal tracking-tighter text-foreground md:text-xl md:leading-none">
-                {card.title}
-              </h2>
-              <p className="mt-2.5 text-sm leading-normal font-normal tracking-tighter text-pretty text-gray-50 md:w-80 md:text-base xl:w-114">
-                {card.description}
-              </p>
-            </div>
-
-            <NotifyCodeTabs
-              className="relative z-10 mt-8 h-61 md:absolute md:bottom-0 md:left-7 md:mt-0 md:h-67 md:w-110 lg:w-124 xl:w-134"
-              tabs={codeTabs}
-            />
-          </div>
-        </article>
-
-        {/* The bell breaks out of the card's top edge; the open Inbox hangs
-            below its bottom edge, like a notification popover in a real app. */}
-        <span
-          className="notify-hero-bell absolute -top-5 right-8 z-20 hidden size-11 items-center justify-center rounded-full border border-gray-20 bg-[#101114] shadow-[0_8px_24px_rgba(0,0,0,0.6)] md:flex xl:right-14"
-          aria-hidden="true"
-        >
-          <Bell className="size-5 text-foreground" />
-          <span className="absolute -top-1 -right-1 flex size-4.5 items-center justify-center rounded-full bg-[#FB3748] text-[10px] leading-none font-medium text-white">
-            6
-          </span>
-        </span>
-
-        <InboxComponent
-          animateEntrance={false}
-          className="notify-live-inbox zoom-[0.85] xl:zoom-[0.98] absolute top-10 right-8 m-0 hidden lg:block xl:right-14"
-          themeTabsClassName="absolute top-40 left-7 m-0 hidden lg:flex"
-          variant="home"
-        />
-      </MagicBento>
-
-      <style>{`
-        @media (prefers-reduced-motion: no-preference) {
-          @keyframes notify-hero-bell-ring {
-            0%, 82%, 100% { transform: rotate(0deg); }
-            85% { transform: rotate(12deg); }
-            88% { transform: rotate(-10deg); }
-            91% { transform: rotate(7deg); }
-            94% { transform: rotate(-4deg); }
-            97% { transform: rotate(2deg); }
-          }
-          .notify-hero-bell svg {
-            animation: notify-hero-bell-ring 6s ease-in-out infinite;
-            transform-origin: 50% 0%;
-          }
-        }
-      `}</style>
+        </MagicBento>
+      </div>
     </section>
   )
 }

--- a/src/components/pages/notify/inbox-capabilities.tsx
+++ b/src/components/pages/notify/inbox-capabilities.tsx
@@ -1,0 +1,82 @@
+import NextLink from "next/link"
+import { ArrowUpRight } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+export interface IInboxCapability {
+  description: string
+  href?: string
+  linkLabel?: string
+  title: string
+}
+
+interface IInboxCapabilitiesProps {
+  className?: string
+  items: IInboxCapability[]
+}
+
+function CapabilityCardBody({ item }: { item: IInboxCapability }) {
+  return (
+    <>
+      <h3 className="text-base leading-tight font-medium tracking-tighter text-foreground">
+        {item.title}
+      </h3>
+      <p className="mt-2 text-sm leading-normal font-normal tracking-tighter text-pretty text-gray-50">
+        {item.description}
+      </p>
+      {item.href && item.linkLabel && (
+        <span className="mt-auto flex items-center gap-1 pt-4 text-sm leading-none font-medium tracking-tighter text-blue-1">
+          {item.linkLabel}
+          <ArrowUpRight
+            className="size-3.5 transition-transform duration-300 group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
+            aria-hidden
+          />
+        </span>
+      )}
+    </>
+  )
+}
+
+function InboxCapabilities({ className, items }: IInboxCapabilitiesProps) {
+  if (!items || items.length === 0) {
+    return null
+  }
+
+  const cardClassName =
+    "flex h-full flex-col rounded-xl border border-gray-20 bg-[#0B0C0E] p-5 lg:p-6"
+
+  return (
+    <ul
+      className={cn(
+        "grid grid-cols-1 gap-5 font-inter sm:grid-cols-2 lg:grid-cols-3",
+        className
+      )}
+    >
+      {items.map((item) => (
+        <li key={item.title}>
+          {item.href ? (
+            <NextLink
+              className={cn(
+                cardClassName,
+                "group transition-colors duration-300 hover:border-white/25"
+              )}
+              href={item.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              data-click-location="notify_inbox_capabilities"
+              data-click-text={item.linkLabel}
+            >
+              <CapabilityCardBody item={item} />
+            </NextLink>
+          ) : (
+            <div className={cardClassName}>
+              <CapabilityCardBody item={item} />
+            </div>
+          )}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+export default InboxCapabilities

--- a/src/components/pages/notify/inbox-capabilities.tsx
+++ b/src/components/pages/notify/inbox-capabilities.tsx
@@ -25,10 +25,13 @@ function CapabilityCardBody({ item }: { item: IInboxCapability }) {
         {item.description}
       </p>
       {item.href && item.linkLabel && (
-        <span className="mt-auto flex items-center gap-1 pt-4 text-sm leading-none font-medium tracking-tighter text-blue-1">
+        // Matches the case-study link in components/pages/home/featured-customers:
+        // white label, canonical chevron nudged on hover. The whole card is the
+        // link, so the nudge hangs off `group-hover`.
+        <span className="mt-auto flex w-fit items-center gap-1.5 pt-4 text-sm leading-none font-medium tracking-normal text-white">
           {item.linkLabel}
           <ArrowUpRight
-            className="size-3.5 transition-transform duration-300 group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
+            className="size-4 transition-transform duration-300 group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
             aria-hidden
           />
         </span>
@@ -58,7 +61,7 @@ function InboxCapabilities({ className, items }: IInboxCapabilitiesProps) {
             <NextLink
               className={cn(
                 cardClassName,
-                "group transition-colors duration-300 hover:border-white/25"
+                "group transition-colors duration-300 hover:border-gray-50"
               )}
               href={item.href}
               target="_blank"

--- a/src/components/pages/notify/inbox-section.tsx
+++ b/src/components/pages/notify/inbox-section.tsx
@@ -1,7 +1,9 @@
 import NextLink from "next/link"
 import { ROUTE } from "@/constants/routes"
+import { ChevronRight } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
+import { Link } from "@/components/ui/link"
 import CopyPromptButton from "@/components/pages/home/copy-prompt-button"
 
 import InboxCapabilities, { type IInboxCapability } from "./inbox-capabilities"
@@ -27,12 +29,30 @@ function InboxSection({
             {title}
           </h2>
 
-          <div className="mt-4 grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,40.3125rem)_18.125rem] lg:items-start lg:justify-between lg:gap-12">
+          {/* Two buttons max, primary + secondary, with any further action
+              demoted to a chevron link - the rule ui/action-group.tsx encodes
+              and the mcp/copilot heroes follow. Bottom-aligned to the
+              description like the featured-customers header. */}
+          <div className="mt-4 grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,40.3125rem)_auto] lg:items-end lg:justify-between lg:gap-12">
+            {/* "Read docs" rides at the end of the copy instead of becoming a
+                third button, leaving one primary + one secondary in the row. */}
             <p className="max-w-161 text-base leading-normal font-normal tracking-tighter text-pretty text-gray-60 md:text-lg xl:text-xl xl:leading-[1.5]">
-              {description}
+              {description}{" "}
+              <Link
+                className="gap-x-1 align-baseline"
+                href={ROUTE.docsInApp as string}
+                size="none"
+                variant="foreground"
+                animation="arrow-right"
+                data-click-location="notify_inbox_section"
+                data-click-text="read_docs"
+              >
+                Read docs
+                <ChevronRight size={16} />
+              </Link>
             </p>
 
-            <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:gap-4 lg:justify-self-end lg:pt-2">
+            <div className="flex w-full flex-col items-start gap-4 sm:w-auto sm:flex-row sm:items-center sm:gap-5 lg:justify-self-end">
               <CopyPromptButton
                 className="h-11 w-full px-5 text-base leading-none tracking-tight normal-case sm:w-39 [&_svg]:!size-3.5"
                 size="sm"
@@ -40,7 +60,7 @@ function InboxSection({
               />
               <Button
                 className="h-11 w-full px-5 text-base leading-none tracking-tight normal-case sm:w-auto"
-                variant="outline-transparent"
+                variant="outline"
                 size="sm"
                 asChild
               >
@@ -50,20 +70,6 @@ function InboxSection({
                   data-click-text="explore_inbox"
                 >
                   Explore Inbox
-                </NextLink>
-              </Button>
-              <Button
-                className="h-11 w-full px-5 text-base leading-none tracking-tight normal-case sm:w-29.5"
-                variant="outline-transparent"
-                size="sm"
-                asChild
-              >
-                <NextLink
-                  href={ROUTE.docsInApp}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Read docs
                 </NextLink>
               </Button>
             </div>

--- a/src/components/pages/notify/inbox-section.tsx
+++ b/src/components/pages/notify/inbox-section.tsx
@@ -1,0 +1,79 @@
+import NextLink from "next/link"
+import { ROUTE } from "@/constants/routes"
+
+import { Button } from "@/components/ui/button"
+import CopyPromptButton from "@/components/pages/home/copy-prompt-button"
+
+import InboxCapabilities, { type IInboxCapability } from "./inbox-capabilities"
+
+interface IInboxSectionProps {
+  capabilities: IInboxCapability[]
+  description: string
+  prompt: string
+  title: string
+}
+
+function InboxSection({
+  capabilities,
+  description,
+  prompt,
+  title,
+}: IInboxSectionProps) {
+  return (
+    <section className="mt-24 font-inter md:mt-28 lg:mt-32">
+      <div className="mx-auto w-full max-w-3xl px-5 md:px-8 lg:max-w-7xl">
+        <header>
+          <h2 className="max-w-168 text-[2rem] leading-[1.125] font-normal tracking-[-0.04em] text-balance text-foreground md:text-5xl xl:text-[3.25rem]">
+            {title}
+          </h2>
+
+          <div className="mt-4 grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,40.3125rem)_18.125rem] lg:items-start lg:justify-between lg:gap-12">
+            <p className="max-w-161 text-base leading-normal font-normal tracking-tighter text-pretty text-gray-60 md:text-lg xl:text-xl xl:leading-[1.5]">
+              {description}
+            </p>
+
+            <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:gap-4 lg:justify-self-end lg:pt-2">
+              <CopyPromptButton
+                className="h-11 w-full px-5 text-base leading-none tracking-tight normal-case sm:w-39 [&_svg]:!size-3.5"
+                size="sm"
+                value={prompt}
+              />
+              <Button
+                className="h-11 w-full px-5 text-base leading-none tracking-tight normal-case sm:w-auto"
+                variant="outline-transparent"
+                size="sm"
+                asChild
+              >
+                <NextLink
+                  href={ROUTE.inbox}
+                  data-click-location="notify_inbox_section"
+                  data-click-text="explore_inbox"
+                >
+                  Explore Inbox
+                </NextLink>
+              </Button>
+              <Button
+                className="h-11 w-full px-5 text-base leading-none tracking-tight normal-case sm:w-29.5"
+                variant="outline-transparent"
+                size="sm"
+                asChild
+              >
+                <NextLink
+                  href={ROUTE.docsInApp}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Read docs
+                </NextLink>
+              </Button>
+            </div>
+          </div>
+        </header>
+
+        <InboxCapabilities className="mt-12 md:mt-16" items={capabilities} />
+      </div>
+    </section>
+  )
+}
+
+export default InboxSection

--- a/src/components/pages/notify/providers-section.tsx
+++ b/src/components/pages/notify/providers-section.tsx
@@ -1,0 +1,114 @@
+import Image from "next/image"
+import NextLink from "next/link"
+import { ROUTE } from "@/constants/routes"
+
+import type { IIntegration } from "@/types/integration"
+import { Button } from "@/components/ui/button"
+
+interface IProvidersSectionProps {
+  categoryLabels: Record<string, string>
+  description: string
+  providersByCategory: Record<string, IIntegration[]>
+  title: string
+}
+
+function ProvidersSection({
+  categoryLabels,
+  description,
+  providersByCategory,
+  title,
+}: IProvidersSectionProps) {
+  const categories = Object.keys(categoryLabels).filter(
+    (category) => providersByCategory[category]?.length
+  )
+
+  if (categories.length === 0) {
+    return null
+  }
+
+  return (
+    <section className="mt-24 font-inter md:mt-28 lg:mt-32">
+      <div className="mx-auto w-full max-w-3xl px-5 md:px-8 lg:max-w-7xl">
+        <h2 className="max-w-168 text-[2rem] leading-[1.125] font-normal tracking-[-0.04em] text-balance text-foreground md:text-5xl xl:text-[3.25rem]">
+          {title}
+        </h2>
+
+        <div className="mt-4 grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,40.3125rem)_auto] lg:items-start lg:justify-between lg:gap-12">
+          <p className="max-w-161 text-base leading-normal font-normal tracking-tighter text-pretty text-gray-60 md:text-lg xl:text-xl xl:leading-[1.5]">
+            {description}
+          </p>
+
+          <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:gap-4 lg:justify-self-end lg:pt-2">
+            <Button
+              className="h-11 w-full px-5 text-base leading-none tracking-tight normal-case sm:w-auto"
+              variant="outline-transparent"
+              size="sm"
+              asChild
+            >
+              <NextLink
+                href={ROUTE.integrationsChannels}
+                data-click-location="notify_providers"
+                data-click-text="browse_all_integrations"
+              >
+                Browse all integrations
+              </NextLink>
+            </Button>
+            <Button
+              className="h-11 w-full px-5 text-base leading-none tracking-tight normal-case sm:w-auto"
+              variant="outline-transparent"
+              size="sm"
+              asChild
+            >
+              <NextLink
+                href={ROUTE.docsProviders}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Provider docs
+              </NextLink>
+            </Button>
+          </div>
+        </div>
+
+        <div className="mt-12 flex flex-col gap-8 md:mt-16">
+          {categories.map((category) => (
+            <div
+              className="grid grid-cols-1 gap-3 md:grid-cols-[6.5rem_minmax(0,1fr)] md:gap-6"
+              key={category}
+            >
+              <h3 className="pt-2 text-sm leading-none font-normal tracking-normal text-gray-50 uppercase">
+                {categoryLabels[category]}
+              </h3>
+              <ul className="flex flex-wrap gap-2.5">
+                {providersByCategory[category].map((provider) => (
+                  <li key={provider.slug}>
+                    <NextLink
+                      className="flex items-center gap-2.5 rounded-lg border border-gray-20 bg-[#0B0C0E] py-2 pr-3.5 pl-2.5 transition-colors duration-300 hover:border-white/25"
+                      href={provider.pathname}
+                      data-click-location="notify_providers"
+                      data-click-text={provider.slug}
+                    >
+                      <Image
+                        src={provider.icon}
+                        alt=""
+                        width={20}
+                        height={20}
+                        className="size-5 object-contain"
+                        aria-hidden="true"
+                      />
+                      <span className="text-sm leading-none tracking-tighter text-gray-8">
+                        {provider.title}
+                      </span>
+                    </NextLink>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default ProvidersSection

--- a/src/components/pages/notify/providers-section.tsx
+++ b/src/components/pages/notify/providers-section.tsx
@@ -1,9 +1,11 @@
 import Image from "next/image"
 import NextLink from "next/link"
 import { ROUTE } from "@/constants/routes"
+import { ChevronRight } from "lucide-react"
 
 import type { IIntegration } from "@/types/integration"
 import { Button } from "@/components/ui/button"
+import { Link } from "@/components/ui/link"
 
 interface IProvidersSectionProps {
   categoryLabels: Record<string, string>
@@ -33,15 +35,15 @@ function ProvidersSection({
           {title}
         </h2>
 
-        <div className="mt-4 grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,40.3125rem)_auto] lg:items-start lg:justify-between lg:gap-12">
+        <div className="mt-4 grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,40.3125rem)_auto] lg:items-end lg:justify-between lg:gap-12">
           <p className="max-w-161 text-base leading-normal font-normal tracking-tighter text-pretty text-gray-60 md:text-lg xl:text-xl xl:leading-[1.5]">
             {description}
           </p>
 
-          <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:gap-4 lg:justify-self-end lg:pt-2">
+          <div className="flex w-full flex-col items-start gap-4 sm:w-auto sm:flex-row sm:items-center sm:gap-5 lg:justify-self-end">
             <Button
               className="h-11 w-full px-5 text-base leading-none tracking-tight normal-case sm:w-auto"
-              variant="outline-transparent"
+              variant="outline"
               size="sm"
               asChild
             >
@@ -53,20 +55,18 @@ function ProvidersSection({
                 Browse all integrations
               </NextLink>
             </Button>
-            <Button
-              className="h-11 w-full px-5 text-base leading-none tracking-tight normal-case sm:w-auto"
-              variant="outline-transparent"
-              size="sm"
-              asChild
+            <Link
+              className="w-fit shrink-0 gap-x-1 text-base leading-none tracking-tight"
+              href={ROUTE.docsProviders as string}
+              size="none"
+              variant="foreground"
+              animation="arrow-right"
+              data-click-location="notify_providers"
+              data-click-text="provider_docs"
             >
-              <NextLink
-                href={ROUTE.docsProviders}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Provider docs
-              </NextLink>
-            </Button>
+              Provider docs
+              <ChevronRight size={16} />
+            </Link>
           </div>
         </div>
 
@@ -83,7 +83,7 @@ function ProvidersSection({
                 {providersByCategory[category].map((provider) => (
                   <li key={provider.slug}>
                     <NextLink
-                      className="flex items-center gap-2.5 rounded-lg border border-gray-20 bg-[#0B0C0E] py-2 pr-3.5 pl-2.5 transition-colors duration-300 hover:border-white/25"
+                      className="flex items-center gap-2.5 rounded-lg border border-gray-20 bg-[#0B0C0E] py-2 pr-3.5 pl-2.5 transition-colors duration-300 hover:border-gray-50"
                       href={provider.pathname}
                       data-click-location="notify_providers"
                       data-click-text={provider.slug}

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -29,6 +29,7 @@ export const ROUTE: Record<string, Route<string> | URL> = {
   copilot: "/copilot",
   mcp: "/mcp",
   aci: "/aci",
+  notify: "/notify",
 
   // Per-channel Novu Connect landing pages
   channelSlack: "/channels/slack",
@@ -136,9 +137,19 @@ export const ROUTE: Record<string, Route<string> | URL> = {
   docsContentManagement:
     "https://docs.novu.co/platform/workflow/add-notification-content/channels-template-editors",
   docsCustomCode: "https://docs.novu.co/agents/get-started/what-is-aci",
+  docsDigest: "https://docs.novu.co/platform/workflow/digest",
   docsFramework: "https://docs.novu.co/framework/introduction",
   docsGuides: "https://docs.novu.co/guides",
   docsInApp: "https://docs.novu.co/platform/inbox",
+  docsInboxLocalization:
+    "https://docs.novu.co/platform/inbox/advanced-features/localization",
+  docsInboxPreferences:
+    "https://docs.novu.co/platform/inbox/configuration/preferences",
+  docsInboxSetup: "https://docs.novu.co/platform/inbox/setup-inbox",
+  docsInboxSnooze: "https://docs.novu.co/platform/inbox/features/snooze",
+  docsInboxStyling:
+    "https://docs.novu.co/platform/inbox/configuration/styling",
+  docsInboxTabs: "https://docs.novu.co/platform/inbox/configuration/tabs",
   docsMcp: "https://docs.novu.co/platform/additional-resources/mcp",
   docsNotifications: "https://docs.novu.co/platform/sdks/react",
   docsOverview: "https://docs.novu.co/platform",
@@ -147,6 +158,7 @@ export const ROUTE: Record<string, Route<string> | URL> = {
   docsQuickStart:
     "https://docs.novu.co/platform/quickstart/nextjs?utm_campaign=website",
   docsSdks: "https://docs.novu.co/platform/sdks",
+  docsSelfHosting: "https://docs.novu.co/community/self-hosting-novu/overview",
   docsUserPreferences:
     "https://docs.novu.co/platform/sdks/react/hooks/use-preferences",
   docsWorkflow: "https://docs.novu.co/platform/workflow",

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -147,8 +147,7 @@ export const ROUTE: Record<string, Route<string> | URL> = {
     "https://docs.novu.co/platform/inbox/configuration/preferences",
   docsInboxSetup: "https://docs.novu.co/platform/inbox/setup-inbox",
   docsInboxSnooze: "https://docs.novu.co/platform/inbox/features/snooze",
-  docsInboxStyling:
-    "https://docs.novu.co/platform/inbox/configuration/styling",
+  docsInboxStyling: "https://docs.novu.co/platform/inbox/configuration/styling",
   docsInboxTabs: "https://docs.novu.co/platform/inbox/configuration/tabs",
   docsMcp: "https://docs.novu.co/platform/additional-resources/mcp",
   docsNotifications: "https://docs.novu.co/platform/sdks/react",

--- a/src/constants/seo-data.ts
+++ b/src/constants/seo-data.ts
@@ -41,6 +41,12 @@ export const SEO_DATA = {
     description: `Join the team creating open-source notification infrastructure for developers, product teams, and the millions of users they reach.`,
     pathname: ROUTE.careers as string,
   },
+  notify: {
+    title: `Novu Notify | Notification Infrastructure with Inbox and Digest | ${config.projectName}`,
+    description:
+      "Novu Notify is open-source notification infrastructure: a prebuilt in-app Inbox, digests, user-controlled preferences, and one workflow across email, SMS, push, and chat. Install with npm install @novu/react.",
+    pathname: ROUTE.notify as string,
+  },
   pricing: {
     title: `Pricing | ${config.projectName}`,
     description: `Flexible pricing for companies and developers`,

--- a/src/data/pages/notify.ts
+++ b/src/data/pages/notify.ts
@@ -1,0 +1,289 @@
+import { ROUTE } from "@/constants/routes"
+
+import type { IFaqSection } from "@/types/common"
+
+// Single source of truth for the /notify landing page copy. The page
+// (app/(website)/(connect-footer)/notify/page.tsx) and its JSON-LD read from
+// here so the two surfaces cannot drift.
+
+export const NOTIFY_COMMAND = "npm i @novu/react"
+
+export const NOTIFY_PROMPT =
+  "Add Novu Notify to my application. Configure an in-app notification inbox, multi-channel delivery, and user-controlled notification preferences. Follow the instructions on https://novu.co/llms.txt"
+
+export const NOTIFY_INBOX_PROMPT =
+  "Add the Novu Inbox component to my app for real-time in-app notifications with user preferences. Follow the instructions on https://novu.co/llms.txt"
+
+export const NOTIFY_HERO = {
+  label: "Novu Notify",
+  title: "The notification infrastructure 40,000 developers trust",
+  description:
+    "Add an <Inbox /> to your product by end of day. Start sending notifications across every channel with one API tomorrow. Simple.",
+}
+
+export const NOTIFY_INBOX_SECTION = {
+  title: "The Inbox your users already know how to use",
+  description:
+    "Drop the prebuilt Inbox component into your app: real-time notifications, read states, and preferences that match your existing UI. Delivered by Novu directly, no provider to configure.",
+  featured: {
+    title: "Fits perfectly into your app",
+    description:
+      "Deliver a rich in-app notification experience that mirrors your existing UX, not an afterthought or a bolt-on.",
+  },
+  capabilities: [
+    {
+      title: "Prebuilt and composable",
+      description:
+        "Ship the full Inbox in minutes or compose your own from primitives.",
+      href: String(ROUTE.docsInboxSetup),
+      linkLabel: "Set up the Inbox",
+    },
+    {
+      title: "Real-time, with unread counts",
+      description:
+        "New notifications appear instantly and badges stay accurate.",
+      href: String(ROUTE.docsNotifications),
+      linkLabel: "React SDK docs",
+    },
+    {
+      title: "Tabs, filters, and layouts",
+      description: "Organize notifications by project, severity, or team.",
+      href: String(ROUTE.docsInboxTabs),
+      linkLabel: "Configure tabs",
+    },
+    {
+      title: "Read states, archiving, snoozing",
+      description: "State syncs across every open tab and device.",
+      href: String(ROUTE.docsInboxSnooze),
+      linkLabel: "Snooze docs",
+    },
+    {
+      title: "Custom styling and localization",
+      description:
+        "Match your design system and ship in your users' languages.",
+      href: String(ROUTE.docsInboxStyling),
+      linkLabel: "Styling docs",
+    },
+    {
+      title: "Preferences built in",
+      description: "Per-channel controls users manage right inside the Inbox.",
+      href: String(ROUTE.docsInboxPreferences),
+      linkLabel: "Preferences docs",
+    },
+  ],
+}
+
+export const NOTIFY_FEATURE_SECTIONS = [
+  {
+    key: "digest",
+    label: "Digest",
+    title: "Five events. One notification.",
+    description:
+      "A digest collects events over a window, groups them per subscriber, and sends one summary instead of a burst of pings. Your workflow continues once per window, with every collected event available to the message content.",
+    bullets: [
+      "Timed, scheduled, or custom digest windows",
+      "Group events with a digest key: per user, per project, per account",
+      "Aggregated events available as variables in your templates",
+      "Rate limits cap how often anyone gets pinged",
+    ],
+    links: [
+      {
+        label: "Explore Digest",
+        href: String(ROUTE.digest),
+      },
+      {
+        label: "Read the digest docs",
+        href: String(ROUTE.docsDigest),
+        external: true,
+      },
+    ],
+  },
+  {
+    key: "preferences",
+    label: "Preferences",
+    title: "Users choose what reaches them",
+    description:
+      "Let people choose what they receive, when, and where, with quiet hours and snooze built in. Preferences apply across every channel automatically, so respecting them takes zero extra code.",
+    bullets: [
+      "Per-workflow and per-channel opt-in and opt-out",
+      "Quiet hours and snooze built in",
+      "A ready preferences UI inside the Inbox component",
+      "Defaults you control, overrides your users control",
+    ],
+    links: [
+      {
+        label: "Read the preferences docs",
+        href: String(ROUTE.docsInboxPreferences),
+        external: true,
+      },
+      {
+        label: "usePreferences hook",
+        href: String(ROUTE.docsUserPreferences),
+        external: true,
+      },
+    ],
+  },
+  {
+    key: "workflows",
+    label: "Workflows",
+    title: "Trigger once. Reach every channel.",
+    description:
+      "Define a workflow once and Novu handles routing, conditions, delays, and fallbacks across in-app, email, SMS, push, and chat. Connect your existing providers through the Integration Store and keep one API in your code.",
+    bullets: [
+      "In-app Inbox, email, SMS, push, and chat from one trigger",
+      "Conditions, delays, and fallback steps without extra code",
+      "Works with your existing providers through the Integration Store",
+      "Update workflow content without redeploying your app",
+    ],
+    links: [
+      {
+        label: "Explore Novu Framework",
+        href: String(ROUTE.framework),
+      },
+      {
+        label: "Read the workflow docs",
+        href: String(ROUTE.docsWorkflow),
+        external: true,
+      },
+    ],
+  },
+]
+
+export const NOTIFY_EXPLORE = {
+  title: "Go deeper on every piece",
+  description:
+    "Each part of the notification stack has its own page. Pick the one you need next.",
+  items: [
+    {
+      title: "Inbox Component",
+      description:
+        "The prebuilt in-app notification center: theming, tabs, preferences, and framework guides.",
+      href: String(ROUTE.inbox),
+      linkLabel: "Explore Inbox",
+    },
+    {
+      title: "Digest",
+      description:
+        "How digests batch many events into one notification, with strategies and configuration examples.",
+      href: String(ROUTE.digest),
+      linkLabel: "Explore Digest",
+    },
+    {
+      title: "Framework",
+      description:
+        "Define workflows in code with type-safe steps, local development, and version control.",
+      href: String(ROUTE.framework),
+      linkLabel: "Explore Framework",
+    },
+    {
+      title: "Integrations",
+      description:
+        "Every email, SMS, push, and chat provider Novu connects to through the Integration Store.",
+      href: String(ROUTE.integrations),
+      linkLabel: "Browse integrations",
+    },
+    {
+      title: "Pricing",
+      description:
+        "Start free on the open-source core or Novu Cloud, and pay as your volume grows.",
+      href: String(ROUTE.pricing),
+      linkLabel: "See pricing",
+    },
+    {
+      title: "Novu Connect",
+      description:
+        "The other half of Novu: two-way conversations between your AI agents and your users.",
+      href: String(ROUTE.connect),
+      linkLabel: "Explore Connect",
+    },
+  ],
+  docsTitle: "Developer docs",
+  docsItems: [
+    {
+      title: "Quickstart",
+      href: String(ROUTE.docsQuickStart),
+    },
+    {
+      title: "API reference",
+      href: String(ROUTE.docsApis),
+    },
+    {
+      title: "SDKs",
+      href: String(ROUTE.docsSdks),
+    },
+    {
+      title: "Content editors",
+      href: String(ROUTE.docsContentManagement),
+    },
+    {
+      title: "Novu Framework",
+      href: String(ROUTE.docsFramework),
+    },
+    {
+      title: "Self-hosting",
+      href: String(ROUTE.docsSelfHosting),
+    },
+  ],
+}
+
+export const NOTIFY_PROVIDERS_SECTION = {
+  title: "Your providers, one workflow layer",
+  description:
+    "Novu orchestrates, your providers deliver. Connect the email, SMS, push, and chat providers you already pay for through the Integration Store, and swap them without changing your code.",
+  categoryLabels: {
+    email: "Email",
+    sms: "SMS",
+    push: "Push",
+    chat: "Chat",
+  } as Record<string, string>,
+}
+
+export const NOTIFY_FAQ = {
+  title: "Frequently asked questions",
+  accordion: {
+    items: [
+      {
+        question: "What is Novu Notify?",
+        answer:
+          "Novu Notify is open-source notification infrastructure for your product. It gives you a prebuilt in-app Inbox component, a workflow engine with digests, delays, and fallbacks, user-controlled preferences, and delivery across email, SMS, push, and chat through one API.",
+      },
+      {
+        question:
+          "What is the difference between Novu Notify and Novu Connect?",
+        answer:
+          "Novu Notify handles workflow-driven notifications from your product to your users. Novu Connect handles two-way conversations between AI agents and people. Both use Novu's channel, identity, and delivery infrastructure.",
+      },
+      {
+        question: "Do I need to replace my email, SMS, or push provider?",
+        answer:
+          "No. Connect your provider accounts through the Novu Integration Store. Novu gives your application one workflow and API layer while the configured provider handles delivery. You can also configure multiple integrations and use provider-specific settings where required.",
+      },
+      {
+        question: "How does the digest work?",
+        answer:
+          "A digest step collects trigger events over a window you define, groups them per subscriber (and optionally by a digest key such as a project or account), then continues the workflow once per window. Every collected event is available to your message content, so you can send one summary instead of many notifications.",
+      },
+      {
+        question: "Can users control what notifications they receive?",
+        answer:
+          "Yes. Subscribers get per-workflow and per-channel preferences, with quiet hours and snooze built in. The Inbox component ships with a ready preferences UI, and preferences are enforced by Novu automatically across every channel.",
+      },
+      {
+        question: "Which frameworks does the Inbox component support?",
+        answer:
+          "Novu ships prebuilt Inbox components for React, Next.js, and Remix, with full control over styling and behavior. For everything else, the API and SDKs let you build a custom notification center on the same infrastructure.",
+      },
+      {
+        question: "Can I self-host Novu Notify?",
+        answer:
+          "Novu Community Edition can be self-hosted for core notification infrastructure, including Inbox, email, SMS, push, and chat. Novu Cloud adds managed and enterprise capabilities.",
+      },
+    ],
+  },
+} satisfies IFaqSection
+
+export const NOTIFY_CTA = {
+  title: "Start sending notifications today",
+  description:
+    "Create a free account, add the Inbox, and trigger your first workflow today. Open source at the core, one API across every channel.",
+}

--- a/src/data/pages/notify.ts
+++ b/src/data/pages/notify.ts
@@ -117,7 +117,9 @@ export const NOTIFY_FEATURE_SECTIONS = [
         external: true,
       },
       {
-        label: "usePreferences hook",
+        // Reads as a destination rather than a bare identifier, matching the
+        // "React SDK docs" capability card.
+        label: "usePreferences hook docs",
         href: String(ROUTE.docsUserPreferences),
         external: true,
       },


### PR DESCRIPTION
## What

A dedicated self-serve landing page for **Novu Notify** at `/notify`, parallel to `/connect` for Novu Connect. Draft for the Pixel Point team to take a design pass on; the structure, copy, and links are ready to build on.

## Page structure

1. **Hero**: "The notification infrastructure 40,000 developers trust" with three CTAs: **Start for free** (dashboard sign-up), copyable **`npm i @novu/react`**, and **Copy prompt** (coding-agent prompt pointing at llms.txt).
2. **Bell + Inbox breakout**: a floating notification bell with an unread badge breaks out of the featured card's top edge; the live interactive Inbox component hangs below the card's bottom edge like a real popover. Novu dark/light theme toggle and Next.js/Remix/React code tabs included (reuses the homepage bento pieces).
3. **Trusted-by logos** (shared component).
4. **Inbox section**: header with Copy prompt / Explore Inbox / Read docs, plus six capability cards each deep-linking to a verified docs page (setup, React SDK, tabs, snooze, styling, preferences).
5. **Deep-dive splits**: Digest ("Five events. One notification."), Preferences, Workflows, each with bullets and page + docs links, using the homepage novu-notify graphics.
6. **Providers section**: all 54 channel providers rendered from the Integration Store content registry (`getIntegrationsByTab`), grouped Email / SMS / Push / Chat, each logo chip linking to its `/integrations/<slug>` page. New providers appear automatically.
7. **Customers + "Go deeper" cross-links** (/inbox, /digest, /framework, /integrations, /pricing, /connect) + a **Developer docs** pill row (Quickstart, API reference, SDKs, Content editors, Framework, Self-hosting).
8. **Compliance, Notify-specific FAQ (with FAQPage JSON-LD), final CTA** with the npm command + prompt.

## Notes for the design pass

- The hero bell/popover composition is the intended story (bell in any app opens this Inbox); sizing and breakpoints are functional but deserve design attention. Inbox pops out at lg/xl, hides below lg; bell shows md+.
- Provider chip density and the capability-card grid are unstyled-but-consistent with the homepage bento; restyle freely.
- All docs URLs were verified live against docs.novu.co before linking.
- Every link carries `data-click-location`/`data-click-text` for analytics.
- Not included on purpose: header menu entry and homepage cross-links (separate follow-up), OG image for /notify (uses default), and the /notify.md markdown alternate.

## Verification

- `tsc --noEmit` and ESLint clean on this branch (off latest `main`).
- Page smoke-tested with `next dev`: renders 200 with all sections at 1440 / 1100 / 390 widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)