### PR TITLE
feat(solutions): /solutions section + menu-gap pages (AI Agents reference build for Pixel Point)

### DIFF
--- a/src/app/(website)/(connect-footer)/solutions/[slug]/page.tsx
+++ b/src/app/(website)/(connect-footer)/solutions/[slug]/page.tsx
@@ -1,0 +1,223 @@
+import { Metadata } from "next"
+import { notFound } from "next/navigation"
+import { getAllSolutionSlugs, getSolutionBySlug } from "@/data/pages/solutions"
+import {
+  AGENT_CONNECT_CHANNELS,
+  AGENT_CONNECT_DESCRIPTION,
+  AGENT_CONNECT_TITLE,
+} from "@/data/pages/solutions/ai-agents-connect-stack"
+import {
+  AGENT_FEATURE_ITEMS,
+  AGENT_FEATURES_DESCRIPTION,
+  AGENT_FEATURES_TITLE,
+} from "@/data/pages/solutions/ai-agents-features"
+
+import type { TSectionAction } from "@/types/common"
+import type { ISolutionPageData } from "@/types/solution"
+import { getMetadata } from "@/lib/get-metadata"
+import { safeJsonLdStringify } from "@/lib/json-ld"
+import { absoluteUrl, toCanonicalPathname } from "@/lib/site-url"
+import FAQ from "@/components/pages/faq"
+import Compliance from "@/components/pages/home/compliance"
+import ConnectStack from "@/components/pages/home/connect-stack"
+import CTA from "@/components/pages/home/cta"
+import Features from "@/components/pages/home/features"
+import AgentGallery from "@/components/pages/solutions/agent-gallery"
+import ChannelIntentSync from "@/components/pages/solutions/channel-intent-sync"
+import SolutionCode from "@/components/pages/solutions/solution-code"
+import SolutionGlobeHero from "@/components/pages/solutions/solution-globe-hero"
+import SolutionHero from "@/components/pages/solutions/solution-hero"
+import SolutionSections from "@/components/pages/solutions/solution-sections"
+
+type PageProps = {
+  params: Promise<{ slug: string }>
+}
+
+export function generateStaticParams() {
+  return getAllSolutionSlugs().map((slug) => ({ slug }))
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { slug } = await params
+  const solution = getSolutionBySlug(slug)
+
+  if (!solution) {
+    return {}
+  }
+
+  return getMetadata({
+    title: solution.seoTitle,
+    description: solution.seoDescription,
+    pathname: `/solutions/${slug}`,
+  })
+}
+
+function getFinalCtaActions(solution: ISolutionPageData): TSectionAction[] {
+  const actions: TSectionAction[] = []
+
+  if (solution.primaryCta) {
+    actions.push({
+      kind: "primary-button",
+      label: solution.primaryCta.label,
+      href: solution.primaryCta.href,
+      clickLocation: `solution_${solution.slug}_cta`,
+      clickText: "primary_cta",
+    })
+  }
+
+  if (solution.secondaryCta) {
+    actions.push({
+      kind: "secondary-button",
+      label: solution.secondaryCta.label,
+      href: solution.secondaryCta.href,
+      clickLocation: `solution_${solution.slug}_cta`,
+      clickText: "secondary_cta",
+    })
+  }
+
+  return actions
+}
+
+async function SolutionPage({ params }: PageProps) {
+  const { slug } = await params
+  const solution = getSolutionBySlug(slug)
+
+  if (!solution) {
+    notFound()
+  }
+
+  const siteUrl = absoluteUrl("/")
+  const pageUrl = absoluteUrl(
+    toCanonicalPathname(`/solutions/${solution.slug}`)
+  )
+  const organizationId = `${siteUrl}#organization`
+  const websiteId = `${siteUrl}#website`
+  const webPageId = `${pageUrl}#webpage`
+  const faqId = `${pageUrl}#faq`
+  const breadcrumbId = `${pageUrl}#breadcrumb`
+
+  const jsonLdGraph = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "WebPage",
+        "@id": webPageId,
+        name: solution.seoTitle,
+        description: solution.seoDescription,
+        url: pageUrl,
+        isPartOf: { "@id": websiteId },
+        publisher: { "@id": organizationId },
+        breadcrumb: { "@id": breadcrumbId },
+        mainEntity: [{ "@id": faqId }],
+      },
+      {
+        "@type": "FAQPage",
+        "@id": faqId,
+        mainEntity: solution.faq.map((item) => ({
+          "@type": "Question",
+          name: item.question,
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: item.answer,
+          },
+        })),
+      },
+      {
+        "@type": "BreadcrumbList",
+        "@id": breadcrumbId,
+        itemListElement: [
+          {
+            "@type": "ListItem",
+            position: 1,
+            name: "Novu",
+            item: siteUrl,
+          },
+          {
+            "@type": "ListItem",
+            position: 2,
+            name: solution.name,
+            item: pageUrl,
+          },
+        ],
+      },
+    ],
+  }
+
+  // Command-track pages close with the copyable command and coding-agent
+  // prompt; the rest close with their primary and secondary buttons.
+  const ctaActions = solution.command ? [] : getFinalCtaActions(solution)
+
+  return (
+    <div
+      className="overflow-clip font-inter"
+      data-conversion-track={solution.conversionTrack}
+    >
+      {solution.heroVariant === "globe" ? (
+        <>
+          <SolutionGlobeHero solution={solution} />
+          <ChannelIntentSync />
+          <Features
+            title={AGENT_FEATURES_TITLE}
+            description={AGENT_FEATURES_DESCRIPTION}
+            items={AGENT_FEATURE_ITEMS}
+            defaultKey="slack"
+          />
+        </>
+      ) : (
+        <SolutionHero solution={solution} />
+      )}
+      <SolutionSections solution={solution} />
+      {solution.heroVariant === "globe" ? (
+        <>
+          <ConnectStack
+            title={AGENT_CONNECT_TITLE}
+            description={AGENT_CONNECT_DESCRIPTION}
+            channels={AGENT_CONNECT_CHANNELS}
+            defaultChannelValue="slack"
+          />
+          <AgentGallery />
+        </>
+      ) : null}
+      <SolutionCode solution={solution} />
+      {solution.compliance ? (
+        <Compliance
+          className="mt-20 md:mt-24 lg:mt-28 xl:mt-28"
+          title={solution.compliance.title}
+          description={solution.compliance.description}
+          items={solution.compliance.items}
+        />
+      ) : null}
+      <FAQ
+        className="relative z-10 mt-20 pt-0 pb-0 sm:pb-0 md:pt-0 md:pb-0 lg:pb-0"
+        title={`${solution.name.replace(/^For /, "Novu for ")}, common questions`}
+        titleClassName="text-[1.75rem] leading-[1.125] font-normal tracking-[-0.04em] md:text-[2rem]"
+        containerClassName="max-w-176 gap-y-8 lg:max-w-176 lg:px-0"
+        defaultOpenFirst
+        variant="minimal"
+        accordion={{
+          items: solution.faq.map((item) => ({
+            question: item.question,
+            answer: item.answer,
+          })),
+        }}
+      />
+      <CTA
+        title={solution.finalCta.title}
+        description={solution.finalCta.description}
+        {...(solution.command
+          ? { command: solution.command, prompt: solution.prompt }
+          : { actions: ctaActions })}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: safeJsonLdStringify(jsonLdGraph),
+        }}
+      />
+    </div>
+  )
+}
+
+export default SolutionPage

--- a/src/components/pages/home/globe/globe-runtime.tsx
+++ b/src/components/pages/home/globe/globe-runtime.tsx
@@ -61,6 +61,12 @@ interface IGlobeRuntimeProps {
   onReady: () => void
   onUnavailable: () => void
   playbackEnabled: boolean
+  /**
+   * Card events shown around the globe. Defaults to the homepage set. A caller
+   * may pass an alternate set that reuses the same route ids (so the globe
+   * geometry and story/ambient split are unchanged) with different card copy.
+   */
+  cardEvents?: IGlobeCardEvent[]
 }
 
 interface IActivePointer {
@@ -318,6 +324,7 @@ export default function GlobeRuntime({
   onReady,
   onUnavailable,
   playbackEnabled,
+  cardEvents = GLOBE_CARD_EVENTS,
 }: IGlobeRuntimeProps) {
   const shouldReduceMotion = useReducedMotion()
   const rootRef = useRef<HTMLDivElement>(null)
@@ -337,7 +344,7 @@ export default function GlobeRuntime({
   const previousScheduleRotationRef = useRef<number | null>(
     interactionRef.current.rotation
   )
-  const bootstrapEvents = GLOBE_CARD_EVENTS.filter(
+  const bootstrapEvents = cardEvents.filter(
     (event) => (event.initialRouteLeadMs ?? 0) > 0
   )
   const routePlaybackRef = useRef<Record<string, number>>(
@@ -572,9 +579,7 @@ export default function GlobeRuntime({
             activeCardPlaybacksRef.current.map(({ event }) => event.id)
           )
           const events = pickGlobeCardEvents({
-            events: GLOBE_CARD_EVENTS.filter(
-              (event) => !activeEventIds.has(event.id)
-            ),
+            events: cardEvents.filter((event) => !activeEventIds.has(event.id)),
             lastCompletedAt: lastCardCompletedAtRef.current,
             limit: 1,
             nowMs: routeTime,

--- a/src/components/pages/home/hero-globe.tsx
+++ b/src/components/pages/home/hero-globe.tsx
@@ -19,6 +19,7 @@ import {
   loadGlobeLandPoints,
 } from "./globe/globe-assets"
 import GlobeMetric from "./globe/globe-metric"
+import type { IGlobeCardEvent } from "./globe/globe-types"
 
 const loadGlobeRuntime = () => import("./globe/globe-runtime")
 const GlobeRuntime = dynamic(loadGlobeRuntime, {
@@ -76,7 +77,11 @@ function getServerMobileSnapshot() {
   return false
 }
 
-export default function HeroGlobe() {
+export default function HeroGlobe({
+  cardEvents,
+}: {
+  cardEvents?: IGlobeCardEvent[]
+}) {
   const shouldReduceMotion = useSyncExternalStore(
     subscribeToReducedMotion,
     getReducedMotionSnapshot,
@@ -187,6 +192,7 @@ export default function HeroGlobe() {
             onReady={handleRuntimeReady}
             onUnavailable={handleUnavailable}
             playbackEnabled={playbackEnabled}
+            cardEvents={cardEvents}
           />
         </div>
       ) : null}

--- a/src/components/pages/solutions/agent-gallery.tsx
+++ b/src/components/pages/solutions/agent-gallery.tsx
@@ -1,0 +1,77 @@
+import {
+  AGENT_GALLERY_CARDS,
+  AGENT_GALLERY_DESCRIPTION,
+  AGENT_GALLERY_TITLE,
+} from "@/data/pages/solutions/ai-agents-gallery"
+
+import BentoCardBackground from "@/components/pages/home/bento-card-background"
+import CopyPromptButton from "@/components/pages/home/copy-prompt-button"
+import ChannelIcon from "@/components/pages/home/features/channel-icon"
+import CliCommand from "@/components/pages/home/features/cli-command"
+import MagicBento from "@/components/pages/home/magic-bento"
+
+const CARD_GRADIENT =
+  "radial-gradient(120% 110% at 85% 100%, rgba(93,52,168,0.22) 0%, rgba(28,20,46,0.1) 45%, rgba(11,12,14,0) 72%)"
+
+function AgentGallery() {
+  return (
+    <section className="mt-20 font-inter md:mt-24 lg:mt-28">
+      <div className="mx-auto w-full max-w-3xl px-5 md:px-8 lg:max-w-7xl">
+        <header>
+          <h2 className="max-w-168 text-[1.75rem] leading-[1.125] font-normal tracking-[-0.04em] text-balance text-foreground md:text-3xl xl:text-4xl">
+            {AGENT_GALLERY_TITLE}
+          </h2>
+          <p className="mt-4 max-w-161 text-base leading-normal font-normal tracking-tighter text-pretty text-gray-60 md:text-lg">
+            {AGENT_GALLERY_DESCRIPTION}
+          </p>
+        </header>
+
+        <MagicBento
+          className="mt-10 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3"
+          particles={false}
+        >
+          {AGENT_GALLERY_CARDS.map((card) => (
+            <article
+              className="magic-bento-card relative flex flex-col overflow-hidden rounded-xl border border-gray-20 bg-[#0B0C0E] p-5 md:p-6"
+              key={`${card.scenario}-${card.channel}`}
+            >
+              <BentoCardBackground backgroundImage={CARD_GRADIENT} />
+              <div className="relative z-10 flex grow flex-col">
+                <div className="flex items-center gap-2.5">
+                  <ChannelIcon
+                    channel={card.channel}
+                    className="size-6"
+                    isActive
+                  />
+                  <span className="text-sm leading-none font-medium tracking-tighter text-gray-50">
+                    {card.channelLabel}
+                  </span>
+                </div>
+                <h3 className="mt-4 text-lg/tight font-medium tracking-tighter text-foreground">
+                  {card.scenario}
+                </h3>
+                <p className="mt-2.5 grow text-sm/normal font-normal tracking-tighter text-pretty text-gray-50 md:text-base">
+                  {card.description}
+                </p>
+                <div className="mt-5 flex flex-col gap-2.5">
+                  <CliCommand
+                    command={card.command}
+                    className="w-full rounded-md border-gray-30 bg-[#05050b] text-sm tracking-normal text-gray-80"
+                  />
+                  <CopyPromptButton
+                    className="h-10 w-full px-4 text-sm leading-none font-medium tracking-tight normal-case [&_svg]:size-3.5"
+                    variant="outline-transparent"
+                    size="none"
+                    value={card.prompt}
+                  />
+                </div>
+              </div>
+            </article>
+          ))}
+        </MagicBento>
+      </div>
+    </section>
+  )
+}
+
+export default AgentGallery

--- a/src/components/pages/solutions/channel-intent-sync.tsx
+++ b/src/components/pages/solutions/channel-intent-sync.tsx
@@ -1,0 +1,64 @@
+"use client"
+
+import { useEffect } from "react"
+
+import {
+  HOME_CHANNEL_SELECT_EVENT,
+  type IHomeChannelSelectDetail,
+} from "@/components/pages/home/channel-navigation"
+
+// Maps a visitor's intent to the right Features tab without scrolling. If the
+// URL carries a channel hint (?channel=whatsapp, or a utm_term that names a
+// channel), preselect that channel in the Features demo on load. Renders
+// nothing. Never scrolls; it only sets the active tab so the demo matches
+// what the visitor came for.
+const CHANNEL_KEYS: Record<string, string> = {
+  slack: "slack",
+  teams: "teams",
+  "microsoft-teams": "teams",
+  msteams: "teams",
+  whatsapp: "whatsapp",
+  telegram: "telegram",
+  email: "email",
+}
+
+function resolveChannelKey(): string | null {
+  const params = new URLSearchParams(window.location.search)
+  const candidates = [
+    params.get("channel"),
+    params.get("utm_term"),
+    params.get("utm_content"),
+  ]
+
+  for (const raw of candidates) {
+    if (!raw) continue
+    const normalized = raw.toLowerCase()
+    for (const [needle, key] of Object.entries(CHANNEL_KEYS)) {
+      if (normalized.includes(needle)) return key
+    }
+  }
+
+  return null
+}
+
+function ChannelIntentSync() {
+  useEffect(() => {
+    const key = resolveChannelKey()
+    if (!key) return
+
+    // Defer so the Features section has mounted and is listening.
+    const timeout = window.setTimeout(() => {
+      window.dispatchEvent(
+        new CustomEvent<IHomeChannelSelectDetail>(HOME_CHANNEL_SELECT_EVENT, {
+          detail: { key },
+        })
+      )
+    }, 150)
+
+    return () => window.clearTimeout(timeout)
+  }, [])
+
+  return null
+}
+
+export default ChannelIntentSync

--- a/src/components/pages/solutions/solution-code.tsx
+++ b/src/components/pages/solutions/solution-code.tsx
@@ -1,0 +1,38 @@
+import type { ISolutionPageData } from "@/types/solution"
+
+function SolutionCode({ solution }: { solution: ISolutionPageData }) {
+  const snippet = solution.codeSnippet
+
+  if (!snippet) {
+    return null
+  }
+
+  return (
+    <section className="mt-20 font-inter md:mt-24 lg:mt-28">
+      <div className="mx-auto w-full max-w-3xl px-5 md:px-8 lg:max-w-7xl">
+        <div className="grid grid-cols-1 items-start gap-8 lg:grid-cols-[minmax(0,26rem)_minmax(0,1fr)] lg:gap-12">
+          <header>
+            <h2 className="text-[1.75rem] leading-[1.125] font-normal tracking-[-0.04em] text-balance text-foreground md:text-4xl">
+              {snippet.heading}
+            </h2>
+            {snippet.description ? (
+              <p className="mt-4 text-base leading-normal font-normal tracking-tighter text-pretty text-gray-60 md:text-lg">
+                {snippet.description}
+              </p>
+            ) : null}
+          </header>
+          <div className="overflow-hidden rounded-xl border border-gray-20 bg-[#05050b]">
+            <div className="border-b border-gray-20 px-4 py-3 font-mono text-xs leading-none text-gray-50">
+              {snippet.label}
+            </div>
+            <pre className="overflow-x-auto p-5 font-mono text-sm leading-relaxed text-gray-90">
+              <code>{snippet.code}</code>
+            </pre>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default SolutionCode

--- a/src/components/pages/solutions/solution-globe-hero.tsx
+++ b/src/components/pages/solutions/solution-globe-hero.tsx
@@ -1,0 +1,157 @@
+"use client"
+
+import Image, { type StaticImageData } from "next/image"
+import NextLink from "next/link"
+import { ROUTE } from "@/constants/routes"
+import { AGENT_GLOBE_CARD_EVENTS } from "@/data/pages/solutions/ai-agents-globe-events"
+import emailIcon from "@/svgs/pages/connect/channels/email.svg"
+import slackIcon from "@/svgs/pages/connect/channels/slack.svg"
+import teamsIcon from "@/svgs/pages/connect/channels/teams.png"
+import telegramIcon from "@/svgs/pages/connect/channels/telegram.svg"
+import whatsappIcon from "@/svgs/pages/connect/channels/whatsapp.svg"
+
+import type { ISolutionPageData } from "@/types/solution"
+import { cn } from "@/lib/utils"
+import { CopyCommand } from "@/components/ui/copy-command"
+import AnimatedCopyCheck from "@/components/pages/home/animated-copy-check"
+import {
+  HOME_CHANNEL_SELECT_EVENT,
+  HOME_FEATURES_SECTION_ID,
+  type IHomeChannelSelectDetail,
+} from "@/components/pages/home/channel-navigation"
+import CopyPromptButton from "@/components/pages/home/copy-prompt-button"
+import HeroGlobe from "@/components/pages/home/hero-globe"
+
+const CHANNEL_Z_INDEX_CLASSES = ["z-[5]", "z-[4]", "z-[3]", "z-[2]", "z-[1]"]
+
+// The five approved Connect channels. Clicking one drives the Features section
+// below (same event the homepage uses), so the hero and the section are one flow.
+const CHANNELS: Array<{
+  key: string
+  name: string
+  icon: StaticImageData | string
+}> = [
+  { key: "slack", name: "Slack", icon: slackIcon },
+  { key: "teams", name: "Microsoft Teams", icon: teamsIcon },
+  { key: "whatsapp", name: "WhatsApp", icon: whatsappIcon },
+  { key: "telegram", name: "Telegram", icon: telegramIcon },
+  { key: "email", name: "Email", icon: emailIcon },
+]
+
+function selectChannel(key: string) {
+  window.dispatchEvent(
+    new CustomEvent<IHomeChannelSelectDetail>(HOME_CHANNEL_SELECT_EVENT, {
+      detail: { key },
+    })
+  )
+
+  const target = document.getElementById(HOME_FEATURES_SECTION_ID)
+  if (!target) return
+
+  const prefersReducedMotion = window.matchMedia(
+    "(prefers-reduced-motion: reduce)"
+  ).matches
+
+  target.scrollIntoView({
+    behavior: prefersReducedMotion ? "auto" : "smooth",
+    block: "start",
+  })
+}
+
+function ChannelLinks() {
+  return (
+    <span
+      className="flex w-fit items-center"
+      role="group"
+      aria-label="See your agent on each channel"
+    >
+      {CHANNELS.map(({ key, name, icon }, index) => (
+        <a
+          className={cn(
+            "group relative flex size-12 cursor-pointer items-center justify-center rounded-full focus-visible:ring-2 focus-visible:ring-foreground/60 focus-visible:outline-none lg:size-14",
+            index > 0 && "-ml-2.5 lg:-ml-4",
+            CHANNEL_Z_INDEX_CLASSES[index]
+          )}
+          href={`#${HOME_FEATURES_SECTION_ID}`}
+          key={name}
+          onClick={(event) => {
+            event.preventDefault()
+            selectChannel(key)
+          }}
+          aria-label={`See your agent on ${name}`}
+        >
+          <span className="pointer-events-none relative flex size-full items-center justify-center rounded-full border-[1.5px] border-gray-20 bg-[#05050B] shadow-[0_2px_5px_rgba(13,0,28,0.65)] transition-[border-color,translate] duration-300 ease-out group-hover:-translate-y-0.5 group-hover:border-gray-40">
+            <Image
+              className="relative z-10 size-6 object-contain lg:size-7"
+              src={icon}
+              alt=""
+              width={22}
+              height={22}
+              loading="eager"
+              aria-hidden="true"
+            />
+          </span>
+        </a>
+      ))}
+    </span>
+  )
+}
+
+function SolutionGlobeHero({ solution }: { solution: ISolutionPageData }) {
+  const { hero, command, prompt } = solution
+
+  return (
+    <section className="hero relative overflow-hidden bg-black font-inter">
+      <HeroGlobe cardEvents={AGENT_GLOBE_CARD_EVENTS} />
+      <div className="pointer-events-none relative z-10 [&_a]:pointer-events-auto [&_button]:pointer-events-auto">
+        <div className="mx-auto flex w-full max-w-4xl flex-col items-center px-5 pt-14 text-center md:px-8 md:pt-20 lg:pt-24">
+          <h1 className="max-w-3xl text-[2.5rem] leading-[1.05] font-normal tracking-plus-tight text-balance text-foreground md:text-[3.5rem] lg:text-[4rem] lg:leading-[1.05]">
+            {hero.heading}
+          </h1>
+          <p className="mt-5 max-w-2xl text-base leading-normal tracking-tight text-pretty text-[#a3a6b2] select-text md:text-lg md:leading-normal">
+            {hero.subheading}
+          </p>
+          <div className="mt-8 flex w-full flex-col items-center justify-center gap-3 sm:w-auto sm:flex-row sm:gap-4">
+            {command ? (
+              <CopyCommand
+                command={command}
+                variant="highlighted"
+                commandClassName="pointer-events-auto select-text"
+                copiedContent={<AnimatedCopyCheck />}
+              />
+            ) : null}
+            {prompt ? (
+              <CopyPromptButton
+                className="h-11 w-full px-5 text-base leading-none font-medium tracking-tight normal-case sm:w-39 [&_svg]:size-3.5"
+                variant="outline-transparent"
+                size="none"
+                resetInterval={2000}
+                value={prompt}
+              />
+            ) : null}
+          </div>
+          <p className="mt-4 flex flex-wrap items-center justify-center gap-x-1.5 rounded-full border border-gray-20 bg-[#0B0C0E]/80 px-4 py-2 text-sm leading-none font-normal tracking-tight text-gray-60 backdrop-blur-sm">
+            <span>First 5 replies run free. No account, no API key.</span>
+            <NextLink
+              className="text-gray-80 underline decoration-gray-40 underline-offset-2 transition-colors hover:text-white"
+              href={ROUTE.bookADemo}
+              data-click-location="solution_ai-agents_hero"
+              data-click-text="book_a_call"
+            >
+              Or talk to us
+            </NextLink>
+          </p>
+          <div className="mt-7">
+            <ChannelLinks />
+          </div>
+        </div>
+
+        {/* Reserve the globe's vertical space (the homepage fills this with a
+            customer-logos band; we keep it clean so the globe reads centered). */}
+        <div className="mt-[62vw] md:mt-[52vw] lg:mt-124" aria-hidden="true" />
+      </div>
+    </section>
+  )
+}
+
+export default SolutionGlobeHero

--- a/src/components/pages/solutions/solution-hero.tsx
+++ b/src/components/pages/solutions/solution-hero.tsx
@@ -1,0 +1,83 @@
+import NextLink from "next/link"
+
+import type { ISolutionPageData } from "@/types/solution"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import CopyPromptButton from "@/components/pages/home/copy-prompt-button"
+import CliCommand from "@/components/pages/home/features/cli-command"
+
+const BUTTON_CLASS_NAME =
+  "h-11 shrink-0 rounded-md px-5 text-base leading-none font-medium tracking-[-0.025em] normal-case"
+
+function SolutionHero({ solution }: { solution: ISolutionPageData }) {
+  const { hero, primaryCta, secondaryCta, command, prompt } = solution
+
+  return (
+    <section className="relative pt-18 font-inter md:pt-24">
+      <div className="mx-auto flex w-full max-w-3xl flex-col items-start px-5 md:items-center md:px-8 md:text-center lg:max-w-7xl">
+        <Badge
+          className="mb-5 flex h-6 justify-center border-purple-3/40 bg-purple-3/30 px-2.5 py-1.25 text-sm leading-none tracking-tighter whitespace-nowrap text-purple-1"
+          size="sm"
+          variant="outline-muted"
+        >
+          {hero.eyebrow}
+        </Badge>
+        <h1 className="max-w-200 text-[2.5rem] leading-[1.1] font-normal tracking-[-0.04em] text-balance text-foreground md:text-5xl md:leading-[1.125] xl:text-[3.5rem]">
+          {hero.heading}
+        </h1>
+        <p className="mt-4 max-w-176 text-base leading-normal font-normal tracking-tighter text-pretty text-gray-60 md:text-lg xl:text-xl xl:leading-[1.5]">
+          {hero.subheading}
+        </p>
+        <div className="mt-8 flex w-full flex-col items-stretch gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:gap-4 md:w-auto md:justify-center">
+          {command ? (
+            <CliCommand
+              command={command}
+              className="w-full rounded-md border-gray-30 bg-[#05050b] text-base tracking-normal text-gray-80 sm:w-auto sm:min-w-70"
+            />
+          ) : null}
+          {prompt ? (
+            <CopyPromptButton
+              className="h-11 w-full px-5 text-base leading-none tracking-tight normal-case sm:w-auto [&_svg]:!size-3.5"
+              size="sm"
+              value={prompt}
+            />
+          ) : null}
+          {primaryCta ? (
+            <Button
+              size="none"
+              variant="default"
+              className={BUTTON_CLASS_NAME}
+              asChild
+            >
+              <NextLink
+                href={primaryCta.href}
+                data-click-location={`solution_${solution.slug}_hero`}
+                data-click-text="primary_cta"
+              >
+                {primaryCta.label}
+              </NextLink>
+            </Button>
+          ) : null}
+          {secondaryCta ? (
+            <Button
+              size="none"
+              variant="outline-transparent"
+              className={BUTTON_CLASS_NAME}
+              asChild
+            >
+              <NextLink
+                href={secondaryCta.href}
+                data-click-location={`solution_${solution.slug}_hero`}
+                data-click-text="secondary_cta"
+              >
+                {secondaryCta.label}
+              </NextLink>
+            </Button>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default SolutionHero

--- a/src/components/pages/solutions/solution-sections.tsx
+++ b/src/components/pages/solutions/solution-sections.tsx
@@ -1,0 +1,222 @@
+import Image from "next/image"
+import NextLink from "next/link"
+import { getChannelBySlug } from "@/data/pages/channels"
+
+import type { ISolutionPageData, ISolutionSection } from "@/types/solution"
+import { cn } from "@/lib/utils"
+import BentoCardBackground from "@/components/pages/home/bento-card-background"
+import ConnectMascotEyes from "@/components/pages/home/connect-mascot-eyes"
+import ChannelIcon from "@/components/pages/home/features/channel-icon"
+import MagicBento from "@/components/pages/home/magic-bento"
+
+// The five approved Connect channels, in display order. The channels registry
+// may hold more entries (e.g. gated ones), so solutions pages list explicitly.
+const CONNECT_CHANNEL_SLUGS = [
+  "slack",
+  "microsoft-teams",
+  "whatsapp",
+  "telegram",
+  "email",
+] as const
+
+// Subtle glow for cards without a graphic, so text-only cards read as
+// intentional bento tiles rather than empty boxes.
+const CARD_GRADIENT =
+  "radial-gradient(120% 110% at 85% 100%, rgba(93,52,168,0.25) 0%, rgba(28,20,46,0.1) 45%, rgba(11,12,14,0) 72%)"
+
+const CONTAINER_CLASS_NAME =
+  "mx-auto w-full max-w-3xl px-5 md:px-8 lg:max-w-7xl"
+
+/**
+ * Text-only sections render as a two-column spread (heading left, body and
+ * bullets right) so they fill the desktop width, mirroring the homepage
+ * Compliance composition.
+ */
+function ProseSection({ section }: { section: ISolutionSection }) {
+  return (
+    <div
+      className={cn(
+        CONTAINER_CLASS_NAME,
+        "grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,28rem)_minmax(0,1fr)] lg:gap-24"
+      )}
+    >
+      <h2 className="text-[1.75rem] leading-[1.125] font-normal tracking-[-0.04em] text-balance text-foreground md:text-3xl xl:text-4xl">
+        {section.heading}
+      </h2>
+      <div className="lg:pt-1">
+        <p className="text-base leading-normal font-normal tracking-tighter text-pretty text-gray-60 md:text-lg xl:leading-[1.6]">
+          {section.body}
+        </p>
+        {section.bullets?.length ? (
+          <ul className="mt-6 flex flex-col gap-3.5">
+            {section.bullets.map((bullet) => (
+              <li
+                key={bullet}
+                className="flex items-start gap-2.5 text-base leading-normal font-normal tracking-tighter text-gray-60"
+              >
+                <span
+                  className="mt-2.25 size-1.5 shrink-0 rounded-xs bg-purple-3"
+                  aria-hidden
+                />
+                {bullet}
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+/** Stacked header for sections followed by a full-width grid. */
+function GridSectionHeader({ section }: { section: ISolutionSection }) {
+  return (
+    <header>
+      <h2 className="max-w-168 text-[1.75rem] leading-[1.125] font-normal tracking-[-0.04em] text-balance text-foreground md:text-3xl xl:text-4xl">
+        {section.heading}
+      </h2>
+      <p className="mt-4 max-w-161 text-base leading-normal font-normal tracking-tighter text-pretty text-gray-60 md:text-lg">
+        {section.body}
+      </p>
+    </header>
+  )
+}
+
+function CardsGrid({ section }: { section: ISolutionSection }) {
+  const cards = section.cards ?? []
+  const gridClassName =
+    cards.length >= 4
+      ? "sm:grid-cols-2 xl:grid-cols-4"
+      : cards.length === 3
+        ? "sm:grid-cols-2 lg:grid-cols-3"
+        : "sm:grid-cols-2"
+
+  return (
+    <MagicBento
+      className={cn("mt-10 grid grid-cols-1 gap-5", gridClassName)}
+      particles={false}
+    >
+      {cards.map((card) => (
+        <article
+          className="magic-bento-card relative flex min-h-72 flex-col overflow-hidden rounded-xl border border-gray-20 bg-[#0B0C0E] md:min-h-80"
+          key={card.title}
+        >
+          <BentoCardBackground backgroundImage={CARD_GRADIENT} />
+          <div className="relative z-10 p-5 md:p-6">
+            <h3 className="text-base/tight font-medium tracking-tighter text-foreground md:text-lg/tight">
+              {card.title}
+            </h3>
+            <p className="mt-2.5 text-sm/normal font-normal tracking-tighter text-pretty text-gray-50 md:text-base">
+              {card.body}
+            </p>
+          </div>
+          {card.image ? (
+            <>
+              <Image
+                className={cn(
+                  "pointer-events-none absolute z-[1] h-auto max-w-none",
+                  card.imageClassName
+                )}
+                src={card.image}
+                alt=""
+                quality={100}
+                sizes="(max-width: 640px) 100vw, (max-width: 1280px) 50vw, 25vw"
+                aria-hidden="true"
+              />
+              {card.mascotEyes ? (
+                <ConnectMascotEyes className={card.imageClassName} />
+              ) : null}
+            </>
+          ) : null}
+        </article>
+      ))}
+    </MagicBento>
+  )
+}
+
+function StatsGrid({ section }: { section: ISolutionSection }) {
+  return (
+    <MagicBento
+      className="mt-10 grid grid-cols-2 gap-5 lg:grid-cols-4"
+      particles={false}
+    >
+      {(section.stats ?? []).map((stat) => (
+        <article
+          className="magic-bento-card relative flex min-h-44 flex-col justify-between gap-6 overflow-hidden rounded-xl border border-gray-20 bg-[#0B0C0E] p-5 md:min-h-52 md:p-6"
+          key={stat.label}
+        >
+          <BentoCardBackground backgroundImage={CARD_GRADIENT} />
+          <span className="relative z-10 text-3xl leading-none font-normal tracking-[-0.04em] text-foreground md:text-5xl">
+            {stat.value}
+          </span>
+          <span className="relative z-10 text-sm leading-normal font-normal tracking-tighter text-gray-50 md:text-base">
+            {stat.label}
+          </span>
+        </article>
+      ))}
+    </MagicBento>
+  )
+}
+
+function ChannelsGrid({ solutionSlug }: { solutionSlug: string }) {
+  const channels = CONNECT_CHANNEL_SLUGS.map((slug) =>
+    getChannelBySlug(slug)
+  ).filter((channel) => channel !== undefined)
+
+  return (
+    <ul className="mt-10 grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-5 md:gap-5">
+      {channels.map((channel) => (
+        <li className="min-w-0" key={channel.slug}>
+          <NextLink
+            href={`/channels/${channel.slug}`}
+            className="group flex h-36 min-w-0 flex-col items-center justify-center gap-3 rounded-xl border border-gray-20 bg-[#0B0C0E] px-3 text-center outline-none hover:border-gray-30 focus-visible:border-gray-40 focus-visible:ring-2 focus-visible:ring-lagune-3/40 md:h-44"
+            aria-label={`Connect your agent to ${channel.channelName}`}
+            data-click-location={`solution_${solutionSlug}_channels`}
+            data-click-text={`channel_${channel.cliSlug}`}
+          >
+            <ChannelIcon
+              channel={channel.cliSlug}
+              className="size-9 md:size-11"
+              isActive
+            />
+            <span className="text-sm leading-tight font-medium tracking-tighter text-gray-70 transition-colors duration-200 group-hover:text-white group-focus-visible:text-white md:text-base">
+              {channel.channelName}
+            </span>
+          </NextLink>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function SolutionSections({ solution }: { solution: ISolutionPageData }) {
+  return (
+    <>
+      {solution.sections.map((section) => {
+        const variant = section.variant ?? "prose"
+
+        return (
+          <section
+            key={section.heading}
+            className="mt-16 font-inter md:mt-20 lg:mt-24"
+          >
+            {variant === "prose" ? (
+              <ProseSection section={section} />
+            ) : (
+              <div className={CONTAINER_CLASS_NAME}>
+                <GridSectionHeader section={section} />
+                {variant === "cards" ? <CardsGrid section={section} /> : null}
+                {variant === "stats" ? <StatsGrid section={section} /> : null}
+                {variant === "channels" ? (
+                  <ChannelsGrid solutionSlug={solution.slug} />
+                ) : null}
+              </div>
+            )}
+          </section>
+        )
+      })}
+    </>
+  )
+}
+
+export default SolutionSections

--- a/src/data/pages/solutions/ai-agents-connect-stack.ts
+++ b/src/data/pages/solutions/ai-agents-connect-stack.ts
@@ -1,0 +1,23 @@
+import emailStackIcon from "@/svgs/pages/home/stack/email.svg"
+import slackStackIcon from "@/svgs/pages/home/stack/slack.svg"
+import teamsStackIcon from "@/svgs/pages/home/stack/teams.svg"
+import telegramStackIcon from "@/svgs/pages/home/stack/telegram.svg"
+import whatsappStackIcon from "@/svgs/pages/home/stack/whatsapp.svg"
+
+import type { IStackOption } from "@/components/pages/home/connect-stack"
+
+// Channel options for the ConnectStack configurator on /solutions/ai-agents.
+// The five approved Connect channels only (the homepage default list also
+// carries iMessage, which is gated here). "Microsoft Teams" spelled in full.
+export const AGENT_CONNECT_CHANNELS: IStackOption[] = [
+  { value: "slack", label: "Slack", icon: slackStackIcon },
+  { value: "teams", label: "Microsoft Teams", icon: teamsStackIcon },
+  { value: "whatsapp", label: "WhatsApp", icon: whatsappStackIcon },
+  { value: "telegram", label: "Telegram", icon: telegramStackIcon },
+  { value: "email", label: "Email", icon: emailStackIcon },
+]
+
+export const AGENT_CONNECT_TITLE = "Wire it for your exact stack"
+
+export const AGENT_CONNECT_DESCRIPTION =
+  "Pick your channel and the framework your agent already uses. Novu generates the prompt to paste into your coding agent, or the exact CLI command to run. Same two minutes, whatever your stack."

--- a/src/data/pages/solutions/ai-agents-features.ts
+++ b/src/data/pages/solutions/ai-agents-features.ts
@@ -1,0 +1,154 @@
+import { HOME_CHANNELS, HOME_CLI_SLUGS } from "@/data/pages/home"
+import featuresBackground from "@/images/pages/home/features/bg.jpg"
+import clientFacingPreview from "@/images/pages/home/features/client-facing.png"
+
+import type { IFeatureChannel } from "@/components/pages/home/features"
+
+// The interactive channel showcase for /solutions/ai-agents, reusing the
+// homepage Features component. Scoped to the five approved Connect channels and
+// their existing client-facing demo videos. The per-channel copy and the
+// fictional company blurbs are agent scenarios (no real customer names).
+
+export const AGENT_FEATURES_TITLE = "See your agent talk on every channel"
+
+export const AGENT_FEATURES_DESCRIPTION =
+  "One agent, connected once, holding a real two-way conversation on each channel your users already use. Pick a channel to see it in action."
+
+const CONNECT_KEYS = [
+  "slack",
+  "teams",
+  "whatsapp",
+  "telegram",
+  "email",
+] as const
+
+// Tab label. The narrow tab truncates "Microsoft Teams", so the tab reads
+// "Teams" (unambiguous next to the Teams icon, and never the banned "MS Teams").
+// The full "Microsoft Teams" still appears in the panel title and body copy.
+const LABEL_OVERRIDES: Record<string, string> = {
+  teams: "Teams",
+}
+
+// How each channel actually connects, shown in the demo panel so a visitor sees
+// the mechanism, not just the promise. Novu handles the app, identity, and
+// two-way routing; the agent code does not change per channel.
+const CONNECT_EXPLANATIONS: Record<string, string> = {
+  slack:
+    "Novu installs a Slack app in your workspace, maps each Slack user to your agent, and routes every reply back to the same thread. One command wires the app, identity, and delivery.",
+  teams:
+    "Novu registers a Microsoft Teams app for your org, aware of channels and threads, with a human handoff step built in. Your agent reaches staff and clients where they already work.",
+  whatsapp:
+    "Novu connects through the WhatsApp Business API with approved message templates and delivery receipts, so a customer can reply and your agent answers in the same chat.",
+  telegram:
+    "Novu connects through a Telegram bot and routes each reply back to the right conversation, with rich messages and media supported out of the box.",
+  email:
+    "Novu connects through your email provider and threads replies back to your agent by reply-to. Responsive templates and high-deliverability routing, no inbox to build.",
+}
+
+const CLIENT_FACING_VIDEOS: Record<
+  string,
+  {
+    webm: string
+    mp4: string
+    poster: string
+    displaySize?: { width: number; height: number }
+  }
+> = {
+  slack: {
+    webm: "/videos/pages/home/features/slack-client-facing.webm",
+    mp4: "/videos/pages/home/features/slack-client-facing.mp4",
+    poster: "/videos/pages/home/features/slack-client-facing-poster.webp",
+    displaySize: { width: 504, height: 348 },
+  },
+  whatsapp: {
+    webm: "/videos/pages/home/features/whatsapp-client-facing.webm",
+    mp4: "/videos/pages/home/features/whatsapp-client-facing.mp4",
+    poster: "/videos/pages/home/features/whatsapp-client-facing-poster.webp",
+    displaySize: { width: 504, height: 348 },
+  },
+  telegram: {
+    webm: "/videos/pages/home/features/telegram-client-facing.webm",
+    mp4: "/videos/pages/home/features/telegram-client-facing.mp4",
+    poster: "/videos/pages/home/features/telegram-client-facing-poster.webp",
+    displaySize: { width: 504, height: 436 },
+  },
+  email: {
+    webm: "/videos/pages/home/features/email-client-facing.webm",
+    mp4: "/videos/pages/home/features/email-client-facing.mp4",
+    poster: "/videos/pages/home/features/email-client-facing-poster.webp",
+    displaySize: { width: 504, height: 414 },
+  },
+  teams: {
+    webm: "/videos/pages/home/features/teams-client-facing.webm",
+    mp4: "/videos/pages/home/features/teams-client-facing.mp4",
+    poster: "/videos/pages/home/features/teams-client-facing-poster.webp",
+    displaySize: { width: 504, height: 332 },
+  },
+}
+
+// 2-line blurb shown on hover over the company in each demo: a fictional
+// company and what its agent does on that channel.
+const COMPANY_INFO: Record<
+  string,
+  { name: string; about: string; useCase: string }
+> = {
+  slack: {
+    name: "Helix",
+    about:
+      "A data-pipeline platform that keeps its customers' analytics flowing.",
+    useCase:
+      "Its support agent works in shared Slack Connect channels, diagnosing sync failures and fixing them once the customer approves.",
+  },
+  whatsapp: {
+    name: "Fernweh",
+    about: "A direct-to-consumer travel-gear brand.",
+    useCase:
+      "Its agent handles orders and delivery changes over WhatsApp, so a shopper can reroute a package in a few taps.",
+  },
+  telegram: {
+    name: "Lumen",
+    about: "A developer API platform.",
+    useCase:
+      "Its agent answers usage and billing questions in Telegram, showing real limits and upgrading a plan on request.",
+  },
+  teams: {
+    name: "Vesta",
+    about: "An enterprise security and compliance vendor.",
+    useCase:
+      "Its agent works with client IT admins in Microsoft Teams, provisioning access with the approvals enterprises require.",
+  },
+  email: {
+    name: "Brightledger",
+    about: "A billing and finance platform.",
+    useCase:
+      "Its agent resolves invoice questions over email, explaining charges and issuing credits through secure action links.",
+  },
+}
+
+export const AGENT_FEATURE_ITEMS: IFeatureChannel[] = CONNECT_KEYS.map(
+  (key) => {
+    const channel = HOME_CHANNELS.find((item) => item.key === key)
+
+    if (!channel) {
+      throw new Error(`Missing HOME_CHANNELS entry for "${key}"`)
+    }
+
+    const cliSlug = HOME_CLI_SLUGS[key]
+
+    return {
+      key: channel.key,
+      label: LABEL_OVERRIDES[key] ?? channel.label,
+      title: channel.title,
+      description: CONNECT_EXPLANATIONS[key] ?? channel.description,
+      badges: channel.badges,
+      features: channel.features,
+      prompt: channel.prompt,
+      availability: "live" as const,
+      cliCommand: cliSlug ? `npx novu connect --channel ${cliSlug}` : undefined,
+      backgroundImage: featuresBackground,
+      clientFacingImage: clientFacingPreview,
+      clientFacingVideo: CLIENT_FACING_VIDEOS[key],
+      company: COMPANY_INFO[key],
+    }
+  }
+)

--- a/src/data/pages/solutions/ai-agents-gallery.ts
+++ b/src/data/pages/solutions/ai-agents-gallery.ts
@@ -1,0 +1,85 @@
+// Agent gallery for /solutions/ai-agents: runnable example agents (templates).
+// Each card is a recognizable scenario on one channel, with a one-click action
+// (the scoped coding-agent prompt) and the exact command. The scenarios mirror
+// the demo conversations already approved for the channel pages. No real
+// customer names.
+
+export interface IAgentGalleryCard {
+  /** Channel key, matches the ChannelIcon channel prop (cliSlug). */
+  channel: string
+  channelLabel: string
+  scenario: string
+  description: string
+  /** Scoped coding-agent prompt (the agents.md on-ramp), the card's action. */
+  prompt: string
+  /** The exact command this agent starts from. */
+  command: string
+}
+
+export const AGENT_GALLERY_TITLE = "Or start from a ready-made agent"
+
+export const AGENT_GALLERY_DESCRIPTION =
+  "Real agent patterns running on Novu Connect today. Find the one closest to yours, copy the prompt into your coding agent, and it wires the same thing for you."
+
+export const AGENT_GALLERY_CARDS: IAgentGalleryCard[] = [
+  {
+    channel: "slack",
+    channelLabel: "Slack",
+    scenario: "Support troubleshooter",
+    description:
+      "Diagnoses a failing job in the thread, asks for approval, runs the fix, and confirms. The pattern for a product support agent.",
+    prompt:
+      "Add a support troubleshooter agent to my app on Slack with Novu, with threaded replies and a human approval step. https://novu.co/agents.md",
+    command: "npx novu connect --channel slack",
+  },
+  {
+    channel: "whatsapp",
+    channelLabel: "WhatsApp",
+    scenario: "Order and delivery agent",
+    description:
+      "Lets a customer reschedule or reroute an order in a few taps, over WhatsApp, with delivery receipts. The pattern for a consumer-facing agent.",
+    prompt:
+      "Add an order and delivery agent to my app on WhatsApp with Novu, with two-way replies and delivery receipts. https://novu.co/agents.md",
+    command: "npx novu connect --channel whatsapp",
+  },
+  {
+    channel: "email",
+    channelLabel: "Email",
+    scenario: "Finance approval agent",
+    description:
+      "Answers invoice questions and issues credits over email, behind a human approval. The pattern for a finance or billing agent.",
+    prompt:
+      "Add a finance agent to my app on email with Novu, that explains charges and issues credits behind a human approval. https://novu.co/agents.md",
+    command: "npx novu connect --channel email",
+  },
+  {
+    channel: "telegram",
+    channelLabel: "Telegram",
+    scenario: "Usage and billing agent",
+    description:
+      "Answers usage and billing questions in Telegram and upgrades a plan on request. The pattern for a developer-facing API agent.",
+    prompt:
+      "Add a usage and billing agent to my app on Telegram with Novu, showing real limits and handling plan upgrades. https://novu.co/agents.md",
+    command: "npx novu connect --channel telegram",
+  },
+  {
+    channel: "teams",
+    channelLabel: "Microsoft Teams",
+    scenario: "IT access agent",
+    description:
+      "Provisions access for client admins in Microsoft Teams with the approvals enterprises require. The pattern for an internal or B2B agent.",
+    prompt:
+      "Add an IT access agent to my app on Microsoft Teams with Novu, with a human approval workflow for access requests. https://novu.co/agents.md",
+    command: "npx novu connect --channel teams",
+  },
+  {
+    channel: "slack",
+    channelLabel: "Slack",
+    scenario: "SDK setup agent",
+    description:
+      "Walks a developer to their first successful API call, in Slack. The pattern for a developer-onboarding agent.",
+    prompt:
+      "Add an SDK setup agent to my app on Slack with Novu, that walks a developer to their first API call. https://novu.co/agents.md",
+    command: "npx novu connect --channel slack",
+  },
+]

--- a/src/data/pages/solutions/ai-agents-globe-events.ts
+++ b/src/data/pages/solutions/ai-agents-globe-events.ts
@@ -1,0 +1,111 @@
+import { GLOBE_CARD_EVENTS } from "@/components/pages/home/globe/globe-data"
+import type { IGlobeCardEvent } from "@/components/pages/home/globe/globe-types"
+
+// Agent-only variant of the homepage globe cards, for /solutions/ai-agents.
+// We override ONLY the card copy (label, channel, lines, status) and reuse the
+// homepage events for everything structural (id, routeId, anchor, timing,
+// placement, widthPx). That keeps the globe geometry and the story/ambient
+// route split identical to the homepage; only the words on the cards change.
+//
+// Every card is a two-way agent scenario. At least two are human-in-the-loop
+// approvals ("Needs approval", "Human in the loop"), which is Novu Connect's
+// differentiator: the agent asks, a person decides, the answer returns.
+// Channels stay within Slack, WhatsApp, and Email (approved Connect channels
+// that also have a card icon). No customer names, no em dashes.
+type TAgentCardOverride = Pick<
+  IGlobeCardEvent,
+  "label" | "channel" | "channelLabel" | "lines" | "status"
+>
+
+const AGENT_CARD_OVERRIDES: Record<string, TAgentCardOverride> = {
+  "product-event": {
+    label: "Agent reply",
+    channel: "slack",
+    channelLabel: "Slack",
+    lines: [
+      { label: "User", value: "where's my sync?" },
+      { label: "Agent", value: "found it, fixing now" },
+    ],
+    status: "Replied in 1.2s",
+  },
+  "agent-digest": {
+    label: "Agent summary",
+    channel: "email",
+    channelLabel: "Email",
+    lines: [
+      { label: "Agent", value: "research agent" },
+      { label: "Sends", value: "weekly summary" },
+      { label: "To", value: "3 stakeholders" },
+    ],
+    status: "Sent in 96ms",
+  },
+  "customer-sync": {
+    label: "Needs approval",
+    channel: "slack",
+    channelLabel: "Slack",
+    lines: [
+      { label: "Agent", value: "refund agent" },
+      { label: "Asks", value: "approve $12,000 refund?" },
+      { label: "To", value: "finance lead" },
+    ],
+    status: "Awaiting decision",
+  },
+  "workflow-run": {
+    label: "Agent asks",
+    channel: "whatsapp",
+    channelLabel: "WhatsApp",
+    lines: [
+      { label: "Agent", value: "onboarding agent" },
+      { label: "Asks", value: "ready to go live?" },
+    ],
+    status: "Replied in 2s",
+  },
+  "security-event": {
+    label: "Human in the loop",
+    channel: "slack",
+    channelLabel: "Slack",
+    lines: [
+      { label: "Agent", value: "access agent" },
+      { label: "Asks", value: "grant admin for 24h?" },
+      { label: "To", value: "security" },
+    ],
+    status: "Awaiting decision",
+  },
+  fallback: {
+    label: "Channel handoff",
+    channel: "whatsapp",
+    channelLabel: "WhatsApp",
+    lines: [
+      { label: "No reply on", value: "Slack" },
+      { label: "Reached on", value: "WhatsApp" },
+    ],
+    status: "Same thread kept",
+  },
+  "pacific-product-event": {
+    label: "Agent reply",
+    channel: "whatsapp",
+    channelLabel: "WhatsApp",
+    lines: [
+      { label: "User", value: "reschedule to Friday" },
+      { label: "Agent", value: "done, confirmed" },
+    ],
+    status: "Replied in 1.4s",
+  },
+  "india-workflow-run": {
+    label: "Agent update",
+    channel: "email",
+    channelLabel: "Email",
+    lines: [
+      { label: "Agent", value: "billing agent" },
+      { label: "Sends", value: "usage summary" },
+    ],
+    status: "Sent in 92ms",
+  },
+}
+
+export const AGENT_GLOBE_CARD_EVENTS: IGlobeCardEvent[] = GLOBE_CARD_EVENTS.map(
+  (event) => {
+    const override = AGENT_CARD_OVERRIDES[event.id]
+    return override ? { ...event, ...override } : event
+  }
+)

--- a/src/data/pages/solutions/ai-agents.tsx
+++ b/src/data/pages/solutions/ai-agents.tsx
@@ -1,0 +1,113 @@
+import { ROUTE } from "@/constants/routes"
+import customerFacingGraphic from "@/images/pages/home/novu-connect/customer-facing.jpg"
+import fullContextGraphic from "@/images/pages/home/novu-connect/full-context.jpg"
+import humanApprovalGraphic from "@/images/pages/home/novu-connect/human-approval.jpg"
+import oneConversationGraphic from "@/images/pages/home/novu-connect/one-conversation.jpg"
+
+import type { ISolutionPageData } from "@/types/solution"
+
+// Persona: "The AI Product Builder". VP Engineering, Head of Platform, or
+// senior product engineer at an 11-500 person SaaS. The agent feature works
+// in staging; the blocker is the last mile into real channels.
+export const aiAgentsSolutionData: ISolutionPageData = {
+  slug: "ai-agents",
+  name: "For AI Agents",
+  seoTitle: "Novu for AI Agents | Put Your Agent in Front of Users",
+  seoDescription:
+    "Your agent already works. Novu Connect is the ACI, Agent Communication Infrastructure, layer that puts it in front of users on Slack, Microsoft Teams, WhatsApp, Telegram, and Email. Two-way, one thread.",
+  conversionTrack: "self-serve",
+  heroVariant: "globe",
+  hero: {
+    eyebrow: "For AI agents",
+    heading: "Your agent works. Now put it where your users are.",
+    subheading:
+      "Novu Connect is the ACI, Agent Communication Infrastructure, that puts the agent you already built in front of users on Slack, Microsoft Teams, WhatsApp, Telegram, and Email. Two-way, one thread, live in minutes.",
+  },
+  secondaryCta: {
+    label: "Explore Novu Connect",
+    href: ROUTE.connect,
+  },
+  command: "npx novu connect",
+  prompt: "Add an agent to my app https://novu.co/agents.md",
+  sections: [
+    {
+      heading:
+        "The agent was the hard part. The last mile is the annoying part.",
+      body: "Your team already did the difficult work. What stands between your agent and your users is channel plumbing: every channel has its own webhook format, identity model, and threading rules. That is weeks of engineering with nothing to do with your product. Novu standardizes it once, so the next channel is a config change, not a quarter.",
+    },
+    {
+      heading: "What Novu handles, so your agent code doesn't",
+      body: "Connect once. Your agent writes one reply, and Novu makes it native on every channel while keeping the conversation straight.",
+      variant: "cards",
+      cards: [
+        {
+          title: "Identity resolution",
+          body: "The same user on Slack and email maps to one person, so your agent always knows who it is talking to.",
+          image: fullContextGraphic,
+          imageClassName: "bottom-0 left-1/2 w-[80%] -translate-x-1/2",
+        },
+        {
+          title: "Delivery and threading",
+          body: "Retries, delivery status, and one conversation thread that follows the user across channels.",
+          image: oneConversationGraphic,
+          imageClassName: "bottom-0 left-1/2 w-[92%] -translate-x-1/2",
+          mascotEyes: true,
+        },
+        {
+          title: "OAuth and credentials",
+          body: "Provider connections, tokens, and scopes managed for every channel, no secrets in your agent code.",
+          image: humanApprovalGraphic,
+          imageClassName: "bottom-0 left-1/2 w-[88%] -translate-x-1/2",
+        },
+        {
+          title: "Content normalization",
+          body: "One reply becomes Slack blocks, WhatsApp buttons, or HTML email, native to each channel.",
+          image: customerFacingGraphic,
+          imageClassName: "bottom-0 left-1/2 w-[92%] -translate-x-1/2",
+        },
+      ],
+    },
+    {
+      heading: "We never run your brain",
+      body: "Novu is the delivery layer between your agent and its users. Your model, your prompts, your logic stay on your side, and Novu carries the messages. MCP connects agents to tools, A2A connects agents to each other, and ACI, Agent Communication Infrastructure, connects agents to people. That is the layer Novu Connect is.",
+      variant: "prose",
+      bullets: [
+        "Bring LangChain, Vercel AI SDK, Chat SDK, custom code, or a Claude Managed Agent. The agent stays yours.",
+        "Swap the runtime later and the channels, identity, and conversation history come along.",
+        "SOC 2 Type II, HIPAA, ISO 27001, and GDPR. Your model and keys never touch Novu's runtime.",
+      ],
+    },
+  ],
+  faq: [
+    {
+      question: "How do I know this fits our agent?",
+      answer:
+        "One test: does your agent initiate conversations, respond to user input, or surface things that need a human reply? If yes, it needs a two-way channel layer and Novu Connect fits. If it only pushes one-way alerts, standard Novu notification workflows are the simpler answer.",
+    },
+    {
+      question: "Does Novu run my agent's model or logic?",
+      answer:
+        "No. Novu Connect is the ACI, Agent Communication Infrastructure, layer between your agent and its users. Your model, prompts, and logic stay on your side. We never run your brain. That's the whole point.",
+    },
+    {
+      question: "Which channels can my agent reach?",
+      answer:
+        "Slack, Microsoft Teams, WhatsApp, Telegram, and Email. One agent holds one conversation thread across all of them, with identity resolution so the same user maps to one person everywhere.",
+    },
+    {
+      question: "How do I connect my existing agent?",
+      answer:
+        "Run npx novu connect, or paste 'Add an agent to my app https://novu.co/agents.md' into your coding agent. Connect takes about 2 minutes and does not require changes to your agent's logic.",
+    },
+    {
+      question: "What if I don't have an agent yet?",
+      answer:
+        "Start from a Managed Agent, a hosted template you configure in about 10 minutes, or write a Custom Code Agent for full control. Whichever path you pick, you only ever change the part that holds your logic.",
+    },
+  ],
+  finalCta: {
+    title: "Give your agent a voice",
+    description:
+      "Run npx novu connect, or paste 'Add an agent to my app https://novu.co/agents.md' into your coding agent. Your agent talks to users in about 2 minutes.",
+  },
+}

--- a/src/data/pages/solutions/app-notifications.tsx
+++ b/src/data/pages/solutions/app-notifications.tsx
@@ -1,0 +1,125 @@
+import { ROUTE } from "@/constants/routes"
+
+import type { ISolutionPageData } from "@/types/solution"
+
+// Persona: Head or Director of Engineering at an 11-500 person SaaS who owns
+// a home-grown notification stack (SendGrid or Twilio glue code, a cron
+// digest, a half-wired preferences table) and a React front end.
+export const appNotificationsSolutionData: ISolutionPageData = {
+  slug: "app-notifications",
+  name: "For App Notifications",
+  seoTitle: "Novu for App Notifications | One Workflow, Every Channel",
+  seoDescription:
+    "Novu Notify: an embeddable in-app Inbox, a workflow engine with digests and delays, subscriber preferences, and provider integrations. One workflow, every channel: In-App, Email, SMS, Push, Chat.",
+  conversionTrack: "self-serve",
+  hero: {
+    eyebrow: "For app notifications",
+    heading: "Retire the notification code nobody wants to own",
+    subheading:
+      "Every product grows one: an email helper here, a cron digest there, a preferences table that is half wired up. Novu Notify replaces the pile with an embeddable Inbox, a real workflow engine, and your existing providers behind one API. Build the workflow once, deliver to In-App, Email, SMS, Push, and Chat.",
+  },
+  primaryCta: {
+    label: "Start free",
+    href: ROUTE.dashboardV2SignUp,
+  },
+  secondaryCta: {
+    label: "Explore the Inbox",
+    href: ROUTE.inbox,
+  },
+  sections: [
+    {
+      heading: "It worked, until product asked for more",
+      body: "The in-house version always starts small and always ends in the same place: product wants digests, quiet hours, per-tenant branding, and a notification center, and suddenly notifications are a roadmap item with no owner. That feature list is exactly what the workflow engine ships with, so your team goes back to building your product.",
+    },
+    {
+      heading: "Keep your providers, retire your glue code",
+      body: "You already have SendGrid or Twilio accounts, deliverability history, and contracts. Keep them. Novu routes each workflow step through the provider connections you configure, retries on failure, and records what happened, so what you replace is the orchestration code around the providers, not the providers.",
+      variant: "prose",
+      bullets: [
+        "Bring your own provider connections, like SendGrid for email or Twilio for SMS",
+        "Open and click tracking on delivered messages",
+        "Delivery status you can query per message",
+        "Migrate workflow by workflow, no big-bang cutover",
+      ],
+    },
+    {
+      heading: "An Inbox your users expect",
+      body: "Ship a real notification center without building one. Embed the React component, or go headless and keep full control of the UI.",
+      variant: "prose",
+      bullets: [
+        "Drop-in <Inbox /> React component, styled to match your app",
+        "Headless APIs when you want to build the UI yourself",
+        "Subscriber preferences: users pick channels and mute what they don't need",
+        "White-labeling end to end, your brand only",
+      ],
+    },
+    {
+      heading: "A workflow engine, not an if statement",
+      body: "Notification logic grows fast: delays, digests, escalation paths. Novu's workflow engine holds it all, in a visual editor or code-first in TypeScript, typed and reviewed in your repo like everything else.",
+      variant: "prose",
+      bullets: [
+        "Delays and scheduled steps",
+        "Digest aggregation: batch 40 events into one summary",
+        "Throttling so users never get flooded",
+        "Conditional branching on payload, preference, or a prior step",
+        "Multi-tenant support for B2B apps",
+      ],
+    },
+    {
+      heading: "One layer of the communication layer",
+      body: "Notify is not a separate product. The same platform that delivers your product notifications carries your agent conversations. Add Novu Connect later and both run through one workflow, one subscriber identity, one preference center.",
+    },
+  ],
+  codeSnippet: {
+    heading: "Define it in TypeScript",
+    description:
+      "Workflows live in your codebase: typed, versioned, reviewed like any other code. Prefer clicking? The same workflow is editable visually in the dashboard.",
+    label: "workflows/comment-digest.ts",
+    code: `import { workflow } from "@novu/framework"
+
+export const commentDigest = workflow("comment-digest", async ({ step }) => {
+  const digest = await step.digest("digest-comments", () => ({
+    amount: 10,
+    unit: "minutes",
+  }))
+
+  await step.inApp("notify-inbox", () => ({
+    subject: digest.events.length + " new comments on your post",
+    body: "Open the thread to reply.",
+  }))
+})`,
+  },
+  faq: [
+    {
+      question:
+        "We already send email and SMS from our own code. What does migration look like?",
+      answer:
+        "Incremental. Keep your provider accounts and deliverability history, point Novu at them as provider connections, and move one workflow at a time. Most teams start with the noisiest workflow (usually a digest candidate) and retire the in-house path behind it.",
+    },
+    {
+      question: "Do I have to use the React Inbox component?",
+      answer:
+        "No. The <Inbox /> component is the fastest path, but everything it does is available through headless APIs, so you can build your own notification UI on top of the same data.",
+    },
+    {
+      question: "Can I define workflows in code instead of the dashboard?",
+      answer:
+        "Yes. Workflows are code-first in TypeScript if you want them versioned and reviewed in your repo, or you can build the same workflows in the visual editor. Both run on the same engine.",
+    },
+    {
+      question: "Which channels does a workflow cover?",
+      answer:
+        "One workflow can deliver to In-App, Email, SMS, Push, and Chat. Each step routes through the provider connection you configure, for example SendGrid for email, with open and click tracking on delivery.",
+    },
+    {
+      question: "Does Novu support multi-tenant apps?",
+      answer:
+        "Yes. Tenants keep separate branding, preferences, and provider configuration, so one workflow serves every customer of your B2B app without custom routing code.",
+    },
+  ],
+  finalCta: {
+    title: "Ship your notification system this week",
+    description:
+      "Embed the Inbox, define one workflow, connect a provider. Delays, digests, and preferences come with the engine, not with more of your code.",
+  },
+}

--- a/src/data/pages/solutions/builders.tsx
+++ b/src/data/pages/solutions/builders.tsx
@@ -1,0 +1,108 @@
+import { ROUTE } from "@/constants/routes"
+
+import type { ISolutionPageData } from "@/types/solution"
+
+// Persona: founder, indie builder, or first engineer at a 1-50 person team.
+// No platform team, evaluates through GitHub, allergic to lock-in and
+// surprise bills, wants to ship this week.
+export const buildersSolutionData: ISolutionPageData = {
+  slug: "builders",
+  name: "For Builders",
+  seoTitle: "Novu for Builders | Open Source Notification Infrastructure",
+  seoDescription:
+    "MIT-licensed core, roughly 40,000 GitHub stars, 4 years of notification infrastructure. Ship notifications and agent chat from a free tier, or self-host the whole thing.",
+  conversionTrack: "self-serve",
+  hero: {
+    eyebrow: "For builders",
+    heading: "Ship notifications like you have a platform team",
+    subheading:
+      "You don't have a platform team. You have a product to ship. Novu is open source notification infrastructure with an MIT-licensed core, roughly 40,000 GitHub stars, and 4 years of production history: notifications and agent chat from the free tier, or self-host and run every piece yourself.",
+  },
+  primaryCta: {
+    label: "View on GitHub",
+    href: ROUTE.github,
+  },
+  secondaryCta: {
+    label: "Start free",
+    href: ROUTE.dashboardV2SignUp,
+  },
+  sections: [
+    {
+      heading: "Open source, actually",
+      body: "Not open-core marketing with the real product behind a wall. The core is MIT-licensed: read it, run it, patch it.",
+      variant: "prose",
+      bullets: [
+        "MIT-licensed core, every line on GitHub",
+        "Roughly 40,000 GitHub stars",
+        "4 years of production notification infrastructure",
+        "Self-host with Docker, or use the cloud free tier",
+      ],
+    },
+    {
+      heading: "The parts you skip building",
+      body: "A notification system is a pile of undifferentiated work: provider APIs, retry queues, batching logic, preference storage. Novu ships it so your weekend project keeps its weekend.",
+      variant: "prose",
+      bullets: [
+        "Provider connections for email, SMS, push, chat, and in-app",
+        "Digest, delay, and throttle logic",
+        "Subscriber identity and preferences",
+        "Delivery status, retries, and logs",
+      ],
+    },
+    {
+      heading: "No lock-in, by construction",
+      body: "The exit is built in. Workflows are TypeScript in your repo, provider accounts stay yours, and the MIT core means self-hosting is always on the table. If Novu ever stops earning its place in your stack, you leave with your code and your data.",
+    },
+    {
+      heading: "Agent chat, same stack",
+      body: "When your project grows an agent, the same infrastructure carries the conversation. Run npx novu connect and your agent talks to users on Slack, Microsoft Teams, WhatsApp, Telegram, and Email. No new vendor, no second identity model.",
+    },
+  ],
+  codeSnippet: {
+    heading: "First notification, a few lines",
+    description:
+      "Trigger a workflow from your backend. Novu resolves the subscriber, walks the workflow steps, and delivers through your provider connections.",
+    label: "notify.ts",
+    code: `import { Novu } from "@novu/api"
+
+const novu = new Novu({ secretKey: process.env.NOVU_SECRET_KEY })
+
+await novu.trigger({
+  workflowId: "deploy-finished",
+  to: { subscriberId: "dev_512" },
+  payload: { project: "api", status: "passed" },
+})`,
+  },
+  faq: [
+    {
+      question: "Is Novu really open source?",
+      answer:
+        "Yes. The core is MIT-licensed and developed in the open on GitHub, with roughly 40,000 stars and 4 years of history. You can read the code, run it locally, and self-host it.",
+    },
+    {
+      question: "Can I self-host Novu?",
+      answer:
+        "Yes. Run the full stack yourself with Docker, or start on the cloud free tier and move later. The same workflows run in both.",
+    },
+    {
+      question: "What does the free tier cover?",
+      answer:
+        "Enough to ship a real project: the in-app Inbox, workflows, and provider integrations. Check the pricing page for current limits before you rely on a number.",
+    },
+    {
+      question: "What happens when I outgrow the free tier?",
+      answer:
+        "Your workflows don't change, your subscriber data stays, and pricing scales on the pricing page in the open. If cloud pricing ever stops making sense for you, self-hosting the MIT core is a real option, not a threat we hope you never test.",
+    },
+    {
+      question: "Can I add an AI agent later without new infrastructure?",
+      answer:
+        "Yes. Run npx novu connect and the agent you built talks to users on Slack, Microsoft Teams, WhatsApp, Telegram, and Email, on the same Novu stack that sends your notifications.",
+    },
+  ],
+  finalCta: {
+    title: "Build the product, not the plumbing",
+    description:
+      "Star the repo, read the code, then trigger your first workflow. Notifications and agent chat on one open source stack.",
+  },
+}

--- a/src/data/pages/solutions/enterprise.tsx
+++ b/src/data/pages/solutions/enterprise.tsx
@@ -1,0 +1,117 @@
+import { ROUTE } from "@/constants/routes"
+
+import type { ISolutionPageData } from "@/types/solution"
+
+// Persona: "The Enterprise Agent Deployer". Director or VP of Engineering,
+// platform, or architecture at a 1,000+ company, often in a regulated
+// industry. Security-review-driven; evaluating internal agents and worried
+// about where agent conversation data flows.
+export const enterpriseSolutionData: ISolutionPageData = {
+  slug: "enterprise",
+  name: "For Enterprise",
+  seoTitle: "Novu for Enterprise | Compliant Communication Infrastructure",
+  seoDescription:
+    "Notifications and agent conversations at enterprise scale. SOC 2 Type II, HIPAA, ISO 27001, GDPR, SSO/SAML, RBAC, audit logs, SLA. Cloud with US or EU data residency, or self-hosted.",
+  conversionTrack: "book-a-call",
+  hero: {
+    eyebrow: "For enterprise",
+    heading: "Communication infrastructure your security team can sign off",
+    subheading:
+      "Notifications and agent conversations at enterprise scale, for teams whose review process reads the audit log before the feature list: SOC 2 Type II, HIPAA, ISO 27001, and GDPR, with SSO, RBAC, audit logs, and an SLA. Run it in our cloud with US or EU data residency, or self-host it in yours.",
+  },
+  primaryCta: {
+    label: "Book a demo",
+    href: ROUTE.bookADemo,
+  },
+  secondaryCta: {
+    label: "Security at Novu",
+    href: ROUTE.security,
+  },
+  sections: [
+    {
+      heading: "The agent question your review board will ask",
+      body: "Who runs the model, and what sees your data? With Novu the answer is short: you do, and yours does. Novu is the delivery layer, the ACI, Agent Communication Infrastructure, bridge between your agents and your people. The intelligence is your code or a model platform you bring under your own keys. We never run your brain. That's the whole point.",
+      variant: "prose",
+      bullets: [
+        "Your agent logic and models stay under your control",
+        "Managed Agents can run Claude through AWS, on the AWS bill you already have",
+        "No new model vendor enters your stack through Novu",
+      ],
+    },
+    {
+      heading: "Control who does what",
+      body: "Enterprise access control from day one, so rolling Novu out across teams does not mean sharing one admin login.",
+      variant: "prose",
+      bullets: [
+        "SSO with SAML",
+        "Role-based access control",
+        "Audit logs for every change",
+        "SLA-backed support",
+      ],
+    },
+    {
+      heading: "Deploy it your way",
+      body: "Most enterprise teams arrive with an in-house notification system nobody wants to maintain. Migrate incrementally: run both side by side, move one workflow at a time, and keep the old system as a fallback until you switch it off.",
+      variant: "prose",
+      bullets: [
+        "Cloud with US or EU data residency",
+        "Self-hosted in your own infrastructure",
+        "Incremental migration from in-house notification systems",
+        "One platform for product notifications and agent conversations",
+      ],
+    },
+    {
+      heading: "Internal agents, staff channels",
+      body: "The same platform carries internal AI agents to your staff on Slack, Microsoft Teams, and email. On-call summaries, approval requests, IT helpdesk: agents reach employees where they already work, with the audit trail your compliance team expects.",
+    },
+  ],
+  compliance: {
+    title: "Compliance, on paper",
+    description:
+      "Procurement asks, we answer with documents, not promises. The certifications your review checklist expects are in place.",
+    items: [
+      {
+        question: "Which certifications does Novu hold?",
+        answer:
+          "SOC 2 Type II, HIPAA, ISO 27001, and GDPR. Documentation is available for your security review; book a call and we walk your team through it.",
+      },
+      {
+        question: "Can we keep data in the EU?",
+        answer:
+          "Yes. Novu cloud offers US and EU data residency. If residency rules are stricter than that, you can self-host the platform in your own infrastructure.",
+      },
+      {
+        question: "What about the audit trail?",
+        answer:
+          "Audit logs cover every change, with SSO and role-based access control in front of them, across notifications and agent conversations alike.",
+      },
+    ],
+  },
+  faq: [
+    {
+      question: "Does Novu run models on our conversation data?",
+      answer:
+        "No. Novu is the delivery layer, the ACI, Agent Communication Infrastructure, bridge. Your agent's intelligence is your own code or a model platform you bring under your own keys, and Novu carries the messages. We never run your brain.",
+    },
+    {
+      question: "Can we keep data in the EU?",
+      answer:
+        "Yes. Novu cloud offers US and EU data residency. If residency rules are stricter than that, you can self-host the platform in your own infrastructure.",
+    },
+    {
+      question: "How do we migrate off an in-house notification system?",
+      answer:
+        "Incrementally. Run Novu next to the existing system, move one workflow at a time, and keep the old path as a fallback until every workflow is across. No cutover weekend.",
+    },
+    {
+      question: "Can internal AI agents reach our employees through Novu?",
+      answer:
+        "Yes. Internal agents talk to staff on Slack, Microsoft Teams, and email through the same platform that sends your product notifications, with SSO, RBAC, and audit logs applied throughout.",
+    },
+  ],
+  finalCta: {
+    title: "Bring your security team",
+    description:
+      "A 30-minute demo covering architecture, compliance, deployment options, and migration. Come with the hard questions.",
+  },
+}

--- a/src/data/pages/solutions/index.ts
+++ b/src/data/pages/solutions/index.ts
@@ -1,0 +1,25 @@
+import type { ISolutionPageData } from "@/types/solution"
+
+import { aiAgentsSolutionData } from "./ai-agents"
+import { appNotificationsSolutionData } from "./app-notifications"
+import { buildersSolutionData } from "./builders"
+import { enterpriseSolutionData } from "./enterprise"
+
+export const solutionPages: Record<string, ISolutionPageData> = {
+  "ai-agents": aiAgentsSolutionData,
+  "app-notifications": appNotificationsSolutionData,
+  builders: buildersSolutionData,
+  enterprise: enterpriseSolutionData,
+}
+
+export function getSolutionBySlug(slug: string): ISolutionPageData | undefined {
+  return solutionPages[slug]
+}
+
+export function getAllSolutionSlugs(): string[] {
+  return Object.keys(solutionPages)
+}
+
+export function getAllSolutions(): ISolutionPageData[] {
+  return Object.values(solutionPages)
+}

--- a/src/types/solution.ts
+++ b/src/types/solution.ts
@@ -1,0 +1,107 @@
+import type { Route } from "next"
+import type { StaticImageData } from "next/image"
+
+/**
+ * Data model for a /solutions landing page (e.g. /solutions/ai-agents).
+ * One entry per audience lives in `src/data/pages/solutions/`.
+ */
+
+export type TSolutionConversionTrack = "self-serve" | "book-a-call"
+
+export interface ISolutionCta {
+  label: string
+  href: Route<string> | URL
+}
+
+/**
+ * How a section renders. "prose" is heading + body + optional bullet grid;
+ * "cards" is a bento card grid (optionally with home-page graphics);
+ * "stats" is a stat-tile strip; "channels" is the five-channel icon grid.
+ */
+export type TSolutionSectionVariant = "prose" | "cards" | "stats" | "channels"
+
+export interface ISolutionCard {
+  title: string
+  body: string
+  /** Optional graphic reused from the homepage assets. */
+  image?: StaticImageData
+  imageClassName?: string
+  /**
+   * Overlay the interactive Connect mascot eyes on the graphic (only valid on
+   * the one-conversation artwork, which shares the eyes' coordinate system).
+   */
+  mascotEyes?: boolean
+}
+
+export interface ISolutionStat {
+  value: string
+  label: string
+}
+
+export interface ISolutionSection {
+  heading: string
+  body: string
+  variant?: TSolutionSectionVariant
+  bullets?: string[]
+  cards?: ISolutionCard[]
+  stats?: ISolutionStat[]
+}
+
+export interface ISolutionCodeSnippet {
+  heading: string
+  description?: string
+  /** Filename-style label shown in the code block header, e.g. "workflow.ts". */
+  label: string
+  code: string
+}
+
+export interface ISolutionFaqItem {
+  question: string
+  answer: string
+}
+
+/** Feeds the homepage Compliance strip (cert badges + book-a-call). */
+export interface ISolutionCompliance {
+  title: string
+  description: string
+  items: ISolutionFaqItem[]
+}
+
+export interface ISolutionPageData {
+  slug: string
+  /** Short display name for breadcrumbs, e.g. "For AI Agents". */
+  name: string
+  seoTitle: string
+  seoDescription: string
+  /** Which conversion track this page is optimized for. */
+  conversionTrack: TSolutionConversionTrack
+  /**
+   * Hero treatment. "globe" reuses the homepage animated globe hero (with a
+   * page-specific set of card events); "default" is the compact text hero.
+   */
+  heroVariant?: "default" | "globe"
+  hero: {
+    eyebrow: string
+    heading: string
+    subheading: string
+  }
+  /**
+   * Hero buttons. On pages where `command` is present, the command block takes
+   * the primary slot, so `primaryCta` may be omitted.
+   */
+  primaryCta?: ISolutionCta
+  secondaryCta?: ISolutionCta
+  /** Copy-paste CLI command shown in the hero and the closing CTA. */
+  command?: string
+  /** Copy-paste prompt a developer hands to their coding agent. */
+  prompt?: string
+  sections: ISolutionSection[]
+  codeSnippet?: ISolutionCodeSnippet
+  /** When set, the homepage Compliance strip renders before the FAQ. */
+  compliance?: ISolutionCompliance
+  faq: ISolutionFaqItem[]
+  finalCta: {
+    title: string
+    description: string
+  }
+}


### PR DESCRIPTION
## The idea

A new **/solutions** section that speaks to a specific audience per page, plus the remaining menu-gap pages. This PR contains a working reference build of the flagship page (**/solutions/ai-agents**) so the concept is concrete, not a doc. Pixel Point: please draft and get the full set of pages ready, using the AI Agents page as the pattern.

Everything here reuses existing homepage building blocks (globe hero, the channel Features demo, the ConnectStack channel-x-framework configurator, bento cards, the Compliance strip), so it should feel native to the new site.

## What's in this PR (reference build)

`/solutions/[slug]` with four audience pages. **AI Agents is fully built out** and is the reference for everything else:

1. Centered **globe hero** reusing the homepage globe, parameterized with agent-specific "card events" (the messages flying around the globe are agent conversations: agent replies, human-in-the-loop approvals). Copyable `npx novu connect` + "copy prompt", a "5 replies free" reward line, and a book-a-call link.
2. **Channel demo** ("See your agent talk on every channel"): the homepage Features component scoped to the 5 Connect channels, each panel explaining how that channel connects.
3. **"What Novu handles"** bento cards (identity, delivery + threading with the mascot eyes, OAuth, content normalization).
4. **"Wire it for your exact stack"**: the ConnectStack configurator (channel + framework -> generated prompt/CLI).
5. **"Start from a ready-made agent"**: a gallery of runnable agent templates, one-click copy prompt/command each.
6. FAQ + final CTA.

App Notifications, Builders, and Enterprise pages are present with final copy but still need the visual polish the AI Agents page has.

## What we need drafted / built

- [ ] **Polish** App Notifications / Builders / Enterprise to match the AI Agents page (bento cards, graphics, rhythm).
- [ ] **AI on-ramp pages**: `/ai/prompt`, `/ai/codex`, `/ai/cursor` (paste-one-prompt flow via agents.md).
- [ ] **/about** page (company story, ~40K stars, compliance, open source).
- [ ] **History of Notifications** editorial page (timeline from pagers to ACI).
- [ ] **/channels/imessage** channel page (waitlist-gated; needs sign-off before publish).
- [ ] **Nav wiring**: Solutions dropdown in the header + menu links to the above.

(These existed in an earlier draft but were lost in a local mishap; rebuilding from the reference is the fastest path.)

## Brand rules (non-negotiable, apply to all copy)

- No em dashes anywhere.
- Gloss ACI on first use every time: "ACI, Agent Communication Infrastructure".
- Never say Novu runs the agent's brain. Approved line: "We never run your brain. That's the whole point."
- GitHub stars: ~40K, never 50K.
- Connect channels are exactly Slack, Microsoft Teams, WhatsApp, Telegram, Email. Write "Microsoft Teams", never "MS Teams". No Instagram/Discord/Google Chat as promised channels. iMessage is gated.
- No real customer names. Use the fictional companies already in the code (Helix, Fernweh, etc.).

## Preview

`pnpm install && pnpm dev`, then open `/solutions/ai-agents`. The other three solution pages are at `/solutions/app-notifications`, `/solutions/builders`, `/solutions/enterprise` (not yet linked in the nav).

Draft PR: happy to walk through the intent live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
