### PR TITLE
Content drafts: 10 voice-of-customer blog articles (polish + blog structure redesign)

### DIFF
--- a/content-drafts/blog/01-build-vs-buy.md
+++ b/content-drafts/blog/01-build-vs-buy.md
@@ -1,0 +1,140 @@
+---
+title: "Build vs buy notification infrastructure, honestly (and why AI coding made it worse)"
+slug: build-vs-buy-notification-infrastructure
+description: "Notifications look like a weekend project. The pain is maintenance, not v1. A build-vs-buy framework, TCO model, and where AI coding tilts the math."
+category: Engineering
+target_keyword: build vs buy notification system
+reading_time: 13
+---
+
+A product manager files a ticket: "Send users an email when their report is ready." You wire up an API call to your email provider, template the subject line, ship it that afternoon. It works. Everyone is happy.
+
+Six months later you own a retry queue, a preference center, a template repository nobody wants to touch, a dead-letter table you check every Monday, and a Slack channel that pings you when a provider starts bouncing mail at 3am. Nobody decided to build a notification system. You built one anyway, one ticket at a time.
+
+That is the trap. Notifications look like a weekend project at version one, and the actual work shows up later, after the demo, after the launch, after the person who wrote it moves teams. This piece is about the honest version of the build-vs-buy decision: where the cost really lives, why AI coding tools have made the math worse for building rather than better, when you genuinely should build anyway, and a rough model you can run against your own numbers.
+
+## The trap: version one is always easy
+
+Here is version one of a notification system. It is not a strawman. This is roughly what ships on day one at most companies:
+
+```ts
+async function notifyReportReady(user: User, report: Report) {
+  await sendgrid.send({
+    to: user.email,
+    from: "reports@acme.com",
+    subject: `Your report ${report.name} is ready`,
+    html: renderTemplate("report-ready", { user, report }),
+  });
+}
+```
+
+Nothing wrong with it. It compiles, it sends, the PM closes the ticket. If your entire notification surface is one transactional email to one channel and it never grows, you are done. Genuinely. Stop reading and go build it.
+
+The problem is that this is never where it stops. The second ticket asks for a Slack message instead of email for internal users. The third asks users to choose. The fourth is a digest so you stop spamming people. The fifth is quiet hours because someone in Sydney got paged at 2am by a "your invoice is ready" message. Each ticket is small. The sum is a distributed system with delivery guarantees, and you are now maintaining it.
+
+## The real cost is maintenance, not v1
+
+The line item that kills you is not the code you write in the first afternoon. It is everything that keeps that code alive and correct for the next three years. Walk through what actually lands on your plate.
+
+**Retries and backoff.** Providers fail. Networks partition. A send that returns a 500 needs a retry, and a naive retry loop turns one transient blip into a thundering herd against a provider that is already struggling. You need exponential backoff, jitter, a cap on attempts, idempotency keys so a retry does not double-send, and a dead-letter path for the sends that never succeed. That is a real queue with real semantics, not a `for` loop.
+
+**Provider quirks and outages.** Every provider has edges. SendGrid categorizes bounces differently than you expect. WhatsApp enforces template pre-approval and a messaging window. Slack rate-limits per workspace and returns a `retry_after` you have to honor. Telegram bots have their own throttle. When one provider degrades, you want to fail over or at least degrade gracefully, which means you need a provider abstraction and health signals, not a hardcoded SDK call in a request handler.
+
+**Preference and quiet-hours logic.** "Let users choose what they get and when" sounds like a settings page. Underneath it is a policy engine: per-user, per-channel, per-category opt-in and opt-out, timezone-aware quiet hours, digest batching windows, and a way to enforce all of it consistently at send time no matter which service triggers the notification. Get it wrong and you either spam people who opted out (a compliance problem) or silently drop messages people wanted (a trust problem). Both generate tickets.
+
+**Template sprawl.** Ten notifications across five channels is fifty variants, each with copy, localization, and channel-specific formatting. Slack wants Block Kit. Email wants inlined CSS that survives Outlook. WhatsApp wants pre-approved templates with placeholder variables. SMS wants brevity and a character budget. Six months in, nobody remembers which template is live, marketing wants to edit copy without a deploy, and you are the bottleneck because the copy lives in your codebase.
+
+**Deliverability.** This is its own discipline. SPF, DKIM, DMARC, warming a sending domain, watching your sender reputation, staying off blocklists, keeping bounce and complaint rates low enough that Gmail keeps accepting your mail. It is not code you write once. It is an ongoing operational concern that determines whether your messages arrive at all, and most backend teams have no one who owns it.
+
+**On-call.** All of the above has to run at 3am. When notifications stop, users notice fast, because a missing password reset or a missing "your order shipped" is a support ticket within minutes. Someone carries the pager. That someone is you.
+
+None of these show up in the version-one demo. All of them show up in year two. The build-vs-buy decision is really a maintenance decision wearing a v1 costume.
+
+## The 2026 twist: AI writes v1 for free and rots at maintenance
+
+Here is the part that changed. Two years ago, "we could just build it" was throttled by the cost of writing version one. That afternoon of work was a real afternoon. Now an LLM writes it in ten minutes. You describe the notification service, and a coding assistant hands you the sender, the template renderer, a queue consumer, even a first pass at retry logic. The friction that used to make teams pause before building has mostly evaporated.
+
+The instinct is to read that as a point for building. It is the opposite. Look again at where the cost actually lives. It is not in version one, which is exactly the part AI does well. It is in the long-lived maintenance, which is exactly the part AI does poorly.
+
+LLMs are excellent at first drafts of well-understood patterns. A retry loop, a template function, a webhook handler: these are all over the training data, and you get a competent version instantly. What an LLM does not do is carry the context of a living system across three years. It was not on-call when WhatsApp changed its template policy. It did not feel the incident when a retry storm took down your own API. It does not remember that the preference table has a subtle timezone bug that only fires during daylight-saving transitions. It will happily generate a plausible-looking `sendWithRetry` that lacks idempotency, and it will do it with total confidence, because plausible-looking is the job.
+
+So AI lowers the cost of the cheap part and does nothing for the expensive part. That makes the build option look cheaper than it is, precisely because the sticker price you now see (an afternoon, or ten minutes) is more misleading than ever. A team that would have hesitated to build in 2023 now ships a v1 in an afternoon and inherits the full maintenance burden without having priced it.
+
+> **AI can write your notification service in an afternoon. It cannot carry the pager for it at 2am.**
+
+That is the whole argument in one line. The economics of build-vs-buy were always about who owns the maintenance. AI changed the cost of the part that was never the problem.
+
+## A build-vs-buy decision framework
+
+Skip the vibes. Answer five concrete questions about your actual situation.
+
+**1. How many channels, and will that number grow?** One channel that will stay one channel is a strong build signal. The cost of a notification system scales with channels, because each channel is its own provider, its own template format, its own failure mode, its own rate limits. If you can honestly commit to a single channel forever, building is defensible. If product has already asked for a second, you are on the multi-channel path whether you admit it or not.
+
+**2. Do you need user-facing preferences?** A preference center is where "simple notification code" becomes a policy engine. If every user gets every message and that is acceptable, you have dodged the hardest part. The moment users need to choose channels, categories, or timing, you are building and maintaining consent logic, and that logic has compliance consequences.
+
+**3. What is your tolerance for delivery failure?** A missed marketing digest is an annoyance. A missed password reset or a missed "your trade executed" alert is a support escalation or worse. The higher the stakes of a dropped message, the more you need mature retry, failover, and observability, and the more expensive building that becomes.
+
+**4. Who owns this in year two?** Name the team. If the answer is "whoever built it," and that person is planning to still be on this team in two years and wants to own notification infrastructure, fine. If the answer is a shrug, you are about to create orphaned infrastructure that decays until it pages someone who does not understand it.
+
+**5. Is notification delivery a differentiator for your product?** Be honest. For almost every product, users do not choose you because your retry logic is elegant. They never see it. Delivery is table stakes that hurts when it breaks and is invisible when it works. If that describes you, building it is spending your scarcest engineering hours on something no customer will ever credit you for.
+
+Tally the answers. Multi-channel, preference-heavy, high-stakes, unowned, and non-differentiating points hard at buy. Single-channel, no preferences, low-stakes, clearly-owned, and core-to-the-product points at build. Most teams land closer to buy than they expect, because they answer question one as "just email" and question two as "not yet," and both are usually wrong within a year.
+
+## When you should actually build
+
+Buying is not always right, and pretending otherwise is how vendors lose credibility. Three cases where building is the correct call:
+
+**A single trivial channel with no growth path.** Internal tool, one email a day to a fixed list of admins, no preferences, nobody's password depends on it. Wiring an SDK call is the right amount of engineering. A notification platform is overkill.
+
+**Hard data-residency or air-gap constraints.** If you operate under regulatory or contractual rules that forbid message content from leaving your infrastructure, or you run in an air-gapped environment where an external delivery service is a non-starter, self-hosting or building may be the only compliant path. Note that this argues for self-hosting an open-source platform as much as for building from scratch, since you get to keep the code inside your walls either way.
+
+**Notifications are your core product.** If you are building a notification product, an alerting company, an incident-response platform, then delivery is your differentiator and you should own every layer of it. That is the one case where question five flips.
+
+Outside those, the honest answer is usually buy or self-host something that already exists.
+
+## What buying actually offloads
+
+The pitch for buying is not "less code," though it is that too. It is that you stop owning the maintenance categories from earlier as your problem. A notification platform absorbs:
+
+- Retry, backoff, idempotency, and dead-letter handling as a managed workflow engine rather than code you keep patching.
+- A provider abstraction across channels (Slack, Microsoft Teams, WhatsApp, Telegram, Email, plus in-app Inbox and push as product features) so a provider swap is configuration, not a refactor.
+- A preference and subscription layer with per-channel, per-category, timezone-aware logic already built and enforced at send time.
+- Template management your non-engineers can edit without a deploy.
+- Deliverability tooling and provider health, so a degraded provider is handled by the platform instead of your pager.
+- Observability into every message: sent, delivered, failed, retried, why.
+
+Novu is one option here, and worth naming because it covers the case most teams actually have. It is open source (around 40K GitHub stars), so you can self-host the whole thing if data residency is your constraint, or use the managed cloud if it is not. Either way the retry logic, provider abstraction, preference layer, and template management are code you no longer own line by line. That is the real trade: you give up total control of a system that is not your differentiator, and you get back the engineering hours and the sleep.
+
+## A rough TCO model
+
+Numbers make the trade concrete. These are illustrative, not a quote. Plug in your own rates and hours, because the shape of the answer matters more than the exact figures.
+
+Assume a fully loaded engineer costs about 200,000 per year, roughly 100 per hour. Assume a multi-channel system with preferences, the common case.
+
+| Cost line | Build (year 1) | Build (steady state, per year) | Buy / self-host |
+| --- | --- | --- | --- |
+| Initial build (3 channels, retries, preferences, templates) | ~320 hours (~32,000) | 0 | Integration: ~40 hours (~4,000) |
+| Ongoing maintenance and provider changes | included above | ~0.3 FTE (~60,000) | ~0.05 FTE (~10,000) |
+| On-call load attributable to notifications | ~40 hours (~4,000) | ~0.1 FTE (~20,000) | near 0 (platform absorbs delivery) |
+| Deliverability and provider ops | ~40 hours (~4,000) | ~0.1 FTE (~20,000) | mostly absorbed |
+| Platform / infra cost | hosting only | hosting only | subscription or self-host infra |
+| Opportunity cost (features not shipped) | high | recurring | low |
+| **Rough year-one total** | **~40,000 in labor, before opportunity cost** | **~100,000/year recurring** | **~14,000 labor + platform cost** |
+
+The build column looks cheapest at the initial-build cell, which is exactly the cell AI just made even cheaper. Then the steady-state row shows up and never leaves. Around half an FTE of recurring cost is a reasonable estimate for keeping a multi-channel notification system healthy, and that is before you count the features your best engineers did not ship because they were debugging a retry storm.
+
+The opportunity-cost row is the one teams underweight most. Every hour on notification plumbing is an hour not on the product that actually differentiates you.
+
+## The analogy buyers reach for on their own
+
+Sit through enough of these decisions across cybersecurity tooling, automotive-retail software, logistics platforms, capital-markets systems, and health platforms, and the same realization repeats. Different domains, same arc: v1 was easy, year two was a slog, and someone eventually said the quiet part.
+
+The analogy they reach for, unprompted, is payments. Nobody builds their own payment processor anymore. Stripe exists, it handles the boring, high-stakes, compliance-heavy, endlessly-maintained parts, and you integrate it and move on. Not because you could not build a payments system, but because it would be a bad use of your engineers to own that maintenance forever when the differentiator is your product, not your card-processing retry logic.
+
+Notifications are following the same path. High-stakes, boring when they work, painful when they break, endless to maintain, and not your differentiator. The question stopped being "can we build this," because with AI you obviously can, in an afternoon. The question is whether you want to own it at 2am for the next three years.
+
+## Where to land
+
+Run the five questions against your real situation, not the version-one demo in your head. If you are genuinely single-channel, preference-free, low-stakes, clearly owned, and notifications are your product, build it and do not overthink it. Everyone else is on the multi-channel maintenance path and should price it honestly, including the recurring FTE and the on-call the demo never showed.
+
+If you want to see what buying or self-hosting actually offloads, Novu is open source and you can run it yourself or start on the managed cloud. Try the self-serve setup, read the code, and decide against your own numbers.

--- a/content-drafts/blog/02-notification-pricing-models.md
+++ b/content-drafts/blog/02-notification-pricing-models.md
@@ -1,0 +1,84 @@
+---
+title: "How notification pricing models actually work (and why per-message billing is a trap)"
+slug: notification-pricing-models
+description: "Per-message, per-subscriber, per-profile, or per-workflow-run: the four notification pricing models explained, with a worked cost model at scale."
+category: Engineering
+target_keyword: notification service pricing model
+reading_time: 9
+---
+
+You picked a notification vendor because the demo was clean and the entry price looked fine. Then you hit real volume, the invoice tripled, and finance is in your Slack asking why. Nothing about your product changed. You just ran into the pricing model, and you never actually evaluated it.
+
+This is the single most common source of confusion when teams buy notification infrastructure. The features across vendors converge. The pricing models do not, and they diverge in ways that can swing your bill by an order of magnitude at scale. Two vendors can look comparably priced on the pricing page and bill you numbers that are nowhere near each other once you send real traffic. The model, not the sticker rate, decides what you pay.
+
+Here are the four models in plain terms, a worked example that shows where each one explodes, and a method to forecast your real cost before you sign anything.
+
+## Why notification bills surprise people
+
+The surprise is almost always a mismatch between the unit you think in and the unit you are billed in. You think in events: "a user did a thing, so we told them." The vendor might bill in messages, and one event can fan out to many messages. You think in active users, but the vendor might bill in stored profiles, and you are storing far more profiles than you have active users.
+
+The bill scales on the vendor's unit, not yours. When those two units diverge, and they usually do at scale, the invoice does something your capacity planning did not predict. The fix is to understand which unit each model charges on before you commit, so the unit you are billed in is one you can actually forecast.
+
+## The four pricing models, plainly
+
+**Per-message (or per-send).** You pay for each individual message that leaves the system. One email is one unit. One event that sends email plus Slack plus SMS is three units. This is the classic model for single-channel senders. SendGrid, for example, prices email in volume tiers, effectively per message sent. The model is easy to reason about for one channel and gets expensive fast the moment you fan out across channels, because every added channel multiplies your unit count.
+
+**Per-subscriber or per-MAU.** You pay based on how many recipients you can notify, often counted as monthly active users. Send that user one message or fifty in the month and the count is the same. This rewards high message volume per user and punishes large, sparsely-messaged audiences, because you pay for every reachable user whether or not you contacted them much.
+
+**Per-profile.** You pay for every profile stored in the system, active or not. Customer.io bills on profiles (its billable-profile model), and CleverTap similarly meters on monthly active or tracked profiles. The trap here is dormant data: profiles you imported, churned users you never deleted, test accounts, and duplicates all sit in the billable count. Your bill can grow while your actual sending stays flat, purely from data you are storing.
+
+**Per-workflow-run (per-event).** You pay once when a workflow fires, regardless of how many channels it fans out to. One event that sends email, then falls back to Slack, then pushes an in-app Inbox message is one run, not three sends. Channels are included in the run. This decouples your bill from channel count, which is the thing that blows up the other models at multi-channel scale. Novu prices this way.
+
+A quick caveat before the numbers: vendor pricing changes, and every vendor structures tiers, overages, and add-ons differently. Treat the model descriptions as the durable part and verify current rates on each vendor's pricing page before you plan a budget around them.
+
+## A worked example: one event, 500,000 recipients, three channels
+
+Take a concrete scenario. You fire one notification workflow: a service announcement that goes to 500,000 recipients. It sends across three channels, say email, plus a push or in-app Inbox message, plus a Slack or Telegram message for the segment that connected one. Assume for simplicity the fan-out averages out so that this single event produces roughly 1.5 million individual messages across the three channels (not every recipient gets all three, but many get two).
+
+Now price that one event under each model. The rates below are round illustrative numbers for comparison, not vendor quotes.
+
+| Model | Billable unit | Units for this event | Illustrative rate | Cost of this one event |
+| --- | --- | --- | --- | --- |
+| Per-message | Individual message sent | ~1,500,000 | ~0.0004 each | ~600 |
+| Per-subscriber / MAU | Reachable users this month | 500,000 | tiered by user count | high fixed floor, scales with audience |
+| Per-profile | Stored profiles | 500,000+ (plus dormant) | tiered by profile count | high, and grows with stored data |
+| Per-workflow-run | Workflow execution | 1 run (x recipients) | per-run tier | lowest per delivered message at this fan-out |
+
+The point of the table is the direction, not the decimals. Per-message pricing scales with the fan-out, so the more channels you add and the wider you send, the faster it climbs. At half a million recipients across three channels, per-message billing gets expensive fast, because you are paying 1.5 million times for one logical event. Per-profile and per-subscriber pricing do not care how many messages you sent, but they charge you for your whole audience every month, including the users you barely touch and the dormant profiles you forgot to delete. Per-workflow-run pricing charges for the event and includes the channels, so adding the third channel does not multiply the bill.
+
+The teams that feel this most are the ones with wide fan-out and multiple channels: healthcare-staffing platforms blasting shift alerts, online-trading systems pushing time-sensitive notices across app and messaging channels, pharma-compliance tools with multi-step approval notifications, and consumer-fintech apps sending transactional confirmations everywhere at once. A recurring pattern in those spaces: the workflow-run model is harder to estimate at first, because you have to think in events rather than the messages you are used to counting, but it comes out cheaper at multi-channel scale precisely because it does not multiply by channel.
+
+> **You are not paying to send a message. You are paying for a pricing model. Pick the model before you pick the vendor.**
+
+## How to forecast your real monthly cost
+
+Do not price off the headline rate. Model your own traffic in four steps.
+
+**1. Count your events, not your messages.** How many distinct notification-worthy things happen per month? A signup, an order, a report finishing, an alert firing. This is your event volume, and it is the number you actually control.
+
+**2. Measure your fan-out.** For an average event, how many individual messages go out across all channels? If a typical event hits two channels for most recipients, your fan-out is roughly 2x. Multiply event volume by fan-out to get message volume. The gap between these two numbers is exactly what separates a per-run bill from a per-message bill.
+
+**3. Count your real profiles, including the dead ones.** How many profiles will actually sit in the system, not how many you actively message? Include churned users, imports, test accounts, and duplicates. For per-profile and per-subscriber models, this is your billable base, and it is usually bigger than you think.
+
+**4. Compute the bill under each model and stress it.** Take your event count, message count, and profile count, and run each against the vendor's tiers. Then multiply your growth: if you 5x next year, which model 5x's your bill and which 20x's it? The model that stays proportional to your actual growth is the one you want. The one that multiplies faster than your business is the trap.
+
+This takes an afternoon in a spreadsheet and saves you the renegotiation later.
+
+## The questions to ask any vendor before you sign
+
+Get these answered in writing before a signature:
+
+- **What exactly is a billable unit?** Message, event, workflow run, profile, or active user. Make them define it precisely.
+- **Does adding a channel multiply my bill?** This separates per-run models from per-message models, and it is the question that predicts your multi-channel cost.
+- **Am I billed for stored profiles I never message?** For profile-based models, ask how dormant and duplicate profiles are counted and whether deleting them lowers the bill.
+- **What are the overage rates past my tier?** The in-tier rate is marketing. The overage rate is what you pay when you grow.
+- **How is a retry or a fallback counted?** If a failed email retries or falls back to another channel, is that one unit or several? At scale this compounds.
+- **Can I see a bill modeled on my real volume?** Give them your event, message, and profile numbers and ask for a modeled invoice, not a headline price.
+
+If a vendor cannot answer these cleanly, that is information too.
+
+## Where to land
+
+The mistake is picking a vendor on features and inheriting a pricing model you never evaluated. Reverse the order. Model your own event volume, fan-out, and real profile count, run them against each model, and stress the numbers against your growth. The model that stays proportional to your business is the one to buy, whatever the logo on it.
+
+Novu prices per workflow-run with channels included, so adding Slack, Microsoft Teams, WhatsApp, Telegram, Email, or in-app Inbox to a workflow does not multiply your bill by channel. Model your own numbers against it and check the current rates on the pricing page before you plan a budget.

--- a/content-drafts/blog/03-delivery-guarantee.md
+++ b/content-drafts/blog/03-delivery-guarantee.md
@@ -1,0 +1,165 @@
+---
+title: What "delivery guarantee" really means for notifications
+slug: notification-delivery-guarantee
+description: No honest vendor can promise your push or email arrived. Here is what each provider actually confirms, and the architecture that gets you close.
+category: Engineering
+target_keyword: guaranteed notification delivery
+reading_time: 11
+---
+
+A vendor tells you their notification platform offers "guaranteed delivery." You put it in your architecture diagram. Six months later a customer swears they never got the password reset email, your logs say "delivered," and you spend an afternoon learning that "delivered" in your dashboard meant "we handed it to an SMTP server that returned a 250." Those are not the same event. They are not even close.
+
+This is not a knock on any one vendor. It is a property of the system. The moment a notification leaves your infrastructure, it enters a chain of parties you do not control: an email provider, a mailbox provider, a mobile push gateway, a carrier's SMS network, a device that may be off. Each hop can drop the message, and most of them will never tell you they did. A delivery guarantee that spans that chain cannot exist, because you cannot guarantee behavior you cannot observe.
+
+What you can do is understand exactly what each provider confirms, build retries and fallbacks around the gaps, and instrument the whole thing so that when someone says "I never got it," you have real evidence instead of a green checkmark that means less than it looks like. That is the honest version of the job, and it is the one worth doing well.
+
+## "Delivered" is a lie most dashboards let you believe
+
+Walk through what actually happens when you send a transactional email. Your service connects to an SMTP relay and hands off the message. The relay accepts it and returns a `250 OK`. Your notification tool records this as a success and, in a lot of dashboards, shows it as "delivered."
+
+Here is the problem: `250` means "I have accepted responsibility for this message." It does not mean the recipient's mailbox provider accepted it, and it certainly does not mean a human saw it. Between that `250` and the inbox, the message can still be bounced, greylisted, routed to spam, or silently dropped by a filter that decided your domain looked risky today.
+
+The same optimistic labeling happens across channels. A push gateway returns a `200`, and the dashboard says "delivered." An SMS aggregator queues your message, and the dashboard says "delivered." In almost every case, the word "delivered" is standing in for "accepted by the next hop," which is a much weaker claim. The gap between those two meanings is where your 3am pages live.
+
+The takeaway for anyone designing this: treat the provider's success response as "accepted for processing," not "arrived." Then decide, per channel, how much closer to "arrived" you can actually get.
+
+## What each provider actually confirms
+
+Different channels give you wildly different amounts of downstream signal. Knowing the exact shape of each one tells you where you are flying blind.
+
+### Email: accepted, then maybe delivered, then maybe bounced
+
+SMTP is a store-and-forward protocol, so confirmation arrives in stages, and the stages are not simultaneous.
+
+- **Accepted.** The receiving SMTP server returns `250`. This is synchronous and immediate. It tells you the message was accepted for relay, nothing more.
+- **Delivered.** Some email providers (through their APIs and webhooks) report a separate "delivered" event when the destination mailbox provider accepts the message. This is closer to truth, but "the mailbox provider accepted it" still is not "it landed in the inbox rather than spam."
+- **Bounced.** A hard bounce (`550`, mailbox does not exist) or soft bounce (`452`, mailbox full) can come back synchronously or asynchronously, sometimes minutes later as a separate bounce message. You have to consume bounce webhooks to catch the async ones.
+- **Deferred.** The receiver asks you to try again later (greylisting is common). Not a failure yet, but not delivered either.
+
+So even for email, which has some of the richest downstream signal of any channel, "delivered" is a probabilistic statement, and spam placement is invisible to you entirely.
+
+### Push on iOS: APNs gives you a real answer, eventually
+
+Apple Push Notification service (APNs) returns a meaningful synchronous status when you submit a notification. A `200` means APNs accepted it for delivery to the device. Error statuses are specific and useful: `400` for a bad request, `403` for a certificate or token problem, `410` for a token that is no longer active (the device uninstalled or the token expired). That `410` is genuinely valuable because it lets you prune dead tokens.
+
+APNs also offers store-and-forward with a `apns-expiration` header, and it will collapse notifications with a matching `apns-collapse-id`. What APNs does not hand you by default is a "the user's phone displayed this" event. Its acknowledgment is "I, APNs, have accepted responsibility." It is a stronger acceptance than most, and paired with the companion piece on push tracking it is about as good as this category gets, but it is still acceptance, not proof of arrival on the device.
+
+### Push on Android: FCM accepts, and then goes quiet
+
+Firebase Cloud Messaging (FCM) is the hardest case, and it is worth being precise about why. When you send through the FCM HTTP v1 API, a `200` response with a message name means FCM accepted the message. FCM does not provide delivery receipts or delivery webhooks. There is no callback that fires when the message reaches the device. The FCM documentation is candid that delivery is best-effort and that message success at the API level does not indicate the device received or displayed anything.
+
+You can get some aggregate, delayed insight through the BigQuery data export for FCM, which reports counts of messages sent and, for some message types, delivered. That is an analytics-grade signal with latency, not a per-message, real-time confirmation you can act on in a workflow. For an individual notification, FCM returning success tells you FCM has the message. Whether the phone ever got it is, from your server's point of view, unknowable in real time.
+
+That is not a bug you can engineer around inside FCM. It is a documented limit of the platform, and any vendor claiming per-message Android delivery confirmation through FCM is describing something FCM does not expose.
+
+### SMS: delivery receipts exist, and they vary
+
+SMS is interesting because the protocol does support a delivery receipt (DLR). When you send through an aggregator (Twilio and similar providers), the carrier can return a status callback: `queued`, `sent`, `delivered`, `undelivered`, `failed`. A `delivered` DLR is a real downstream confirmation from the carrier.
+
+The catch is that DLR quality is uneven. Some carriers and some international routes do not return honest receipts, and a few return `delivered` optimistically. So SMS gives you more truth than FCM but less than you would like, and how much you can trust it depends on the route. Consume the status callbacks, but do not treat every `delivered` as gospel on every route.
+
+## At-least-once versus exactly-once
+
+Once you accept that confirmation is partial, the next design question is what delivery semantics you even want.
+
+**Exactly-once delivery is not a thing you can promise across this chain.** It is hard enough inside a single distributed system, and here the last hop is a mobile carrier or a mailbox provider that will happily deliver a message twice if a retry races an ack. Chasing exactly-once at the channel level is chasing a guarantee the substrate cannot give.
+
+**At-least-once is the honest and achievable target.** You retry until you get an acceptance (or exhaust your policy), which means a recipient can occasionally receive a duplicate. The engineering job then splits in two:
+
+1. Make sure every notification is attempted at least once, with retries that survive transient failures.
+2. Make duplicates harmless, so that at-least-once does not become annoying-many-times.
+
+That second point is why idempotency matters, and it is the part teams skip.
+
+## Retries, backoff, and idempotency keys
+
+Retries are where good intentions turn into incidents. A retry loop with no backoff turns a provider's brief hiccup into a self-inflicted flood. A retry loop with no idempotency key turns "at-least-once" into "the customer got charged-confirmation emails four times."
+
+Two rules cover most of it. Retry only on errors that can plausibly succeed later (network timeouts, `429` rate limits, `5xx`), and never on errors that will fail identically forever (a `400` bad payload, a `410` dead token). Back off exponentially with jitter so your retries spread out instead of synchronizing into a thundering herd.
+
+```ts
+type SendResult = { ok: true } | { ok: false; retryable: boolean };
+
+async function deliverWithRetries(
+  notificationId: string,
+  send: (idempotencyKey: string) => Promise<SendResult>,
+  maxAttempts = 5,
+): Promise<boolean> {
+  // Same key on every attempt for this notification, so a provider that
+  // supports idempotency collapses duplicates from our retries.
+  const idempotencyKey = `notif:${notificationId}`;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const result = await send(idempotencyKey);
+    if (result.ok) return true;
+    if (!result.retryable) return false; // 400, 410: retrying cannot help
+
+    // Exponential backoff with full jitter: base 500ms, cap 30s.
+    const backoff = Math.min(30_000, 500 * 2 ** attempt);
+    const jittered = Math.random() * backoff;
+    await new Promise((r) => setTimeout(r, jittered));
+  }
+  return false; // exhausted: escalate to fallback, do not silently drop
+}
+```
+
+The idempotency key is the quiet hero here. If your provider honors idempotency keys (many email and payment-adjacent APIs do), the same key across retries lets the provider deduplicate on its side. Where the provider does not support keys, you carry the burden yourself: record which notification IDs have been accepted, and check before re-sending. Either way, the key has to be stable for a given logical notification, not regenerated per attempt, or it does nothing.
+
+One more thing the loop shows: when retries are exhausted, the function returns `false` instead of pretending success. That failure is a signal, and the next section is what you do with it.
+
+## Fallback chains, and the one channel that actually confirms
+
+When a channel exhausts its retries, you have a decision encoded in your workflow: give up, or fall back to a different channel. Fallback chains are how you convert "this channel failed" into "the person still found out."
+
+A typical chain for a high-value notification: try push, and if it is not confirmed within a window, send an email, and if that bounces, send an SMS. Each step trades cost and intrusiveness for a higher chance of reaching a human. The logic is straightforward to describe and genuinely annoying to build reliably by hand, which is most of why notification infrastructure exists.
+
+Here is the flow for a single notification moving through trigger, provider, retry, and fallback:
+
+```mermaid
+sequenceDiagram
+    participant App as Your service
+    participant Wf as Workflow engine
+    participant Push as FCM / APNs
+    participant Email as Email provider
+    participant Inbox as In-app Inbox
+
+    App->>Wf: Trigger notification (event + recipient)
+    Wf->>Push: Send push
+    Push-->>Wf: 200 accepted (not confirmed arrival)
+    Note over Wf,Push: No delivery webhook from FCM.<br/>Wait for a confirmation window.
+    Wf->>Wf: Window elapses, no read/open signal
+    Wf->>Email: Fallback: send email
+    Email-->>Wf: 250 accepted
+    Email-->>Wf: Later: bounce webhook (hard bounce)
+    Wf->>Wf: Retry exhausted on email
+    Wf->>Inbox: Write to in-app Inbox
+    Inbox-->>Wf: Persisted (server-confirmed)
+    Note over Wf,Inbox: In-app is the one hop you fully control.
+```
+
+Notice where the diagram ends. Push was accepted but never confirmed. Email was accepted and then bounced. The only step that returns a confirmation you can fully trust is the in-app Inbox, because the message is stored in a system you own. When the user's client fetches their feed, it reads a record you wrote, and you know with certainty whether it exists and whether it was marked read.
+
+That is the whole reason in-app matters as more than a UI feature. In-app is the only channel where delivered means delivered. Everywhere else you are trusting someone who will not tell you.
+
+This is also why the sane pattern for anything that truly must reach a user is: fire the external channels for reach and immediacy, and write to the in-app Inbox as the durable source of truth. The push may or may not have arrived. The Inbox record definitely exists, and it is still there when the user opens the app tomorrow.
+
+## Instrumenting for real delivery evidence
+
+The final piece is making all of this observable, because a delivery pipeline you cannot inspect is a delivery pipeline you cannot trust. When a customer in a regulated industry asks you to prove a notice was sent, "the dashboard was green" is not an answer. A timestamped activity trail is.
+
+Instrument at four points, and store the events, not just the latest status:
+
+- **Accepted by provider.** The synchronous response, with the provider's message ID. This is your correlation key for everything downstream.
+- **Downstream events.** Bounces, deferrals, DLRs, `410` token invalidations. These arrive asynchronously through webhooks, so you need an endpoint that ingests them and joins them back to the message ID.
+- **Fallback transitions.** When a channel exhausts and the next one fires, record it. This is what explains why a user got an SMS instead of a push.
+- **In-app read state.** Delivered-to-feed and marked-read, both of which you own and can report with certainty.
+
+Persist these as an append-only activity feed per notification, keyed by the notification ID and enriched with each provider's message ID. That feed is what lets you answer "what happened to this specific message" honestly, and it is the difference between a support conversation that takes two minutes and one that takes an afternoon.
+
+A note on what not to promise while you build this. Teams in database and developer-infrastructure, in fintech capital-raising, and in govtech will ask you for an SLA and delivery proof, and the honest answer is to give them the proof (the activity trail) without inventing an SLA you cannot back. You can commit to what you control: attempts, retries, fallbacks, and a durable in-app record. You cannot commit to a mailbox provider's spam filter or FCM's best-effort delivery, and saying so plainly builds more trust than a number you would have to walk back.
+
+## Where Novu fits
+
+Novu is the delivery layer that runs this machinery so you do not hand-roll it. It manages retries with backoff, executes fallback chains across Slack, Microsoft Teams, WhatsApp, Telegram, and Email, writes to an in-app Inbox as your durable source of truth, and records every step in an activity feed you can query and show to an auditor. It does not pretend to confirm what FCM will not confirm. It gives you the closest honest approximation and the evidence trail to back it up.
+
+If you are building notification delivery you have to defend later, start from the provider truths in this article, then look at how the [Novu docs](https://docs.novu.co) handle retries, fallback, and the activity feed. Build on what you can actually observe, and be honest in your own dashboard about the rest.

--- a/content-drafts/blog/04-push-delivery-apns-fcm.md
+++ b/content-drafts/blog/04-push-delivery-apns-fcm.md
@@ -1,0 +1,132 @@
+---
+title: What "delivered" really means for push: APNs vs FCM
+slug: push-delivery-tracking-apns-fcm
+description: Sent, delivered, and opened mean different things on iOS and Android. Why FCM cannot confirm delivery, what APNs signals, and how to track push anyway.
+category: Engineering
+target_keyword: fcm delivery status push delivery tracking
+reading_time: 9
+---
+
+You ship a feature that depends on push notifications, and then the questions start. A user says the alert never showed up. Product asks what your delivery rate is. Someone wants a dashboard that says how many notifications were "delivered" versus "opened." You go looking for those numbers and discover that the two platforms you send to, Apple's and Google's, answer the question very differently, and one of them barely answers it at all.
+
+This is the detail that trips up most push implementations: "delivered" is not a single, portable concept. On iOS it means one thing and you get a decent signal for it. On Android it means something you largely cannot observe. If you build a metric that treats both the same, the metric lies, and it lies in the direction that makes Android look worse or better than reality depending on how you fudged it.
+
+This piece is the push-specific companion to the broader look at notification delivery guarantees. Here we stay inside the push pipeline: what actually happens between your server and a device, exactly what APNs and FCM each tell you, how to define sent, delivered, and opened so the definitions survive contact with reality, and how to build the best tracking the platforms allow.
+
+## The push pipeline, end to end
+
+A push notification is not a direct connection from your server to a phone. It is a relay through a gateway that each platform owns, and understanding the hops is what makes the confirmation gaps obvious.
+
+The path is the same shape on both platforms:
+
+1. Your server builds a payload and sends it to the platform gateway (APNs for Apple, FCM for Google), authenticated with a token or key, and addressed to a device token.
+2. The gateway validates the request and accepts or rejects it, returning a status to your server.
+3. The gateway attempts to deliver to the device over its own persistent connection, storing and forwarding if the device is briefly offline.
+4. The device's operating system receives the payload and either displays it or hands it to your app.
+5. If the user taps it, your app can record that interaction.
+
+Your server has direct visibility into step 2 only. Steps 3 and 4 happen inside the gateway and the device, on infrastructure you cannot see. Step 5 you can instrument yourself, on the client. Every claim about "delivery" lives or dies on how much the gateway tells you about step 3, and that is exactly where the two platforms diverge.
+
+```mermaid
+flowchart TB
+    subgraph iOS[iOS pipeline]
+        A1[Your server] -->|HTTP/2 request| A2[APNs]
+        A2 -->|status: 200 / 400 / 410| A1
+        A2 -->|push over persistent conn| A3[Device OS]
+        A3 --> A4[App displays / handles]
+        A4 -.tap.-> A5[Open event, client-side]
+    end
+    subgraph Android[Android pipeline]
+        B1[Your server] -->|HTTP v1 request| B2[FCM]
+        B2 -->|200 + message name| B1
+        B2 -->|best-effort delivery| B3[Device OS]
+        B3 --> B4[App displays / handles]
+        B4 -.tap.-> B5[Open event, client-side]
+    end
+    A2 -.no per-message<br/>delivery callback.-> A1
+    B2 -.no delivery receipt<br/>or webhook.-> B1
+```
+
+Both platforms leave the server blind after acceptance. The difference is in the quality of that acceptance and the error detail that comes with it.
+
+## APNs signal versus FCM silence
+
+### What APNs tells you
+
+When you send to APNs over its HTTP/2 API, you get a synchronous response with a status code and, on failure, a specific reason. The useful ones:
+
+- **`200`.** APNs accepted the notification for delivery. Paired in the response with an `apns-id` you can log and correlate.
+- **`400`.** Bad request, with a reason string like `BadDeviceToken` or `PayloadTooLarge`. This is a fix-your-request signal, not a retry signal.
+- **`403`.** An authentication problem with your token or certificate.
+- **`410`.** The device token is no longer valid, with a `timestamp` for when it went inactive. This is the one to act on: delete the token so you stop sending to a dead endpoint.
+
+APNs also honors an `apns-expiration` header (store and forward until this time, then give up) and collapses notifications sharing an `apns-collapse-id`. What none of this gives you is a callback that fires when the phone displays the notification. APNs acceptance means "APNs has taken responsibility and will attempt delivery," which is a genuinely useful, specific acceptance, but it is still acceptance, not a delivery receipt.
+
+### What FCM does not tell you
+
+FCM's HTTP v1 API returns a `200` with a message name (like `projects/your-project/messages/0:1234567890`) when it accepts your message. Error responses are reasonably specific too: `UNREGISTERED` for a stale token (Android's analog to APNs `410`), `INVALID_ARGUMENT` for a malformed payload, `QUOTA_EXCEEDED` for rate limits.
+
+But acceptance is where the real-time signal ends. FCM does not provide delivery receipts. There are no delivery webhooks. Nothing calls back to your server when the message reaches the device or when the OS displays it. Google's own documentation states that FCM delivery is best-effort and that a successful API response does not guarantee the device received the message. This is not an oversight in your integration. It is the documented behavior of the platform.
+
+There is one partial escape hatch, and it is worth knowing precisely for what it is. FCM offers a BigQuery data export that logs message events, including aggregate delivery data for certain message types. It is delayed (batched into BigQuery, not real-time) and aggregate-oriented, so it can tell you roughly how many messages were delivered over a period. It cannot give you a live, per-message "this notification arrived" event you can branch on inside a workflow. A govtech team that wants to correlate a specific message ID with its delivery outcome can join that message name against the BigQuery export after the fact, which is real and useful for audits, but it is forensics, not real-time tracking.
+
+So the blunt summary, and the line worth remembering when you design around it: FCM will tell you it accepted your message. It will never tell you the phone got it.
+
+## Sent, delivered, opened, defined precisely
+
+Because the platforms report different things, your metric definitions have to be explicit or your dashboard becomes fiction. Define each state by the observable event that backs it, not by a hopeful label.
+
+- **Sent.** Your server received a success response from the gateway (APNs `200` or FCM `200`). This is fully observable on both platforms and means "accepted by the gateway." It does not mean the device has it. Both platforms support this cleanly.
+- **Delivered.** The message reached the device OS. On iOS you cannot directly observe this in real time either, though APNs acceptance is a stronger proxy and its error codes prune failures well. On Android you cannot observe it per message in real time at all. Be honest that "delivered" for push is, at best, an inference, and on FCM it is an aggregate estimate from a delayed export.
+- **Opened.** The user interacted with the notification (tapped it, or your app registered it as seen). This is the one delivery-adjacent state you can measure directly, because it happens in your app on the device, where your code runs.
+
+The practical consequence: "sent" and "opened" are honest, portable metrics. "Delivered" is a soft metric that means different things per platform, and you should either annotate it heavily or avoid presenting it as if it were a hard number. A health platform frustrated that Firebase messaging gives no delivery signal is not misconfigured. It is running into the platform's actual limit, and the right response is to stop treating "delivered" as a reliable Android metric and lean on "opened" plus in-app state instead.
+
+## Correlating message IDs and instrumenting opens
+
+Since the gateways will not push delivery events to you, the tracking you can build rests on two things you do control: the message IDs the gateways hand back, and the client-side events your app can emit.
+
+**Correlate on the gateway message ID.** Log the `apns-id` (iOS) and the FCM message name (Android) at send time, keyed to your own internal notification ID. This is what lets you later join an individual notification against APNs error responses, an FCM `UNREGISTERED` cleanup, or the FCM BigQuery export. Without that correlation stored at send time, after-the-fact reconciliation is impossible.
+
+**Instrument opens on the client.** The device is the one place you can observe what actually happened to the notification, so put your best tracking there. Include your internal notification ID in the payload, and report back when the app handles or the user taps the notification.
+
+```ts
+// Client-side (React Native example). Report the open back to your server,
+// carrying the same notification ID you logged at send time.
+messaging().onNotificationOpenedApp((remoteMessage) => {
+  const notificationId = remoteMessage.data?.notificationId;
+  if (!notificationId) return;
+
+  fetch("https://api.yourapp.com/notifications/opened", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      notificationId,
+      platform: Platform.OS, // "ios" | "android"
+      openedAt: new Date().toISOString(),
+    }),
+  });
+});
+```
+
+On iOS you can go a little further: a Notification Service Extension runs when a notification with `mutable-content` arrives, before the user interacts, which gives you a closer-to-delivery client signal than Android exposes. It is not free (it runs on the device under a tight time budget and only for notifications configured for it), but for high-value alerts it is the nearest thing to a real iOS delivery event.
+
+The pattern that falls out of this: you cannot measure delivery from the server, so you measure engagement from the client and treat that as your ground truth for "the notification reached a human."
+
+## Designing around the gaps
+
+Once you accept what the platforms do and do not report, the architecture almost writes itself. Three principles cover it.
+
+**Treat push as best-effort, always.** Never make push the sole path for anything that must reach the user, because you have no per-message confirmation on Android and only a strong proxy on iOS. Push is for immediacy and reach, not for guarantees. If a message truly must land, push is one of several attempts, not the whole plan.
+
+**Make the in-app Inbox your source of truth.** The one channel where you can confirm the message exists and know whether it was read is the in-app feed, because the record lives in a system you own. Write every important notification there in addition to firing push. When the user opens the app, they read a record you wrote, and you know for certain it was delivered and whether it was seen. Push may have arrived; the Inbox record definitely did.
+
+**Clean up dead tokens on the signals you do get.** Both platforms tell you when a token is dead (APNs `410`, FCM `UNREGISTERED`). Consume those, delete the tokens, and your "sent" numbers stop being polluted by endpoints that were never going to receive anything. This is the one place the gateways give you unambiguous truth, so use it.
+
+Put together, the honest push stack looks like this: send to APNs and FCM for reach, log both gateway message IDs, prune dead tokens on the error signals, instrument opens on the client as your real engagement metric, and back everything with an in-app Inbox that actually confirms. That is the most tracking the platforms allow, and it is enough to run on, as long as you never mistake FCM's `200` for a phone that buzzed.
+
+## Where Novu fits
+
+Novu is the delivery layer that puts APNs and FCM behind one workflow, so you send once and Novu handles the per-platform payloads, token cleanup on `410` and `UNREGISTERED`, and message-ID logging for correlation. It records each step in an activity feed and pairs push with an in-app Inbox that gives you the confirmation the gateways cannot. Novu does not invent a delivery receipt FCM refuses to send. It gives you the real signals, cleanly unified, plus the one channel that actually confirms.
+
+If you are wiring up push tracking and want to stop hand-rolling two platform integrations, see how the [Novu docs](https://docs.novu.co) model push alongside the in-app Inbox and the activity feed. Track what you can observe, treat the rest as best-effort, and be precise in your own dashboard about which is which.

--- a/content-drafts/blog/05-transactional-email-vs-infra.md
+++ b/content-drafts/blog/05-transactional-email-vs-infra.md
@@ -1,0 +1,146 @@
+---
+title: "Transactional email service vs notification infrastructure: when you outgrow SendGrid"
+slug: transactional-email-vs-notification-infrastructure
+description: "An ESP sends email. Notification infrastructure decides what to send, to whom, and on which channel. Here is when you cross that line."
+category: Engineering
+target_keyword: transactional email vs notification infrastructure
+reading_time: 9
+---
+
+You picked SendGrid (or Resend, or Postmark) on day one and it was the right call. A password reset, a receipt, a welcome email. One channel, a handful of templates, an API key in an environment variable. It worked, and it kept working for a long time.
+
+Then the product grew. Someone asked for an in-app bell icon. Support wanted a Slack ping when a high-value account hit an error. Users started replying "stop emailing me about this" and you realized you had no preference model. A single noisy job began sending forty separate emails where one summary would do. None of these are email problems. They are notification problems, and an email service provider (ESP) was never built to solve them.
+
+This is a guide to that transition. When one channel and a template stop being enough, what the actual difference is between a transactional email service and multi-channel notification infrastructure, and the concrete signals that tell you which side of the line you are on. The short version, which is worth keeping in mind the whole way through: an ESP sends email. A notification layer decides what to send, to whom, on which channel, and whether to send at all.
+
+## What an ESP is genuinely great at
+
+Let us be fair, because an ESP is a valid starting point and stays valuable long after you outgrow it as your whole notification stack.
+
+An email service provider is a specialist in the mechanics of getting an email into an inbox. That is a genuinely hard problem, and the good ones are excellent at it:
+
+- **Deliverability.** IP warmup, domain reputation, SPF, DKIM, and DMARC alignment, feedback loops with mailbox providers, bounce and complaint handling. This is deep, unglamorous infrastructure work, and outsourcing it is almost always correct.
+- **Throughput.** Sending millions of messages with retries and rate control against each mailbox provider's limits.
+- **Email-native features.** Template rendering, link tracking, open tracking, suppression lists, and sending-domain management.
+- **A clean API.** One POST and the message is on its way.
+
+Here is the key point: none of this goes away when you adopt notification infrastructure. A good notification layer keeps your ESP exactly where it belongs, as the thing that actually delivers email. You do not rip SendGrid out. You stop asking it to be something it is not.
+
+A basic transactional send looks like this, and for a long time it is all you need:
+
+```ts
+import sgMail from "@sendgrid/mail";
+
+sgMail.setApiKey(process.env.SENDGRID_API_KEY);
+
+await sgMail.send({
+  to: user.email,
+  from: "noreply@acme.com",
+  templateId: "d-welcome-template",
+  dynamicTemplateData: { firstName: user.firstName },
+});
+```
+
+Clean. Readable. Nothing wrong with it. The trouble starts when this snippet stops being the only one.
+
+## The moment email alone breaks
+
+The break is rarely a single dramatic event. It is a slow sprawl. Here is the sequence most teams live through.
+
+**You add a second channel.** Product ships an in-app inbox, that bell icon with a dropdown of recent activity. Now every "we sent an email" moment needs a matching in-app record. Your `sendWelcomeEmail` function grows a sibling, `createInAppNotification`, and every call site has to remember to call both.
+
+**You add push, or Slack, or WhatsApp.** Mobile wants push notifications. A B2B workflow needs to notify a shared Slack channel. Now the same underlying event, "invoice overdue", fans out to email, in-app, push, and Slack. Four SDKs, four payload shapes, four failure modes, called from the same handler.
+
+**You add preferences.** Users want control. Email me for security, but only in-app for social. Digest the noisy stuff. Now every send site needs a preference check before it fires. That logic lands wherever it is convenient, which means it lands in ten places, subtly different in each.
+
+**You add digests and throttling.** A batch job that touches a thousand records should not send a thousand emails. You need to collect events over a window and roll them into one. That is stateful. It does not belong in a send call at all, but that is where it ends up, wrapped in a Redis key someone will be afraid to touch in a year.
+
+**You add routing rules.** Try push first, fall back to email if the device token is stale. Route by user tier. Suppress during quiet hours in the user's timezone. This is real business logic, and it is now interleaved with template IDs and API keys.
+
+Step back and look at what you have built. Scattered across your codebase, in controllers and jobs and webhook handlers, is a notification system. Nobody designed it. It emerged. It has no single place to answer basic questions: what did we send this user this week, why did this message not go out, how do we add a channel without touching forty files.
+
+We saw this exact shape at an AI-infrastructure company whose SendGrid calls were scattered across the codebase with no central place to manage them. Adding a channel meant grepping for `sgMail.send` and praying. Every engineer who touched notifications had to reverse-engineer the implicit rules. The email was never the problem. The absence of a decision layer was.
+
+## ESP vs notification infrastructure, feature by feature
+
+The clearest way to see the gap is to line the two up against the jobs a maturing product actually needs.
+
+| Capability | Transactional email service (ESP) | Notification infrastructure |
+|---|---|---|
+| Email delivery | Yes, this is the core competency | Delegates to an ESP as a provider |
+| Channels | Email only | Email, in-app inbox, push, Slack, Microsoft Teams, WhatsApp, Telegram |
+| Multi-channel workflow | No, one send per call | One event fans out across channels |
+| User preferences | Suppression lists only | Per-channel, per-category preference model |
+| Digest and batching | No | Collect over a window, send one summary |
+| Throttling and quiet hours | Rate limits, not user-facing rules | First-class step in the pipeline |
+| Routing and fallback | No | Try push, fall back to email, route by tier |
+| Provider failover | Single provider | Swap or fail over between providers |
+| Activity feed | Per-email event logs | Per-user, cross-channel delivery timeline |
+| Where logic lives | In your application code | In a versioned workflow definition |
+
+Read the last row twice, because it is the real distinction. With an ESP, every decision about what to send and to whom lives in your application code, spread across call sites. With notification infrastructure, those decisions move into one workflow definition. The application emits an event and the workflow decides the rest.
+
+The shift in the calling code makes it concrete. Instead of orchestrating channels by hand, you trigger one workflow:
+
+```ts
+import { Novu } from "@novu/api";
+
+const novu = new Novu({ secretKey: process.env.NOVU_SECRET_KEY });
+
+// The app emits one event. The workflow decides channels,
+// preferences, digest, and delivery.
+await novu.trigger({
+  workflowId: "invoice-overdue",
+  to: { subscriberId: user.id, email: user.email },
+  payload: { invoiceId, amountDue, dueDate },
+});
+```
+
+Every routing rule, preference check, digest window, and channel choice lives inside the `invoice-overdue` workflow, defined once and versioned. Your ESP is still doing the email delivery underneath. It is just no longer the thing making decisions it was never designed to make.
+
+## A migration path from SendGrid or Resend
+
+The good news is this is not a rip-and-replace. You keep your ESP, your templates, and your deliverability reputation. You are changing who makes the routing decisions, not who delivers the email. A staged path keeps you shippable the whole way.
+
+**1. Add your ESP as a provider.** Connect SendGrid or Resend to the notification layer as its email provider. Your sending domain, reputation, and templates carry over. This step changes nothing user-facing.
+
+**2. Model your first workflow.** Pick one high-value flow, say the welcome sequence. Define it as a workflow with a single email step. Trigger it from one call site. Confirm parity with what you had.
+
+```bash
+# Trigger the workflow from anywhere, one call, one event.
+curl -X POST https://api.novu.co/v1/events/trigger \
+  -H "Authorization: ApiKey $NOVU_SECRET_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "welcome",
+    "to": { "subscriberId": "user_123", "email": "dev@acme.com" },
+    "payload": { "firstName": "Sam" }
+  }'
+```
+
+**3. Migrate call sites incrementally.** Replace direct `sgMail.send` calls with workflow triggers, one flow at a time. Each migration collapses a bundle of ad hoc logic into one event. There is no big-bang cutover, and you can run both paths side by side during the transition.
+
+**4. Add the second channel where it earns its place.** Now the payoff. Add an in-app step to a workflow and it appears in both channels with no new call sites. Add push the same way. The fan-out you were dreading becomes a line in a workflow definition.
+
+**5. Move preferences and digest into the pipeline.** Turn on the preference check and the digest step as workflow stages. The stateful batching logic you were nervous about deleting now lives in infrastructure built for it, not in a Redis key in a cron job.
+
+Each step is independently shippable, and you are never in a broken half-state.
+
+## When you do not need this yet
+
+Honesty matters more than a conversion here, so here is the counsel against adopting too early.
+
+If you send one or two transactional emails, a receipt and a password reset, and you have no plan for a second channel, a direct ESP integration is the right tool. Adding a notification layer would be overhead with no payoff. The three or four lines of `sgMail.send` are genuinely simpler, and simpler is correct until it is not.
+
+You have probably outgrown the ESP-only setup when several of these are true:
+
+- You send across more than one channel, or you know you will within a quarter.
+- The same event has to reach a user in more than one place.
+- Users are asking for notification preferences and you have nowhere clean to put them.
+- A batch job can flood someone, and you are hand-rolling batching.
+- "Why did this message not go out" takes more than a minute to answer.
+- Adding a channel means editing many files instead of one definition.
+
+If you recognized three or more, the sprawl has already started. The question is only whether you manage it deliberately or keep discovering it in production.
+
+Novu keeps your ESP as one provider under a multi-channel workflow, so SendGrid or Resend keeps delivering email while the routing, preferences, and digest logic move into one place you can actually reason about. See the [workflow and provider docs](https://docs.novu.co) to map your first flow.

--- a/content-drafts/blog/06-notification-system-architecture.md
+++ b/content-drafts/blog/06-notification-system-architecture.md
@@ -1,0 +1,237 @@
+---
+title: "Design a multi-channel notification system: a real architecture guide"
+slug: multi-channel-notification-system-architecture
+description: "The components, data model, and delivery guarantees behind a multi-channel notification system, with diagrams and the tradeoffs that matter."
+category: Engineering
+target_keyword: notification system design
+reading_time: 16
+---
+
+Almost every product needs to tell users things. A password was reset, a build failed, an invoice is overdue, someone mentioned you in a comment. The first version is always a send function. Someone writes `sendEmail(user, message)`, ships it, and moves on. It works, and for a while nobody thinks about it again.
+
+Then the requirements arrive. Add push. Add an in-app inbox. Let users mute the noisy stuff. Do not send a thousand emails when a batch job touches a thousand rows. Tell me why a message did not go out. Each request seems small. Together they turn that send function into a distributed system with delivery guarantees, and most teams do not notice the transition until they are debugging it in production.
+
+This is a guide to the shape of that system: the components, the data model, the delivery semantics, and the tradeoffs that actually bite. It is vendor-credible but not a pitch. The product shows up once, at the end, because the architecture is the point. Keep one idea in the back of your mind the whole way through, because everything below is a variation on it: a notification system is not a send function. It is a routing decision, a preference check, and a delivery guarantee wearing a trench coat.
+
+## The requirements that make notifications hard
+
+Before drawing boxes, get honest about what makes this problem non-trivial. If you only ever send one email per event to every user, you do not need any of this. The difficulty comes from the combination of the following requirements, all of which tend to arrive.
+
+- **Multi-channel.** The same event reaches users across email, in-app inbox, push, Slack, Microsoft Teams, WhatsApp, and Telegram. Each has a different payload shape, delivery model, and failure mode. Email is fire-and-hope with async bounces. Push has device tokens that expire. Chat channels have their own rate limits and formatting.
+- **Preferences.** Users want control at the intersection of category and channel. Security alerts by email, social activity in-app only, nothing on weekends. The preference model is a matrix, not a boolean, and it has to be checked on every send without becoming a bottleneck.
+- **Deduplication.** The same logical event can be produced more than once (a retried job, an at-least-once queue, two services reacting to the same state change). Users should not get the same alert twice. That means an idempotency story from ingestion all the way to delivery.
+- **Digest and throttling.** High-frequency events must collapse. Ten comments in five minutes becomes one "10 new comments" notification. A user should never be flooded. This is inherently stateful and time-windowed.
+- **Scale.** Fan-out is multiplicative. One event to a topic with 50,000 subscribers across three channels is 150,000 deliveries, each with its own retry curve. Traffic is spiky, tied to product events and business hours.
+- **Observability.** When someone asks "did the alert go out, and if not, why", you need a per-user, per-message, cross-channel answer. Without it, every notification bug is an archaeology project.
+
+Hold these six in mind. Every component below exists to serve one or more of them.
+
+## The core components, end to end
+
+Here is the decomposition that a maturing notification system converges on, whether the team plans it or discovers it. The names vary. The responsibilities do not.
+
+```mermaid
+flowchart LR
+  A[Application] -->|emit event| B[Event ingestion]
+  B --> C[Workflow engine]
+  C --> D[Preference resolver]
+  D --> E[Digest and throttle]
+  E --> F[Channel router]
+  F --> G1[Email adapter]
+  F --> G2[In-app adapter]
+  F --> G3[Push adapter]
+  F --> G4[Chat adapter]
+  G1 --> H[Provider: ESP]
+  G3 --> I[Provider: APNs / FCM]
+  G4 --> J[Provider: Slack / Teams / WhatsApp / Telegram]
+  G1 --> K[Delivery tracker]
+  G2 --> K
+  G3 --> K
+  G4 --> K
+  K --> L[(Activity feed)]
+```
+
+Walk it left to right.
+
+### Event ingestion
+
+The front door. Your application emits an event, not a message: "invoice.overdue", with a payload of `invoiceId`, `amount`, `subscriberId`. The distinction is load-bearing. The application says what happened. It does not decide who gets told, on which channel, or whether to tell them at all. That separation is what keeps notification logic out of your business code.
+
+Ingestion accepts the event, validates it, assigns it a stable id for idempotency, and hands it to the engine. This is also where you enforce back-pressure. A spike in events should queue, not topple the downstream stages.
+
+### Workflow engine
+
+The brain of the routing decision, and the component people most often under-build. A workflow is the versioned definition of what happens when an event fires: which channels, in what order, with what delays, gated by which conditions. "On invoice.overdue: send email immediately, wait three days, if still unpaid send a second email and an in-app notice."
+
+Keeping this as a first-class, versioned definition (rather than branching `if` statements scattered across services) is the single highest-leverage architectural choice in the whole system. It is the difference between changing behavior by editing one definition and changing it by hunting through call sites.
+
+### Preference resolver
+
+Before any channel fires, this stage answers "is this user willing to receive this category on this channel right now". It reads the preference matrix, applies quiet-hours and timezone rules, and filters the channel list for this specific delivery. Critical-path, so it has to be fast, which usually means the preference store is cached aggressively with careful invalidation.
+
+### Digest and throttle
+
+The stateful stage. It buffers events over a window keyed by user and digest rule, and either releases them individually or collapses them into one summary. This is where "10 new comments" is born. It needs durable timers and a store that survives restarts, because a digest that loses its buffer on deploy silently drops notifications.
+
+### Channel router and provider adapters
+
+The router takes the surviving channel list and dispatches to an adapter per channel. Each adapter translates the canonical message into that channel's specific shape and speaks to the underlying provider: an ESP such as SendGrid or Resend for email, APNs or FCM for push, the platform APIs for Slack, Microsoft Teams, WhatsApp, and Telegram. The adapter owns provider-specific retries, rate limiting, and error mapping. Isolating this means a provider outage or migration touches one adapter, not the whole pipeline.
+
+### Delivery tracker and activity feed
+
+Every attempt, success, failure, bounce, open, and click flows into the tracker, which writes a per-user, per-message, cross-channel timeline. This is what turns "I think it sent" into "delivered to email at 14:03, opened at 14:07, in-app read at 14:10". It is both your debugging surface and, often, the data behind a user-facing in-app inbox.
+
+## The data model
+
+The components above only make sense on top of a small set of durable entities. Get these right and the rest follows.
+
+```mermaid
+erDiagram
+  SUBSCRIBER ||--o{ PREFERENCE : has
+  SUBSCRIBER ||--o{ NOTIFICATION : receives
+  SUBSCRIBER }o--o{ TOPIC : subscribes
+  WORKFLOW ||--o{ NOTIFICATION : produces
+  WORKFLOW ||--o{ STEP : contains
+  STEP ||--o{ NOTIFICATION : generates
+  TOPIC ||--o{ WORKFLOW : triggers
+
+  SUBSCRIBER {
+    string id PK
+    string email
+    string phone
+    json   channels
+    string timezone
+  }
+  PREFERENCE {
+    string subscriberId FK
+    string category
+    string channel
+    bool   enabled
+  }
+  TOPIC {
+    string key PK
+    string name
+  }
+  WORKFLOW {
+    string id PK
+    string name
+    int    version
+  }
+  STEP {
+    string id PK
+    string workflowId FK
+    string channel
+    json   config
+  }
+  NOTIFICATION {
+    string id PK
+    string subscriberId FK
+    string workflowId FK
+    string status
+    json   payload
+  }
+```
+
+Four entities carry the weight.
+
+- **Subscriber.** The recipient, decoupled from your user table. It holds channel identifiers (email, phone, device tokens, chat handles) and a timezone. Keeping subscribers separate from your internal user records means the notification system does not need to understand your domain, only who to reach and how.
+- **Topic.** A named group for fan-out. Instead of enumerating recipients, you publish to a topic ("project-42-watchers") and the system resolves membership at send time. This is what makes broadcast to 50,000 subscribers a single trigger.
+- **Workflow and Step.** The versioned routing logic, described above, made durable. A workflow has ordered steps, each bound to a channel with its own config.
+- **Preference.** The per-subscriber, per-category, per-channel matrix. Modeled as rows rather than a JSON blob so it can be queried and aggregated, though hot reads are almost always cached.
+
+A design note worth stating plainly: separate the subscriber from your user. Teams that jam notification state into their existing users table regret it the first time they need a second product surface, a service account, or an external recipient who is not a user at all.
+
+## Fan-out and delivery: at-least-once and idempotency
+
+This is where the trench coat comes off and you are looking at a distributed system. Fan-out is the moment one event becomes many deliveries, and the delivery guarantee you choose shapes everything downstream.
+
+The honest default is **at-least-once**. Exactly-once delivery across independent external providers is not achievable in the general case (you cannot atomically both send an email and record that you sent it), so you commit to at-least-once and then make duplicates harmless through idempotency. The alternative, at-most-once, means silently dropping notifications on failure, which is rarely acceptable for the security-alert and billing-notice traffic that matters most.
+
+```mermaid
+flowchart TD
+  A[Event: comment.created on topic] --> B{Resolve topic members}
+  B --> C1[Subscriber A]
+  B --> C2[Subscriber B]
+  B --> C3[Subscriber ...N]
+  C1 --> D[Per-subscriber job<br/>idempotency key]
+  C2 --> D
+  C3 --> D
+  D --> E{Already processed?}
+  E -->|yes| F[Skip, log dedup]
+  E -->|no| G[Run workflow steps]
+  G --> H[Enqueue per-channel delivery]
+  H --> I{Delivery attempt}
+  I -->|success| J[Mark delivered]
+  I -->|transient failure| K[Retry with backoff]
+  K --> I
+  I -->|permanent failure| L[Dead-letter + surface in feed]
+```
+
+A few decisions make this robust in practice.
+
+**Idempotency keys everywhere.** Derive a stable key per logical delivery, for example `hash(eventId + subscriberId + stepId)`. Before running a step, check whether that key has been processed. This is what lets you retry aggressively and reprocess a queue without double-sending. It is the single most important reliability mechanism in the system.
+
+**Fan-out as individual jobs.** Resolve topic membership into one durable job per subscriber, do not process a 50,000-member topic in one transaction. Per-subscriber jobs isolate failures (one bad recipient does not sink the batch), parallelize cleanly, and retry independently.
+
+**Retries with backoff, then a dead-letter queue.** Transient provider errors (a 429, a timeout) retry with exponential backoff and jitter. Permanent errors (invalid address, unsubscribed) fail fast, land in a dead-letter queue, and surface in the activity feed rather than retrying forever.
+
+**Queue-backed, not in-request.** None of this happens in the request that emitted the event. Ingestion enqueues, the request returns, and workers drain the pipeline. Your API latency stays flat while a broadcast to tens of thousands processes in the background.
+
+The tradeoff to name out loud: at-least-once plus idempotency is more moving parts than a naive synchronous send, and you will occasionally serve a duplicate if an idempotency check races. In exchange you get a system that does not lose notifications under load or during deploys, which is the correct trade for anything a user relies on.
+
+## Preferences, digest, and throttle in the pipeline
+
+These three are worth a closer look because they are where notification systems earn their keep, and where naive implementations quietly break.
+
+**Preferences as a pipeline stage, not a caller responsibility.** The wrong pattern is checking preferences at each call site before triggering. It scatters the logic and guarantees drift. The right pattern is a resolver stage that every notification passes through, reading the matrix once and filtering channels. A subscriber who muted "social" on email but kept it in-app gets exactly one of the two channels, decided in one place. Because it is on the critical path, the preference store is read-through cached, with invalidation on preference writes.
+
+**Digest as a windowed buffer.** A digest step holds events in a durable buffer keyed by (subscriber, digest rule) for a configured window, a fixed five minutes, or a smarter "wait until quiet" backoff. When the window closes, buffered events collapse into one notification with an aggregated payload. The two failure modes to design against: losing the buffer on restart (use durable storage and timers, not in-memory state) and unbounded windows (cap the buffer and the wait).
+
+```ts
+// A workflow expressed as ordered steps. Preference and digest
+// are stages in the pipeline, not checks in your app code.
+const commentWorkflow = workflow("new-comment", async ({ step, payload }) => {
+  // Collapse bursts: buffer for 5 minutes, then send one summary.
+  const digest = await step.digest("collect", {
+    amount: 5,
+    unit: "minutes",
+  });
+
+  await step.inApp("inbox", () => ({
+    body: `You have ${digest.events.length} new comments`,
+  }));
+
+  // Preference and quiet-hours filtering happen in the resolver
+  // stage before this email is dispatched to the ESP.
+  await step.email("notify", () => ({
+    subject: `${digest.events.length} new comments`,
+    body: renderDigest(digest.events),
+  }));
+});
+```
+
+**Throttle as a rate guard.** Distinct from digest. Throttle caps how many notifications of a type a user can receive per window, dropping or deferring the excess. Where digest merges, throttle limits. Both protect the user from flooding, and both belong in the pipeline rather than in the code that emits events.
+
+## Observability and the activity feed
+
+You cannot operate what you cannot see, and notifications are especially prone to silent failure because the feedback loop runs through external providers and human inboxes. Build the observability in from the start.
+
+Two layers matter.
+
+**System observability** is the operator's view: delivery rates per channel and provider, queue depth and lag, retry and dead-letter volume, per-provider error rates. This is standard metrics-and-tracing work, but the dimensions are notification-specific. A rising email bounce rate or a Slack adapter throwing 429s should page someone before users notice.
+
+**The activity feed** is the per-subscriber timeline: every notification this user was sent, on which channel, with which status, and when it was opened or read. This does double duty. It is the answer to "why did this user not get the alert" (you can see it was suppressed by a preference, or dead-lettered on a bad address), and it is frequently the backing store for a user-facing in-app inbox. Because you are already tracking every delivery for reliability, exposing a filtered slice of it as an inbox is a small additional step, not a separate system.
+
+The design principle: the delivery tracker is not a logging afterthought bolted on at the end. It is a first-class component that every adapter writes to, because the record of what happened is as much a product feature as the sending itself.
+
+## Where a platform saves you
+
+Here is the honest build-versus-buy bridge, because you can build everything above, and for some teams that is the right call.
+
+Build it yourself when notifications are core to your product's differentiation, when you have unusual requirements no general system models well, or when you have the team to own a stateful distributed system for the long haul. It is a real, well-understood engineering project. None of the components above are mysterious.
+
+The reason most teams should not is that the hard parts are not the parts that make your product better. Nobody chooses your product because you hand-rolled idempotent fan-out or a durable digest buffer. That work is necessary, invisible when it works, and painful when it does not. The list is long: the workflow engine, the preference matrix with caching and invalidation, durable digest windows, per-provider adapters and their retry curves, the delivery tracker, and the operational burden of keeping all of it running under spiky load. Mature teams, in construction tech, API security, and AI infrastructure among them, converge on exactly this architecture, and a good share of them decide the undifferentiated core is worth adopting rather than rebuilding.
+
+That is the case for notification infrastructure as a component you integrate rather than a system you own. You keep the parts that are specific to your product (which events fire, what the messages say, how the workflows branch) and delegate the parts that are the same for everyone (fan-out, delivery guarantees, preferences, digest, tracking).
+
+Novu is this architecture as open-source infrastructure, roughly 40K stars on GitHub, available as cloud or self-hosted. The workflow engine, subscriber and preference model, multi-channel routing, digest and throttle steps, and the activity feed are the components in this guide, built and maintained so you integrate them instead of rebuilding them. The [architecture and workflow docs](https://docs.novu.co) map directly onto the sections above if you want to see how the pieces line up in practice.

--- a/content-drafts/blog/07-notification-microservice.md
+++ b/content-drafts/blog/07-notification-microservice.md
@@ -1,0 +1,140 @@
+---
+title: "The notification microservice: components, patterns, and when to extract it"
+slug: notification-microservice-design
+description: "A practical guide to notification microservice design: the service boundary, the internal components, a queue-backed async interface, and when to extract."
+category: Engineering
+target_keyword: notification microservice design
+reading_time: 10
+---
+
+Most notification code does not start as a service. It starts as a function. Someone needs to send a welcome email, so they drop a call to SendGrid into the signup handler. A quarter later, someone else needs a payment-failed alert, so they write a second call in the billing service, with its own retry logic and its own idea of what a template is. A quarter after that, a third team wires up a Slack alert for security events, and now you have three implementations of "send a message to a human" that agree on nothing: not retries, not rate limiting, not user preferences, not how you tell whether a message actually landed.
+
+That is the moment the notification microservice earns its keep. Not before. This guide covers what that service is made of, where its boundary sits, the interface callers talk to, and the honest signal for when extracting it is worth the cost. The build reality is the part most teams underestimate: a real notification service, one with a template engine, multi-channel routing, preferences, delivery tracking, and retries, is roughly a six-to-twelve-month effort for a three-person team. That number is why most teams extract the service once and then quietly question whether they should own the engine inside it.
+
+## Signs your notifications should be their own service
+
+The trigger is duplication, not volume. You can send millions of emails a day from a single well-placed function and never need a service. You can send a few thousand and need one badly. The question is how many places in your codebase know how to send.
+
+Watch for these:
+
+- Three teams each reinventing "send an email" in three slightly different, slightly broken ways. One retries, one does not. One respects a user's unsubscribe flag, two forget it exists.
+- Preference logic copy-pasted. When a user says "no more marketing emails," you have to remember every send site that might violate it. Miss one and you have a compliance problem, not a bug.
+- No single answer to "did this notification get delivered?" Delivery state lives in whatever logs each service happens to write, so debugging a "I never got the email" ticket means grepping three codebases.
+- Every new channel is a project. Adding Slack means touching every service that wants to post to Slack, because there is no shared place for a channel to live.
+- Provider credentials sprayed across services. Your SendGrid key is in four `.env` files, and rotating it is a cross-team coordination exercise.
+
+None of these is fatal on its own. Together they mean the cost of not having a service now exceeds the cost of building one. Here is the takeaway to hold onto: extract notifications when three teams are each reinventing "send an email" in three slightly different, slightly broken ways. Duplication of a broken thing is the signal, because it means the domain is real and the pain is spreading.
+
+## The service boundary and interface
+
+A notification service has one job: turn an intent to notify someone into a delivered message, correctly, once, on the right channel, respecting that person's preferences. Everything the service owns follows from that sentence. Everything a caller has to know should be as small as possible.
+
+The interface is the contract, and the discipline is keeping it thin. A caller should hand over an intent and nothing operational. It should not pass a rendered email body. It should not pass a channel. It should not know your provider exists.
+
+A good trigger call looks like this:
+
+```ts
+await notifications.trigger({
+  // WHAT happened. Maps to a workflow the service owns.
+  workflow: "payment-failed",
+
+  // WHO to reach. Your user ID, not an email or phone number.
+  recipient: { subscriberId: "user_8f3a" },
+
+  // The data the templates need. No formatting, no channel logic.
+  payload: {
+    amountCents: 4200,
+    currency: "USD",
+    invoiceUrl: "https://app.example.com/i/inv_221",
+    retryDate: "2026-08-01",
+  },
+});
+```
+
+Look at what the caller does not supply. No subject line. No "send this on email, and also Slack if they are on the Pro plan." No channel fan-out. No knowledge of whether the user has muted payment alerts. The billing service knows a payment failed and who it belongs to. That is all it should know. The workflow named `payment-failed`, owned by the notification service, decides the rest: which channels, in what order, with which templates, subject to which preferences.
+
+This is what makes the service worth extracting rather than just refactoring. The boundary moves a whole category of decisions out of every product team and into one place that is good at them.
+
+## The internal components
+
+Behind that thin interface sits a small set of components, each with a clear responsibility. You can draw the whole thing on one diagram.
+
+```mermaid
+flowchart LR
+  A[Callers] -->|trigger intent| B[Ingestion API]
+  B --> Q[(Queue)]
+  Q --> C[Workflow engine]
+  C --> P[Preference store]
+  C --> D[Channel router]
+  D --> E1[Email provider]
+  D --> E2[Slack]
+  D --> E3[WhatsApp]
+  D --> E4[Telegram]
+  D --> E5[Teams]
+  D --> T[Delivery tracker]
+  T -.delivery + engagement.-> C
+  P -.allowed channels.-> C
+```
+
+**Ingestion.** The front door. It accepts trigger calls, validates them against a known workflow, resolves or upserts the recipient, and puts the work on a queue. Ingestion does as little as possible synchronously. It says "accepted" and hands off. Keeping this layer thin is what lets you absorb a spike from a batch job without falling over.
+
+**The workflow engine.** The core, and the expensive part to build well. It runs the logic attached to a workflow: send on these channels, in this order, wait this long between steps, skip the SMS if the in-app Inbox message was already seen, batch these ten events into one digest. It renders templates against the payload. It handles the branching. This is where the six-to-twelve months mostly goes, because "wait two hours, then send email only if still unread" is easy to describe and hard to make reliable across restarts, retries, and millions of concurrent flows.
+
+**The channel router.** Given a rendered message and a target channel, it talks to the right provider and normalizes the result. Email goes to your email provider. Slack, Microsoft Teams, WhatsApp, and Telegram each have their own transport and their own failure modes. The router hides those differences from the engine and turns provider-specific responses into one internal shape: accepted, soft-failed (retry), hard-failed (do not retry). In-app Inbox and push are handled here too, as channels the router knows how to write to.
+
+**The delivery tracker.** The component that answers "what happened to this notification?" It records state transitions (queued, sent, delivered, opened, failed) and feeds engagement back to the engine, so a workflow can make a real decision like "they read it in the Inbox, do not also send the email." Without a tracker you have a fire-and-forget system, and fire-and-forget is exactly the thing your three duplicated implementations already do badly.
+
+**The preference store.** The single source of truth for what each recipient has agreed to receive, per channel and per category. The engine consults it before every send. This is the component that, once centralized, quietly deletes a whole class of compliance bugs, because there is now exactly one place that can honor an unsubscribe and exactly one place to audit.
+
+## Sync at the edge, async underneath
+
+The trigger call should return in milliseconds. Delivery should not happen inside it. The moment you make a caller wait for an email provider to accept a message, you have coupled your signup latency to a third party's p99, and you have made a provider outage into an outage of your own product.
+
+So the interface is queue-backed. Ingestion validates and enqueues, then returns. Workers pull from the queue and run the workflow. The queue is not a detail, it is the thing that gives you the properties you actually want:
+
+- **Backpressure.** A million-row batch job floods the queue, not your database or your provider. Workers drain it at a sustainable rate.
+- **Retries with control.** A soft failure goes back on the queue with a backoff. The caller never sees it.
+- **Isolation.** A slow WhatsApp send does not block a fast Inbox write, if you shard queues by channel or priority.
+- **Survivability.** A worker crash mid-workflow does not lose the intent. It is still on the queue, or checkpointed, and another worker resumes it.
+
+Kafka, SQS, Redis streams, or a database-backed queue all work. The choice matters less than the discipline: the synchronous surface is validation and enqueue, and everything with a provider on the other side of it runs async.
+
+```mermaid
+sequenceDiagram
+  participant Caller
+  participant API as Ingestion API
+  participant Q as Queue
+  participant W as Worker (engine)
+  participant Prov as Provider
+  Caller->>API: trigger(intent)
+  API->>Q: enqueue
+  API-->>Caller: 202 Accepted
+  W->>Q: pull
+  W->>Prov: send (async, retried)
+  Prov-->>W: result
+  W->>W: record delivery state
+```
+
+## Multi-tenant concerns
+
+If your product is itself multi-tenant, your notification service inherits that, and a few things stop being optional.
+
+**Isolation of sending reputation.** One tenant's spammy behavior should not tank email deliverability for everyone. That can mean per-tenant subdomains, per-tenant provider subaccounts, or at least per-tenant rate limits and monitoring, so a bad actor is contained.
+
+**Data partitioning.** Recipients, preferences, and delivery history are tenant-scoped. A query must never cross tenants, and your preference lookups should carry the tenant in the key, not rely on application code to remember.
+
+**Per-tenant configuration.** Tenants often need their own branding, their own from-address, sometimes their own provider credentials (bring-your-own-SendGrid). The workflow engine has to resolve config in tenant context at send time, which is another reason the engine is the hard part.
+
+**Fair scheduling.** A single tenant firing a ten-million-recipient campaign should not starve every other tenant's transactional email. Priority lanes, per-tenant quotas, and separate queues for transactional versus bulk are how you keep a password reset moving while a marketing blast drains in the background.
+
+None of this is exotic, but all of it is work, and it is work that compounds the six-to-twelve-month estimate. It is also work you should not do twice, which is the whole argument for the service.
+
+## Build the engine, or adopt one
+
+Here is the fork in the road, stated plainly. Extracting the service is almost always right once you hit the duplication signal. The boundary is yours, the interface is yours, the fact that product teams send an intent and nothing else is yours. That part you own no matter what.
+
+The engine inside the service is the expensive, undifferentiated part. The template rendering, the multi-channel routing, the step-and-wait workflow logic, the delivery tracking, the retry semantics, the preference enforcement: this is the six-to-twelve-months, and it is roughly identical across every company that builds it. Mature teams in construction tech, AI infrastructure, and collaboration platforms all run notifications as a dedicated internal service, and the ones who built the engine from scratch will tell you it was more service than they meant to own.
+
+The pattern that ages well is to keep the boundary and adopt the engine. Your service still owns the interface product teams call. Behind it, an engine handles workflows, channels (Slack, Microsoft Teams, WhatsApp, Telegram, Email, plus in-app Inbox and push), templates, preferences, and delivery tracking, so your three-person team spends its year on the parts specific to your product instead of rebuilding step-and-wait logic that already exists.
+
+Novu is built to be that engine. It gives you the workflow engine, multi-channel routing, a template layer, subscriber preferences, and delivery tracking behind an API, so the service you extract is a thin layer you own over an engine you do not have to maintain. If you are staring at three copies of "send an email" and a year of work to unify them, that is the trade worth weighing. See the [Novu docs](https://docs.novu.co) for the workflow and API model.

--- a/content-drafts/blog/08-notifications-internal-platform.md
+++ b/content-drafts/blog/08-notifications-internal-platform.md
@@ -1,0 +1,106 @@
+---
+title: "Notifications as an internal platform: wrap the vendor behind your own service"
+slug: notifications-internal-platform
+description: "How to decouple notifications from your application: a thin internal service in front of a notification vendor so product teams send only intent."
+category: Engineering
+target_keyword: decouple notifications from application
+reading_time: 10
+---
+
+There is a tell that separates teams who have run notifications at scale from teams who are about to learn. Ask a product engineer at the first kind of team which notification vendor the company uses. They will not know. They send an intent to an internal service, and something they never look at decides the rest. That ignorance is not a gap. It is the design working.
+
+This is the internal platform pattern for notifications: a thin service your product teams call, sitting in front of whatever vendor actually delivers the message. Product teams send three things, an audience, a message, and a destination, and never learn the vendor's SDK, its rate limits, its template syntax, or its name. This guide covers why you would wrap a vendor at all, what the internal interface looks like, how you translate your existing events into it, where preferences and templates live, and the payoff that makes the whole thing worth it: the vendor stays swappable. Which, counterintuitively, is a compliment to a good vendor, not an insult.
+
+## Why wrap a vendor at all
+
+The instinct to push back here is healthy. You picked a good notification vendor precisely so you would not have to build this. Why add a layer in front of it?
+
+Because a raw vendor SDK, called directly from twenty places, recreates every problem the vendor was supposed to solve, just one level up:
+
+- **The vendor's vocabulary leaks into your product code.** Its concept of a "campaign" or "message type" or "audience list" ends up hard-coded in your billing service, your auth service, your onboarding flow. Now the vendor's model is your model, everywhere.
+- **Cross-cutting rules have no home.** Quiet hours, per-user notification caps, a global kill switch for a bad deploy, category-level unsubscribe. With direct calls, each rule has to be re-implemented at every call site, or it does not exist.
+- **You cannot see your own notification traffic.** There is no single place to log, meter, or rate-limit what your product sends, because there is no single place it goes through.
+- **Swapping or adding a vendor is a company-wide migration.** Because the vendor's API is your API, changing it touches every team.
+
+A thin internal service fixes all four by giving you one place that owns the vendor relationship. Product teams talk to you. You talk to the vendor. The best notification integration is the one your product teams never see: they send an intent, and the platform decides everything else.
+
+## The internal interface: audience, message, destination
+
+The whole pattern rests on getting the interface right, and the interface is deliberately small. A caller provides three things:
+
+- **Audience.** Who should receive this, expressed in your identifiers. A user ID. A team ID. A topic like `project:221:watchers`. Never an email address or a phone number, because those are contact details the platform resolves, not the caller.
+- **Message.** What happened and the data to render it, not the rendered text. An event name plus a typed payload. The caller says "an invoice failed, here is the amount and the retry date." It does not say "Subject: Your payment failed."
+- **Destination.** Intent about reach, not mechanism. Often this is nothing at all, and the platform decides from the message type and the recipient's preferences. When a caller does express it, it is coarse: "this is transactional, it must reach them" versus "this is a digest item, batch it."
+
+```ts
+// What a product team writes. Nothing here names the vendor.
+await platform.notify({
+  audience: { userId: "user_8f3a" },
+  message: {
+    event: "invoice.payment_failed",
+    data: { amountCents: 4200, currency: "USD", retryDate: "2026-08-01" },
+  },
+  // destination is optional; the platform resolves channels + preferences
+});
+```
+
+Everything a vendor SDK would demand, the API key, the channel, the template ID, the provider-specific payload shape, is absent. That absence is the product. The caller expresses intent. The platform owns mechanism.
+
+## Translating your events
+
+Most teams do not want product code calling even the internal API by hand for every notification. The higher-leverage move is to translate events you already emit. If your services publish domain events to Kafka (or any bus), you can bridge those into notifications without product teams writing a single notify call.
+
+The bridge is a small consumer sitting between your event bus and an internal HTTP gateway. It subscribes to the domain events that should produce notifications, maps each one to the platform's audience-message-destination shape, and calls the gateway. The gateway is the thin service that owns the vendor.
+
+```mermaid
+flowchart LR
+  subgraph Producers
+    S1[Billing service]
+    S2[Auth service]
+    S3[Collaboration service]
+  end
+  S1 --> K[(Kafka)]
+  S2 --> K
+  S3 --> K
+  K --> C[Event-to-notification consumer]
+  C -->|audience, message, destination| G[Internal notification gateway]
+  G --> V[Notification vendor]
+  V --> Ch[Slack / Teams / WhatsApp / Telegram / Email]
+```
+
+The consumer holds the mapping ("`invoice.payment_failed` becomes a notification to the account owner"), which keeps that policy out of the billing service. The gateway holds the vendor relationship. An AI-infrastructure team running this exact shape translates Kafka events through a gateway so their product services stay entirely event-driven and entirely unaware that a notification vendor is downstream. The producers just emit facts. The bridge turns facts into notifications.
+
+You do not need a bus to use the pattern. A synchronous service calling the gateway's HTTP endpoint directly works fine. The event bridge is simply the version that scales to many producers without any of them learning the platform.
+
+## Where preferences and templates live
+
+Two questions decide how clean this stays: where do user preferences live, and where do templates live. Get these wrong and the vendor leaks back through.
+
+**Preferences belong to the platform.** The platform is the one place that sees every send, so it is the only place that can enforce "no notifications between 10pm and 8am in the user's timezone," "no more than five of these a day," or "this user unsubscribed from digest emails." Product teams must not carry preference logic, because any team that forgets is a compliance incident. Centralizing preferences is most of the reason the platform earns its existence.
+
+**Templates often belong to the product teams, through the platform.** This is the nuance that trips people up. The rendered wording of a payment-failure message is domain knowledge the billing team owns. The mechanism for rendering and delivering it is platform knowledge. The pattern that scales is to let each product team own its templates as versioned artifacts (in their own repo, reviewed by them), and register them with the platform, while the platform owns rendering, channel selection, and delivery. The billing team writes the words. The platform decides it goes to Email and Slack, respects preferences, and tracks whether it landed.
+
+The line is: content is domain, delivery is platform. Preferences are always platform, because they cut across every domain.
+
+## Keeping the vendor swappable
+
+Here is the payoff, and it is worth being precise about what it does and does not mean. Because product teams only ever touched audience-message-destination, and never the vendor's SDK, replacing the vendor is a change inside the gateway alone. You reimplement one adapter. Nothing upstream moves. No product team is involved. A migration that would have been a quarter-long cross-team project becomes a task on the platform team's board.
+
+Being able to swap the vendor is not a plan to swap the vendor. Most teams who build this never switch, and that is fine. Swappability is a compliment to a good vendor, not a threat to it: it means you chose the vendor on its merits and can keep choosing it every quarter, rather than being locked in and quietly resentful. It also means you can run two vendors at once (one for email, one for chat channels), or route a fraction of traffic to a new one to evaluate it, all behind the same internal interface. Optionality is the real prize. The swap is just the proof the optionality is real.
+
+## What you should not abstract
+
+The failure mode of this pattern is over-abstraction, and it is worth naming so you avoid it. Not everything the vendor does should be hidden.
+
+- **Do not abstract away channel-specific richness that your product actually uses.** A Slack message with interactive buttons, a WhatsApp template with its approval requirements, an in-app Inbox item with an action: if your product relies on the shape, force-fitting it into a lowest-common-denominator "message" throws away the reason you chose those channels. Let the platform expose channel-specific options where they matter, rather than pretending every channel is a string.
+- **Do not build a generic "any vendor, any feature" abstraction up front.** Wrap the one vendor you have, for the features you use. A speculative abstraction over vendors you might someday adopt is cost with no payoff, and it usually models the wrong things.
+- **Do not hide delivery status and failures.** Product teams sometimes genuinely need to know a notification bounced or a channel is down. The platform should surface delivery and engagement state through its own API, not swallow it in the name of simplicity.
+- **Do not reinvent the vendor's engine inside the gateway.** The gateway is a thin adapter and a policy layer. If you find yourself building template rendering, retry orchestration, and multi-channel workflow logic inside it, you have stopped wrapping the vendor and started rebuilding it, which is the opposite of the goal.
+
+The gateway is thin on purpose. It owns the interface, preferences, and the vendor relationship. It does not own the delivery engine.
+
+## Where this lands
+
+The pattern is stable across every team that runs it. A construction-tech company whose internal consumers are completely oblivious to which vendor delivers their messages. An API-security company whose notification service receives an audience, a message, and a destination, and nothing more. An AI-infrastructure company translating Kafka events through a gateway so producers stay unaware. Different domains, same shape: a thin internal service, a small intent-based interface, preferences centralized, the vendor swappable and therefore chosen freely.
+
+Novu is designed to sit behind exactly this kind of service. Its `subscriberId` is your user ID, so audience maps straight through with no contact details in your product code. Topics cover the "everyone watching this project" audience without you maintaining recipient lists. The API takes an event and a payload, which is your message, and the platform resolves channels, preferences, templates, and delivery tracking behind it. It is, in other words, the vendor you can put behind a gateway and then stop thinking about. See the [Novu docs](https://docs.novu.co) to map your interface onto it.

--- a/content-drafts/blog/09-subscriberid-your-user-id.md
+++ b/content-drafts/blog/09-subscriberid-your-user-id.md
@@ -1,0 +1,119 @@
+---
+title: "Set subscriberId to your own user ID: the no-mapping integration pattern"
+slug: notification-subscriber-id-pattern
+description: "Use your own user ID as the notification subscriberId, skip the mapping table, and let upsert-on-trigger create the record. Gotchas included."
+category: Engineering
+target_keyword: notification subscriber identity pattern
+reading_time: 6
+---
+
+Most notification integrations start with a mistake that looks like diligence. You stand up a notification service, it hands you back its own opaque subscriber IDs, and you dutifully store them next to your users. Now you own a mapping table. You own the sync job that keeps it warm. You own the race condition where a user exists in your database but not yet in the notification system, and the on-call page that follows.
+
+None of that work needs to exist. The identifier you already have, your user's ID, is a perfectly good notification identity. Use it directly, and the mapping table, the pre-sync, and a whole category of drift bugs disappear.
+
+## The mapping-table anti-pattern
+
+The pattern shows up in almost every first integration. It looks like this:
+
+```
+users
+  id            uuid
+  email         text
+
+notification_subscribers
+  user_id            uuid   -> users.id
+  external_sub_id    text   -> the notification system's ID
+```
+
+That second table is a liability disguised as a foreign key. Consider what it commits you to:
+
+- **A backfill.** Every existing user needs a subscriber record created before they can receive anything.
+- **A sync path.** Every new sign-up has to round-trip to the notification system and store the returned ID before the user is fully usable. If that call fails, you have a user who cannot be notified and a retry queue to manage.
+- **A source-of-truth conflict.** When an email changes, which side wins? You now have two systems that both believe they know a user's contact details, and you get to reconcile them.
+
+Every one of those is a place for the two tables to disagree. A mapping table between your users and your notification users is a cache with no invalidation strategy, and it exists only because you let an external system mint identities it had no need to mint.
+
+## subscriberId equals your user ID
+
+The fix is to stop treating notification identity as separate from application identity. Set `subscriberId` to the ID you already trust. Your database primary key is the natural choice. Trigger a workflow with that ID and attach the subscriber's data inline on the same call:
+
+```ts
+import { Novu } from '@novu/api';
+
+const novu = new Novu({ secretKey: process.env.NOVU_SECRET_KEY });
+
+await novu.trigger({
+  workflowId: 'comment-reply',
+  to: {
+    // Your own user ID. Not a value the notification system invented.
+    subscriberId: user.id,
+    email: user.email,
+    firstName: user.firstName,
+    // Anything the workflow templates need to address this person.
+  },
+  payload: {
+    commentId: comment.id,
+    threadUrl: comment.url,
+  },
+});
+```
+
+There is no lookup before this call. You did not ask the notification system who `user.id` is, because you are telling it. The `to` object carries both the identity and the current contact details, so the trigger is self-describing.
+
+If you address subscribers from more than one service, keep the ID construction identical everywhere. A tiny shared helper is enough to guarantee the billing service and the web app never disagree on what a given user's `subscriberId` is:
+
+```ts
+export const toSubscriberId = (userId: string) => userId;
+```
+
+That looks trivial because it is. The point is having one place that defines the mapping, so it stays a pure function of your user ID and never becomes a stored value someone can edit out from under you.
+
+## Upsert on first trigger, no pre-sync
+
+Here is the part that removes the backfill. You do not have to create the subscriber before you can notify them. When you trigger with a `subscriberId` that has no record yet, Novu creates one from the `to` object on that first call, then updates it on later calls. It is an upsert, keyed on your ID.
+
+That single behavior deletes the pre-sync step. There is no "provision every user first" migration, no readiness flag, no window where a fresh sign-up exists in your database but cannot receive a welcome message. The first time you actually need to notify someone, the record comes into being, populated with whatever contact data you passed. Subscribers who never trigger a workflow never take up space.
+
+Because each trigger carries the current `to` payload, the subscriber's email and profile stay fresh as a side effect of normal traffic. An email change propagates the next time that user is notified. You are not running a sync job. You are letting the write path you already have keep the data current.
+
+## Multi-tenant: topics and a context ID
+
+Per-user identity handles direct messages. Fan-out (notify everyone watching a project, everyone in a workspace) is a different shape, and stapling tenant information into the `subscriberId` is the wrong move. A subscriber is a person and should have one stable ID across every tenant they belong to.
+
+Model the group as a topic instead, and build the topic key from your own tenant and context IDs:
+
+```ts
+const topicKey = `org:${orgId}:project:${projectId}`;
+
+// Add a member. subscriberId is still just the user's ID.
+await novu.topics.subscriptions.create(topicKey, {
+  subscriberIds: [user.id],
+});
+
+// Notify the whole project in one trigger.
+await novu.trigger({
+  workflowId: 'project-activity',
+  to: { type: 'Topic', topicKey },
+  payload: { event: 'deploy.finished' },
+});
+```
+
+The same person can belong to `org:a:project:1` and `org:b:project:9` under one `subscriberId`. Tenancy lives in the topic key, identity lives in the subscriber, and the two compose cleanly. If a user leaves a project, you remove them from that topic and their global identity is untouched. Deriving the topic key from IDs you own means it is reproducible: any service can address the same group without a lookup, exactly as with `subscriberId`.
+
+## Gotchas, honestly
+
+This pattern is simpler, not free. Four things to get right.
+
+**Use a stable ID, never a mutable one.** This is the one that will actually hurt you. Email feels convenient, and it works until someone changes their email. Now their `subscriberId` has changed, their old identity is orphaned, in-app history is stranded on the dead ID, and preferences do not follow them. Key on your immutable primary key, the one your database never reassigns. If you only have an email today, keep the real key in reserve and migrate before it bites you.
+
+**PII travels in the `to` object.** Because contact details ride along with each trigger, you are sending real personal data on a hot path. That is fine, and it is a decision to make on purpose. Send the fields the workflow templates actually use and no more. Do not treat the subscriber profile as a general-purpose user store or a place to stash attributes the notifications never render.
+
+**Deletion has two steps.** Removing the user from your database does not remove the subscriber. When you honor a deletion request, delete the subscriber explicitly so contact details and message history are gone from both systems. Wire it into the same routine that erases the user, so the two never fall out of sync (the exact drift the mapping table used to cause, reintroduced through the back door if you forget).
+
+**Do not silently re-identify.** Because the ID is deterministic, re-creating a user with the same primary key resurrects the old subscriber and its history. Usually that is what you want. Occasionally it is a surprise, for example when IDs get recycled in a test environment. Know which regime you are in.
+
+Weigh those against what you were doing before, running a sync job and reconciling two sources of truth, and it is not close. Teams in analytics and research tooling and in AI infrastructure who moved to this pattern report the same outcome: an entire table and its sync job left the codebase, and the drift bugs that came with them left too.
+
+The takeaway is one sentence. Do not build a table to map your users to notification users. Make them the same user.
+
+Ready to wire it up? The [Novu subscribers documentation](https://docs.novu.co/platform/concepts/subscribers) covers identifiers, the `to` object, and topic subscriptions in full.

--- a/content-drafts/blog/10-notification-spikes-scale.md
+++ b/content-drafts/blog/10-notification-spikes-scale.md
@@ -1,0 +1,142 @@
+---
+title: "Handle notification spikes: fan-out, backpressure, and at-least-once at scale"
+slug: notification-spikes-fan-out-scale
+description: "One event, 500,000 recipients, a few minutes. How fan-out, backpressure, rate limits, and idempotency keep you from dropping or double-sending."
+category: Engineering
+target_keyword: scalable notification service architecture
+reading_time: 11
+---
+
+A homegrown notification system works beautifully in the demo and on a Tuesday afternoon. It falls over the first time real load arrives, and real load never arrives politely. It arrives as one event that has to reach a very large number of people in a very short window. A marketing campaign fires. An incident opens and every subscriber to a service needs to know. A scheduled job wakes up and a million reminders come due at once.
+
+The interesting engineering is not in sending a notification. It is in sending 500,000 of them in a few minutes without dropping any and without sending some twice, while every downstream provider you depend on is actively trying to slow you down. This is the part that a naive implementation gets wrong, and it gets wrong in a specific, predictable order.
+
+## The spike, illustrated
+
+Picture a consumer app with a large user base. Someone clicks send on an announcement targeted at 500,000 users. In the ideal world every one of them gets it within a few minutes, so the throughput you need is on the order of a few thousand messages per second, sustained, across a mix of Email, push, and in-app Inbox.
+
+That number alone is not scary. Plenty of systems push a few thousand operations a second. What makes notifications hard is everything wrapped around that number:
+
+- The work is **spiky**, not steady. You are idle, then you need full throughput now, then you are idle again. You cannot provision for the average.
+- Each recipient may resolve to **several channel deliveries**, each with its own provider, its own rate limit, and its own failure modes.
+- Providers are **third parties you do not control**. They will throttle you, return transient errors, and occasionally accept a message and then lose it.
+- The blast radius of a bug is the whole audience. Send twice and 500,000 people notice at once.
+
+To see why the naive version breaks, start with what it does: a loop.
+
+```ts
+// The version that works in the demo and pages you at 2am.
+for (const user of recipients) {
+  await emailProvider.send(user.email, renderedMessage);
+}
+```
+
+At 500,000 recipients this is a single synchronous loop bottlenecked on one provider connection. It runs for hours, holds one process hostage, and has no story for what happens when it dies at recipient 300,000. Restart it and the first 300,000 people get the message again. Every problem below is a problem this loop cannot solve.
+
+## Fan-out: turn one event into many units of work
+
+The first move is to stop thinking about one big send and start thinking about many small, independent, retryable units of work. One trigger event fans out into one job per recipient per channel, and those jobs run across a pool of workers pulling from a queue.
+
+```mermaid
+flowchart TD
+    E[One trigger event<br/>audience: 500,000] --> R[Fan-out / resolve recipients]
+    R --> Q[Durable queue<br/>partitioned by channel]
+    Q --> W1[Worker pool: Email]
+    Q --> W2[Worker pool: push]
+    Q --> W3[Worker pool: Inbox]
+    W1 --> RL1{Provider rate limit<br/>+ backpressure}
+    W2 --> RL2{Provider rate limit<br/>+ backpressure}
+    RL1 -->|ok| P1[Email provider]
+    RL1 -->|429 / throttle| Q
+    RL2 -->|ok| P2[Push provider]
+    RL2 -->|429 / throttle| Q
+    P1 --> D[Dedup store<br/>idempotency keys]
+    P2 --> D
+```
+
+Three ideas do the heavy lifting here.
+
+**Topics for the fan-out itself.** You do not want the triggering service to enumerate 500,000 recipients in-process. You want it to publish one event against a topic (a project, a segment, a broadcast audience) and let the notification layer expand the membership into individual jobs. The producer stays cheap and fast. The expensive fan-out happens where it can be parallelized and retried.
+
+**Worker pools, partitioned by channel.** Email, push, and Inbox have different throughput ceilings and different providers. Give each its own pool and its own queue partition so a slow Email provider does not stall push delivery. Within a pool you scale workers horizontally to hit your target rate, and because each job is independent, a worker dying takes one job down, not the batch.
+
+**Batching where the provider rewards it.** Many providers accept batch or multicast calls. Grouping a few hundred recipients into one API call cuts overhead dramatically. Batch on the write to the provider, but keep per-recipient accounting so one bad address in a batch does not fail the other 299.
+
+The shape to internalize: producers publish events, a durable queue absorbs the spike, worker pools drain it at a controlled rate. The queue is what converts an instantaneous spike into sustained, survivable throughput.
+
+## Backpressure and provider rate limits
+
+Here is the part homegrown systems almost always skip. Your worker pool can generate load far faster than any provider will accept it. Email providers, push gateways, and messaging APIs all publish rate limits, and they enforce them with `429 Too Many Requests` and, when you really lean on them, by dropping your connection. The provider is not the place to be optimistic.
+
+Backpressure means the system slows itself down on purpose so it never generates more work than the slowest stage can absorb. Without it, the sequence is grimly predictable: workers fire as fast as they can, the provider returns 429s, naive code treats a 429 as a failure and retries immediately, the retries add load, and you have built a feedback loop that guarantees the provider stays angry. This is a self-inflicted denial of service.
+
+Doing it right has three parts:
+
+- **Throttle to the provider's published limit, not your capacity.** A limiter in front of each provider pool (token bucket, leaky bucket) caps outbound rate at or just under what the provider allows. Your workers can be idle waiting on the limiter. That is the system working, not failing.
+- **Respect the signals the provider sends.** A `429` often carries a `Retry-After`. Honor it. Back off exponentially with jitter so a fleet of workers does not resynchronize into a thundering herd on the next attempt.
+- **Let the queue hold the backlog.** When the provider is the bottleneck, work piles up in the durable queue, which is exactly what it is for. Depth rises, then drains. A spike becomes a slightly longer delivery window instead of a pile of dropped messages.
+
+The mental model: the provider sets the pace, and your job is to match it without fighting it.
+
+## At-least-once and dedup: exactly-once is a myth
+
+Now the hard theoretical corner, the one with real operational teeth. You want each recipient to get each notification exactly once. You cannot have that. Distributed exactly-once delivery across systems you do not control is not achievable, because the failure that matters is unobservable from your side.
+
+Walk the sequence. A worker calls the provider. The provider accepts and sends. On the way back, the acknowledgment is lost to a timeout. From where the worker sits, "sent, ack lost" and "never sent" are byte-for-byte identical. You have exactly two options, and both are wrong in one direction:
+
+- Assume it failed and retry: risk sending twice.
+- Assume it succeeded and move on: risk sending zero times.
+
+For notifications, silently dropping a message is usually the worse outcome, so the sane default is **at-least-once delivery**: when in doubt, retry. That guarantees no one is silently skipped, and it guarantees you will sometimes attempt to send the same thing twice. Retries are not a bug in this design. They are the design.
+
+Which is exactly why at-least-once is only half an architecture. The other half is **deduplication**, and it is what turns "at least once" into "effectively once" from the recipient's point of view. Every unit of work carries a stable **idempotency key** derived from its identity, for example a hash of `(eventId, subscriberId, channel, stepId)`. Before a worker sends, it checks a dedup store for that key. First time through, it claims the key and sends. On a retry, the key is already there and the send is skipped.
+
+```ts
+async function deliver(job: DeliveryJob) {
+  // Deterministic across every retry of the same logical send.
+  const idempotencyKey = hash(
+    job.eventId,
+    job.subscriberId,
+    job.channel,
+    job.stepId,
+  );
+
+  // Atomic claim. Returns false if this key was already handled.
+  const claimed = await dedupStore.claim(idempotencyKey, { ttl: '72h' });
+  if (!claimed) {
+    return; // Already delivered (or in flight). Do not send again.
+  }
+
+  try {
+    await provider.send(job);
+  } catch (err) {
+    if (isRetryable(err)) {
+      await dedupStore.release(idempotencyKey); // let a later retry try again
+    }
+    throw err;
+  }
+}
+```
+
+The subtle bits are the ones that decide whether this actually holds up. The claim has to be **atomic**, a compare-and-set, so two workers racing the same job cannot both win. The key needs a **TTL** long enough to outlive your entire retry window, because a dedup entry that expires before the last retry lets a duplicate through. And you have to decide, deliberately, whether a failed send releases the key for another attempt or burns it. The pattern above releases on retryable errors and holds otherwise. Get these three right and at-least-once plus dedup gives you the practical exactly-once that recipients actually experience.
+
+## Throttle to protect downstream systems
+
+Rate limiting is not only about keeping providers happy. It is also about protecting yourself and your users. A 500,000-recipient blast frequently includes a link back to your own application. Every recipient who taps that link arrives within the same few-minute window. Your notification system just became a load generator pointed at your own API.
+
+So throttling runs in two directions. Outbound, you pace to the provider. Inbound to your own infrastructure, you deliberately spread delivery so the click-through wave does not arrive as a wall. Stretching a broadcast over a longer window, or dripping it in controlled waves, keeps the notification from taking down the thing it is advertising. This is also where user-facing throttling lives: collapsing ten rapid-fire events into one digest so a busy account does not get ten separate pings. Same lever, two beneficiaries.
+
+## What breaks a homegrown system first
+
+Build this in-house and the failures arrive in a consistent order.
+
+1. **The synchronous loop, first.** The `for` loop that sends inline is the first thing to fall over. It cannot parallelize, it cannot survive a restart without redelivering, and it turns a few-minute job into a multi-hour one. Replacing it with a queue and worker pool is the first thing everyone does, usually right after the first incident.
+2. **Missing dedup, right behind it.** Once retries exist, and they must, duplicate sends appear. Without idempotency keys and an atomic dedup store, at-least-once delivery means users get the same message two, three, five times. This is the bug that generates support tickets and erodes trust fastest.
+3. **No backpressure, in the first real spike.** The system that never hit a provider limit in testing slams into `429`s in production, retries them blindly, and amplifies its own load. Adding limiters and honoring `Retry-After` is the third lesson.
+4. **State and observability, eventually.** At volume you need to answer "did this specific user get this specific notification," and a system built as fire-and-forget cannot. Per-recipient status, retries, and dead-letter handling get retrofitted, painfully.
+
+None of these are exotic. They are the standard tax on moving from "sends a notification" to "runs a notification service," and the ordering almost never varies.
+
+The scale here is not hypothetical. A consumer-fintech app can project into the hundreds of millions of notifications over a campaign season. An infrastructure vendor can run on the order of a million notifications a day with roughly 300,000 concentrated in a three-hour window. Those are recipient-side realities, not a single system's steady state, and every one of them lives or dies on the four fixes above. At a 500,000 fan-out, the question is not can you send. It is can you not send twice, and can you survive the provider telling you to slow down.
+
+Novu treats fan-out, throttling, retries, and idempotency as infrastructure so you are not rebuilding this queue-and-dedup machinery per project. It is the delivery layer: it moves the messages, paces them to your providers, and keeps per-recipient state, and it is open source (around 40K GitHub stars). The [Novu documentation](https://docs.novu.co) covers topics, workflow steps, and idempotency in depth.

--- a/content-drafts/blog/README.md
+++ b/content-drafts/blog/README.md
@@ -1,0 +1,56 @@
+# Blog content drafts: voice-of-customer, first 10
+
+Ten draft long-form articles for the Novu blog. This is the first wave of a 25-piece content plan built from real demand: we mined roughly 50 customer and prospect call transcripts for the questions developers actually ask, then cross-referenced each theme against live search results. Every article is grounded in a recurring, real question, not guesswork.
+
+**These are drafts. We want two things from this PR.**
+
+## Ask 1: make the content better
+
+The writing is a solid, brand-clean first pass, not a finished piece. Please edit for sharpness, accuracy, flow, and voice. Push back on anything that reads generic. A few known placeholders to fix before any of these publish:
+
+- Cover images: all 10 currently reuse one placeholder asset. Each needs real art.
+- Author byline: currently an existing author as a placeholder. Set the real author.
+- Category: all set to "How to" as a placeholder. Assign the right category.
+- Pricing and competitor claims: verify current numbers before publish (the drafts flag this inline).
+
+## Ask 2: rethink the blog article structure so it is readable and clickable
+
+This is the bigger ask. Right now the blog article template renders these as a wall of text. We do not want a dump of text. We want the article page rebuilt to be scannable, engaging, and clickable. Think about:
+
+- A sticky table of contents and clear section anchors for long reads.
+- Typography and spacing that make a 2,500-word piece easy to scan.
+- First-class treatment for code blocks, tables, callouts, and diagrams (several drafts use mermaid diagrams and comparison tables that should look great, not like preformatted text).
+- Pull quotes for the one-line takeaways each article already contains.
+- Related content, a strong end CTA, and internal links so a reader clicks onward instead of bouncing.
+- Reading time, share, and other signals that make the page feel alive.
+
+Treat the ten drafts as the content system these templates need to serve.
+
+## Where these already live
+
+- **Sanity:** all ten are staged as `blogPost` drafts (noIndex on) and render locally in draft mode at `localhost:3007/blog/<slug>/`. Ask Netanel for a fresh preview link (the draft-mode secret is short-lived).
+- **Notion:** each article is also a "Full draft" sub-page under its brief in the VoC Content Briefs database, with native tables and rendered mermaid diagrams. That is the nicest surface to read them on.
+- **This folder:** the raw markdown source, so edits can be reviewed and suggested inline in this PR.
+
+## The ten drafts
+
+| # | File | Working title |
+|---|---|---|
+| 1 | 01-build-vs-buy.md | Build vs buy notification infrastructure, honestly (and why AI coding made it worse) |
+| 2 | 02-notification-pricing-models.md | How notification pricing models actually work (and why per-message billing is a trap) |
+| 3 | 03-delivery-guarantee.md | What "delivery guarantee" really means for notifications |
+| 4 | 04-push-delivery-apns-fcm.md | What "delivered" really means for push: APNs vs FCM |
+| 5 | 05-transactional-email-vs-infra.md | Transactional email service vs notification infrastructure |
+| 6 | 06-notification-system-architecture.md | Design a multi-channel notification system: a real architecture guide |
+| 7 | 07-notification-microservice.md | The notification microservice: components, patterns, and when to extract it |
+| 8 | 08-notifications-internal-platform.md | Notifications as an internal platform: wrap the vendor behind your own service |
+| 9 | 09-subscriberid-your-user-id.md | Set subscriberId to your own user ID: the no-mapping integration pattern |
+| 10 | 10-notification-spikes-scale.md | Handle notification spikes: fan-out, backpressure, and at-least-once at scale |
+
+## One code change in this PR
+
+`src/lib/blog/index.ts`: the two latest-posts helpers now skip posts with no category or slug. Three existing in-progress drafts had unfilled required fields and were crashing the blog article page in draft-preview mode. This guard is a small robustness fix so a draft with unfilled fields cannot 500 the related-posts list.
+
+## Brand rules these drafts follow (please keep them)
+
+No em dashes. ACI is glossed as "Agent Communication Infrastructure" on first use. GitHub stars are ~40K. Channels are exactly Slack, Microsoft Teams, WhatsApp, Telegram, Email. No customer names anywhere (industry descriptors only). Competitor names are stated factually. Novu is the delivery layer, never the agent's brain.

--- a/src/lib/blog/index.ts
+++ b/src/lib/blog/index.ts
@@ -116,7 +116,11 @@ export async function getAllPosts(
     cache: options.cache,
     useCdn: options.useCdn,
   })
-  return posts.map((post) => transformPost(post))
+  // Skip incomplete posts (missing category/slug) so a draft-only post with
+  // unfilled required fields cannot crash the listing in preview mode.
+  return posts
+    .filter((post) => post.category?.slug?.current && post.slug?.current)
+    .map((post) => transformPost(post))
 }
 
 /**
@@ -133,7 +137,11 @@ export async function getAllPostsWithExcerpt(
     preview,
     tags: [REVALIDATE_BLOG_TAG],
   })
-  return posts.map((post) => transformPost(post))
+  // Skip incomplete posts (missing category/slug) so a draft-only post with
+  // unfilled required fields cannot crash the listing in preview mode.
+  return posts
+    .filter((post) => post.category?.slug?.current && post.slug?.current)
+    .map((post) => transformPost(post))
 }
 
 /**


### PR DESCRIPTION
## What this is

The first 10 draft long-form articles for the Novu blog, the opening wave of a 25-piece voice-of-customer content plan. Each article answers a question developers actually ask us: we mined ~50 customer and prospect call transcripts for recurring questions and objections, then cross-referenced each theme against live search demand. These are grounded in real demand, not guesswork.

They are added here as markdown under `content-drafts/blog/` so edits can be suggested inline. They are **also** staged as Sanity `blogPost` drafts (noIndex, viewable locally in draft mode at `localhost:3007/blog/<slug>/`) and as "Full draft" sub-pages in the Notion VoC Content Briefs database (nicest surface: native tables + rendered mermaid).

## Two asks (for Pixel Point) 🎨

**1. Make the content better.** Solid brand-clean first pass, not finished. Edit for sharpness, accuracy, and voice. Placeholders to fix before publish: cover images (all reuse one placeholder), author byline, category (all "How to"), and verify pricing/competitor claims (flagged inline).

**2. Rethink the blog article structure so it is readable and clickable.** This is the bigger ask. The current template renders these as a wall of text, and we do not want a dump of text. Rebuild the article page to be scannable and engaging: sticky table of contents, typography for long reads, first-class code/table/callout/diagram treatment, pull quotes for the one-line takeaways each article already has, related content, a strong end CTA, internal links, reading time and share signals. Treat the 10 drafts as the content system the template needs to serve.

See `content-drafts/blog/README.md` for the full brief, the article list, and the brand rules to preserve (no em dashes, ~40K stars, no customer names, the five channels, Novu is the delivery layer).

## Also in this PR

`src/lib/blog/index.ts`: the two latest-posts helpers now skip posts missing category/slug, so an in-progress draft with unfilled required fields cannot 500 the related-posts list in preview mode (three existing drafts were doing exactly that).

## Not for merge as-is

This is a draft-content and review PR. Nothing here should publish until the content is polished, the placeholders are replaced, and the structure work lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
