### PR TITLE
feat(home): sharpen FAQ opener and add ACI definition question

### DIFF
--- a/src/data/pages/home.ts
+++ b/src/data/pages/home.ts
@@ -417,13 +417,18 @@ export const HOME_FAQ = {
       {
         question: "What is Novu?",
         answer:
-          "Novu is open-source communication infrastructure for products and AI agents. Use Novu Notify to orchestrate product notifications across Inbox, email, SMS, push, and chat. Use Novu Connect to bring AI agents into the channels where users already communicate.",
+          "Novu is open-source communication infrastructure for products and AI agents. Novu Notify sends product notifications across Inbox, email, SMS, push, and chat. Novu Connect lets AI agents talk with users on the channels they already use, such as Slack, Microsoft Teams, WhatsApp, Telegram, and email.",
       },
       {
         question:
           "What is the difference between Novu Notify and Novu Connect?",
         answer:
           "Novu Notify handles workflow-driven notifications from your product to your users. Novu Connect handles two-way conversations between AI agents and people. Both use Novu's channel, identity, and delivery infrastructure.",
+      },
+      {
+        question: "What is ACI, Agent Communication Infrastructure?",
+        answer:
+          "ACI, Agent Communication Infrastructure, is the layer that connects AI agents to the channels people already use. It handles message delivery, threading, conversation state, user identity, and human approvals, while your agent keeps its own model, tools, and logic. Novu Connect is Novu's ACI.",
       },
       {
         question: "Can I connect an AI agent I have already built?",


### PR DESCRIPTION
## What

Two small copy changes to the homepage FAQ (`src/data/pages/home.ts`, 6 lines):

1. **Reworded the "What is Novu?" answer**: plainer verb ("sends" instead of "orchestrate") and the Connect channels are now named (Slack, Microsoft Teams, WhatsApp, Telegram, and email) instead of implied.
2. **Added one new question in position 3**: "What is ACI, Agent Communication Infrastructure?" with a three-sentence definition ending "Novu Connect is Novu's ACI."

The other 9 questions are untouched.

## Why

The homepage FAQ is what answer engines (ChatGPT, Perplexity, Google AI Overviews) quote when someone asks "what is Novu" or "what is agent communication infrastructure". Since HOME_FAQ feeds the rendered page, the FAQPage JSON-LD, and the /index.md markdown alternate from one source, this edit upgrades all three surfaces at once:

- Concrete channel names make the Q1 definition much more liftable for answer engines than an abstract one.
- No page on the site currently defines "Agent Communication Infrastructure" in extractable Q&A form. Owning that definition on the homepage is the main GEO play for the ACI category.

Copy follows the brand rules: ACI glossed on first use, approved channel names, plain verbs, no em dashes.

## For Pixel Point

Data-only change, no layout or component work needed. The FAQ accordion just renders one more item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)