### PR TITLE
Enable draft blog post previews

### DIFF
--- a/src/lib/blog/index.ts
+++ b/src/lib/blog/index.ts
@@ -1,5 +1,4 @@
 import config from "@/configs/website-config"
-import { ROUTE } from "@/constants/routes"
 
 import {
   ICategory,
@@ -29,39 +28,14 @@ import {
 import { getTableOfContents } from "@/lib/sanity/utils/get-table-of-contents"
 import { absoluteUrl } from "@/lib/site-url"
 
+import { transformCategory, transformPost, transformPosts } from "./transform"
+
 const POSTS_PER_PAGE = config.blog.postsPerPage
 const REVALIDATE_BLOG_TAG = "blog"
 
 type SanityReadOptions = {
   cache?: RequestCache
   useCdn?: boolean
-}
-
-/**
- * Transforms a category data object from Sanity into the application's category format
- * @param category - The raw category data from Sanity
- *
- * @returns A formatted category object with URL
- */
-function transformCategory(category: ICategoryData): ICategory {
-  return {
-    ...category,
-    url: `${ROUTE.blogCategory}/${category.slug.current}`,
-  }
-}
-
-/**
- * Transforms a post data object from Sanity into the application's post format
- * @param post - The raw post data from Sanity
- *
- * @returns A formatted post object with transformed category
- */
-function transformPost(post: IPostData): IPost {
-  return {
-    ...post,
-    url: `${ROUTE.blog}/${post.slug.current}`,
-    category: transformCategory(post.category),
-  }
 }
 
 /**
@@ -79,9 +53,10 @@ export async function getFeaturedPost(
     tags: [REVALIDATE_BLOG_TAG],
   })
 
-  if (!featuredPosts || featuredPosts.length === 0) return null
+  const readyPosts = transformPosts(featuredPosts || [])
+  if (readyPosts.length === 0) return null
 
-  return featuredPosts.map((post) => transformPost(post))
+  return readyPosts
 }
 
 /**
@@ -116,7 +91,7 @@ export async function getAllPosts(
     cache: options.cache,
     useCdn: options.useCdn,
   })
-  return posts.map((post) => transformPost(post))
+  return transformPosts(posts)
 }
 
 /**
@@ -133,7 +108,7 @@ export async function getAllPostsWithExcerpt(
     preview,
     tags: [REVALIDATE_BLOG_TAG],
   })
-  return posts.map((post) => transformPost(post))
+  return transformPosts(posts)
 }
 
 /**
@@ -153,7 +128,7 @@ export async function getLatestPostsWithExcerpt(
     preview,
     tags: [REVALIDATE_BLOG_TAG],
   })
-  return posts.map((post) => transformPost(post))
+  return transformPosts(posts)
 }
 
 /**
@@ -173,7 +148,7 @@ export async function getLatestPosts(
     preview,
     tags: [REVALIDATE_BLOG_TAG],
   })
-  return posts.map((post) => transformPost(post))
+  return transformPosts(posts)
 }
 
 /**
@@ -196,7 +171,7 @@ export async function getPostsByCategory(
     cache: options.cache,
     useCdn: options.useCdn,
   })
-  return posts.map((post) => transformPost(post))
+  return transformPosts(posts)
 }
 
 /**
@@ -219,8 +194,11 @@ export async function getPostBySlug(
 
   if (!post) return null
 
+  const transformedPost = transformPost(post)
+  if (!transformedPost) return null
+
   return {
-    ...transformPost(post),
+    ...transformedPost,
     tableOfContents: getTableOfContents(post.content),
     seo: {
       ...post.seo,
@@ -359,7 +337,7 @@ export async function getPaginatedPosts(
     preview,
     tags: [REVALIDATE_BLOG_TAG],
   })
-  return posts.map((post) => transformPost(post))
+  return transformPosts(posts)
 }
 
 /**
@@ -393,5 +371,5 @@ export async function getPaginatedPostsByCategory(
     preview,
     tags: [REVALIDATE_BLOG_TAG],
   })
-  return posts.map((post) => transformPost(post))
+  return transformPosts(posts)
 }

--- a/src/lib/blog/index.ts
+++ b/src/lib/blog/index.ts
@@ -28,7 +28,12 @@ import {
 import { getTableOfContents } from "@/lib/sanity/utils/get-table-of-contents"
 import { absoluteUrl } from "@/lib/site-url"
 
-import { transformCategory, transformPost, transformPosts } from "./transform"
+import {
+  isCompletePost,
+  transformCategory,
+  transformPost,
+  transformPosts,
+} from "./transform"
 
 const POSTS_PER_PAGE = config.blog.postsPerPage
 const REVALIDATE_BLOG_TAG = "blog"
@@ -194,8 +199,10 @@ export async function getPostBySlug(
 
   if (!post) return null
 
+  // `postBySlugQuery` is intentionally unfiltered so drafts resolve, so the
+  // completeness the post page relies on has to be checked here.
   const transformedPost = transformPost(post)
-  if (!transformedPost) return null
+  if (!transformedPost || !isCompletePost(post)) return null
 
   return {
     ...transformedPost,

--- a/src/lib/blog/transform.ts
+++ b/src/lib/blog/transform.ts
@@ -2,15 +2,29 @@ import { ROUTE } from "@/constants/routes"
 
 import type { ICategory, ICategoryData, IPost, IPostData } from "@/types/blog"
 
-function hasRequiredPostCardFields(post: IPostData) {
+/**
+ * Fields `transformPost` itself dereferences to build the post and category
+ * URLs. Kept deliberately narrow: editorial completeness is enforced by
+ * `postCardReadyFilter` in the queries, and projections that omit card fields
+ * on purpose (see `postExcerptFields`) still have to survive the transform.
+ */
+function hasLinkableFields(post: IPostData) {
+  return Boolean(post.slug?.current && post.category?.slug?.current)
+}
+
+/**
+ * Whether a post carries everything the post page renders. Drafts can be saved
+ * incomplete, so documents fetched without `postCardReadyFilter` — currently
+ * `postBySlugQuery` — have to be checked here instead.
+ */
+export function isCompletePost(post: IPostData) {
   return Boolean(
-    post.title &&
-      post.slug?.current &&
+    hasLinkableFields(post) &&
+      post.title &&
       post.caption &&
       post.publishedAt &&
       post.cover &&
       post.category?.title &&
-      post.category.slug?.current &&
       Array.isArray(post.authors) &&
       post.authors.length > 0
   )
@@ -24,7 +38,7 @@ export function transformCategory(category: ICategoryData): ICategory {
 }
 
 export function transformPost(post: IPostData): IPost | null {
-  if (!hasRequiredPostCardFields(post)) return null
+  if (!hasLinkableFields(post)) return null
 
   return {
     ...post,

--- a/src/lib/blog/transform.ts
+++ b/src/lib/blog/transform.ts
@@ -1,0 +1,43 @@
+import { ROUTE } from "@/constants/routes"
+
+import type { ICategory, ICategoryData, IPost, IPostData } from "@/types/blog"
+
+function hasRequiredPostCardFields(post: IPostData) {
+  return Boolean(
+    post.title &&
+      post.slug?.current &&
+      post.caption &&
+      post.publishedAt &&
+      post.cover &&
+      post.category?.title &&
+      post.category.slug?.current &&
+      Array.isArray(post.authors) &&
+      post.authors.length > 0
+  )
+}
+
+export function transformCategory(category: ICategoryData): ICategory {
+  return {
+    ...category,
+    url: `${ROUTE.blogCategory}/${category.slug.current}`,
+  }
+}
+
+export function transformPost(post: IPostData): IPost | null {
+  if (!hasRequiredPostCardFields(post)) return null
+
+  return {
+    ...post,
+    url: `${ROUTE.blog}/${post.slug.current}`,
+    category: transformCategory(post.category),
+  }
+}
+
+export function transformPosts(posts: IPostData[]): IPost[] {
+  return posts.reduce<IPost[]>((readyPosts, post) => {
+    const transformedPost = transformPost(post)
+    if (transformedPost) readyPosts.push(transformedPost)
+
+    return readyPosts
+  }, [])
+}

--- a/src/lib/sanity/constants/drafts-schema-types.ts
+++ b/src/lib/sanity/constants/drafts-schema-types.ts
@@ -1,4 +1,4 @@
-import { Route } from "next"
+import type { Route } from "next"
 import { ROUTE } from "@/constants/routes"
 
 /**
@@ -6,6 +6,7 @@ import { ROUTE } from "@/constants/routes"
  */
 
 export enum DraftsSchemaTypes {
+  BLOG_POST = "blogPost",
   CHANGELOG_POST = "changelogPost",
   CUSTOMERS = "customers",
   CUSTOMER = "customer",
@@ -16,6 +17,7 @@ export enum DraftsSchemaTypes {
  * Map SchemaType with a preview to its corresponding route
  */
 export const PREVIEW_ROUTES: Record<DraftsSchemaTypes, URL | Route<string>> = {
+  [DraftsSchemaTypes.BLOG_POST]: ROUTE.blog,
   [DraftsSchemaTypes.CHANGELOG_POST]: ROUTE.changelog,
   [DraftsSchemaTypes.CUSTOMERS]: ROUTE.customers,
   [DraftsSchemaTypes.CUSTOMER]: ROUTE.customers,

--- a/src/lib/sanity/preview-path.ts
+++ b/src/lib/sanity/preview-path.ts
@@ -1,0 +1,39 @@
+import {
+  DraftsSchemaTypes,
+  PREVIEW_ROUTES,
+} from "@/lib/sanity/constants/drafts-schema-types"
+
+export interface PreviewDocument {
+  slug?: {
+    current: string
+  }
+  link?: {
+    type: string
+  }
+}
+
+const SLUG_REQUIRED_SCHEMA_TITLES: Partial<Record<DraftsSchemaTypes, string>> =
+  {
+    [DraftsSchemaTypes.BLOG_POST]: "A blog post",
+    [DraftsSchemaTypes.CUSTOMER]: "A customer story",
+  }
+
+export function getPreviewPath(
+  document: PreviewDocument | null,
+  schemaType: string
+) {
+  const previewRoute = PREVIEW_ROUTES[schemaType as DraftsSchemaTypes]
+  if (!previewRoute) {
+    return new Error(`Preview route is not configured for ${schemaType}`)
+  }
+
+  const schemaTitle =
+    SLUG_REQUIRED_SCHEMA_TITLES[schemaType as DraftsSchemaTypes]
+  const slug = document?.slug?.current
+
+  if (schemaTitle && !slug) {
+    return new Error(`${schemaTitle} needs a slug before it can be previewed`)
+  }
+
+  return `${String(previewRoute)}${slug ? `/${encodeURIComponent(slug)}` : ""}`
+}

--- a/src/lib/sanity/queries/blog.ts
+++ b/src/lib/sanity/queries/blog.ts
@@ -4,6 +4,17 @@ import { groq } from "next-sanity"
 
 const COVER_ASPECT_RATIO = config.blog.coverAspectRatio
 
+const postCardReadyFilter = groq`
+  _type == "blogPost" &&
+  defined(title) &&
+  defined(slug.current) &&
+  defined(caption) &&
+  defined(publishedAt) &&
+  defined(category._ref) &&
+  defined(cover.asset._ref) &&
+  count(authors) > 0
+`
+
 const commonPostFields = `
   _type,
   _createdAt,
@@ -104,14 +115,14 @@ const fullPostFields = groq`
 
 // Query for featured post
 export const featuredPostQuery = groq`
-  *[_type == "blogPost" && isFeatured == true] | order(publishedAt desc) {
+  *[${postCardReadyFilter} && isFeatured == true] | order(publishedAt desc) {
     ${postCardFields}
   }
 `
 
 // Query for all categories that have at least one post
 export const categoriesQuery = groq`
-  *[_type == "blogCategory" && count(*[_type == "blogPost" && references(^._id)]) > 0] | order(title asc) {
+  *[_type == "blogCategory" && defined(title) && defined(slug.current) && count(*[${postCardReadyFilter} && references(^._id)]) > 0] | order(title asc) {
     title,
     slug
   }
@@ -119,35 +130,35 @@ export const categoriesQuery = groq`
 
 // Query for all posts with pagination
 export const postsQuery = groq`
-  *[_type == "blogPost"] | order(publishedAt desc) {
+  *[${postCardReadyFilter}] | order(publishedAt desc) {
     ${postCardFields}
   }
 `
 
 // Query for latest N posts (accepts $limit parameter)
 export const latestPostsQuery = groq`
-  *[_type == "blogPost"] | order(publishedAt desc)[0...$limit] {
+  *[${postCardReadyFilter}] | order(publishedAt desc)[0...$limit] {
     ${postCardFields}
   }
 `
 
 // Query for all posts with excerpt
 export const postsWithExcerptQuery = groq`
-  *[_type == "blogPost"] | order(publishedAt desc) {
+  *[${postCardReadyFilter}] | order(publishedAt desc) {
     ${postExcerptFields}
   }
 `
 
 // Query for latest N posts with excerpt
 export const latestPostsWithExcerptQuery = groq`
-  *[_type == "blogPost"] | order(publishedAt desc)[0...$limit] {
+  *[${postCardReadyFilter}] | order(publishedAt desc)[0...$limit] {
     ${postExcerptFields}
   }
 `
 
 // Query for posts by category
 export const postsByCategoryQuery = groq`
-  *[_type == "blogPost" && category->slug.current == $slug] | order(publishedAt desc) {
+  *[${postCardReadyFilter} && category->slug.current == $slug] | order(publishedAt desc) {
     ${postCardFields}
   }
 `
@@ -168,41 +179,41 @@ export const categoryBySlugQuery = groq`
 
 // Query for pagination
 export const totalPostsQuery = groq`{
-  "total": count(*[_type == "blogPost"]),
-  "nonFeatured": count(*[_type == "blogPost" && (!defined(isFeatured) || isFeatured == false)])
+  "total": count(*[${postCardReadyFilter}]),
+  "nonFeatured": count(*[${postCardReadyFilter} && (!defined(isFeatured) || isFeatured == false)])
 }
 `
 
 // Query for total posts by category
 export const totalPostsByCategoryQuery = groq`{
-  "total": count(*[_type == "blogPost" && category->slug.current == $slug]),
-  "nonFeatured": count(*[_type == "blogPost" && category->slug.current == $slug && (!defined(isFeatured) || isFeatured == false)])
+  "total": count(*[${postCardReadyFilter} && category->slug.current == $slug]),
+  "nonFeatured": count(*[${postCardReadyFilter} && category->slug.current == $slug && (!defined(isFeatured) || isFeatured == false)])
 }`
 
 // Query for paginated posts
 export const paginatedPostsQuery = groq`
-  *[_type == "blogPost"] | order(publishedAt desc)[$start...$end] {
+  *[${postCardReadyFilter}] | order(publishedAt desc)[$start...$end] {
     ${postCardFields}
   }
 `
 
 // Query for paginated non-featured posts
 export const paginatedNonFeaturedPostsQuery = groq`
-  *[_type == "blogPost" && (!defined(isFeatured) || isFeatured == false)] | order(publishedAt desc)[$start...$end] {
+  *[${postCardReadyFilter} && (!defined(isFeatured) || isFeatured == false)] | order(publishedAt desc)[$start...$end] {
     ${postCardFields}
   }
 `
 
 // Query for paginated posts by category
 export const paginatedPostsByCategoryQuery = groq`
-  *[_type == "blogPost" && category->slug.current == $slug] | order(publishedAt desc)[$start...$end] {
+  *[${postCardReadyFilter} && category->slug.current == $slug] | order(publishedAt desc)[$start...$end] {
     ${postCardFields}
   }
 `
 
 // Query for paginated non-featured posts by category
 export const paginatedNonFeaturedPostsByCategoryQuery = groq`
-  *[_type == "blogPost" && category->slug.current == $slug && (!defined(isFeatured) || isFeatured == false)] | order(publishedAt desc)[$start...$end] {
+  *[${postCardReadyFilter} && category->slug.current == $slug && (!defined(isFeatured) || isFeatured == false)] | order(publishedAt desc)[$start...$end] {
     ${postCardFields}
   }
 `

--- a/src/lib/sanity/structure/blog/index.ts
+++ b/src/lib/sanity/structure/blog/index.ts
@@ -2,6 +2,8 @@ import { BookIcon, DocumentTextIcon, UlistIcon } from "@sanity/icons"
 import { orderableDocumentListDeskItem } from "@sanity/orderable-document-list"
 import { StructureBuilder, StructureResolverContext } from "sanity/structure"
 
+import { DraftsSchemaTypes } from "@/lib/sanity/constants/drafts-schema-types"
+
 const blogStructure = (
   S: StructureBuilder,
   context: StructureResolverContext
@@ -16,7 +18,9 @@ const blogStructure = (
           S.listItem()
             .title("Posts")
             .icon(DocumentTextIcon)
-            .child(S.documentTypeList("blogPost").title("All Posts")),
+            .child(
+              S.documentTypeList(DraftsSchemaTypes.BLOG_POST).title("All Posts")
+            ),
           orderableDocumentListDeskItem({
             title: "Categories",
             icon: UlistIcon,

--- a/src/lib/sanity/utils/get-structure-document-views.ts
+++ b/src/lib/sanity/utils/get-structure-document-views.ts
@@ -1,44 +1,14 @@
-import { SanityDocument } from "sanity"
 import { Iframe } from "sanity-plugin-iframe-pane"
 import { StructureBuilder } from "sanity/structure"
 
-import {
-  DraftsSchemaTypes,
-  PREVIEW_ROUTES,
-} from "@/lib/sanity/constants/drafts-schema-types"
-
-interface ExtendedSanityDocument extends SanityDocument {
-  slug?: {
-    current: string
-  }
-  link?: {
-    type: string
-  }
-}
-
-function getPreviewPath(
-  doc: ExtendedSanityDocument | null,
-  schemaType: string
-) {
-  const route = PREVIEW_ROUTES[schemaType as DraftsSchemaTypes]
-  if (!route) {
-    return new Error(`Preview route is not configured for ${schemaType}`)
-  }
-
-  if (schemaType === DraftsSchemaTypes.CUSTOMER && !doc?.slug?.current) {
-    return new Error("A customer story needs a slug before it can be previewed")
-  }
-
-  const slug = doc?.slug?.current
-  return `${String(route)}${slug ? `/${encodeURIComponent(slug)}` : ""}`
-}
+import { DraftsSchemaTypes } from "@/lib/sanity/constants/drafts-schema-types"
+import { getPreviewPath, type PreviewDocument } from "@/lib/sanity/preview-path"
 
 function getIframeOptions(schemaType: string) {
   return {
     url: {
       origin: "same-origin" as const,
-      preview: (doc: ExtendedSanityDocument | null) =>
-        getPreviewPath(doc, schemaType),
+      preview: (doc: PreviewDocument | null) => getPreviewPath(doc, schemaType),
       draftMode: "/api/preview",
     },
     showDisplayUrl: false,
@@ -73,7 +43,7 @@ export const getStructureDocumentViews = (
             ...iframeOptions,
             url: {
               ...iframeOptions.url,
-              preview: (doc: ExtendedSanityDocument | null) =>
+              preview: (doc: PreviewDocument | null) =>
                 doc?.link?.type === "story"
                   ? getPreviewPath(doc, schemaType)
                   : new Error("Preview is only available for customer stories"),

--- a/tests/blog-data.test.ts
+++ b/tests/blog-data.test.ts
@@ -2,7 +2,11 @@ import assert from "node:assert/strict"
 import { describe, it } from "node:test"
 
 import type { IPostData } from "@/types/blog"
-import { transformPost, transformPosts } from "@/lib/blog/transform"
+import {
+  isCompletePost,
+  transformPost,
+  transformPosts,
+} from "@/lib/blog/transform"
 import { latestPostsQuery } from "@/lib/sanity/queries/blog"
 
 const completePost = {
@@ -55,5 +59,28 @@ describe("blog data readiness", () => {
       ),
       ["complete-post"]
     )
+  })
+
+  it("keeps posts from projections that omit card fields", () => {
+    // `postExcerptFields` powers site search and never projects a cover
+    const excerptPost = {
+      ...completePost,
+      cover: undefined,
+    } as unknown as IPostData
+
+    assert.deepEqual(
+      transformPosts([excerptPost]).map((post) => post.slug.current),
+      ["complete-post"]
+    )
+  })
+
+  it("treats a cover-less draft as unrenderable on the post page", () => {
+    const draftWithoutCover = {
+      ...completePost,
+      cover: undefined,
+    } as unknown as IPostData
+
+    assert.equal(isCompletePost(completePost), true)
+    assert.equal(isCompletePost(draftWithoutCover), false)
   })
 })

--- a/tests/blog-data.test.ts
+++ b/tests/blog-data.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import type { IPostData } from "@/types/blog"
+import { transformPost, transformPosts } from "@/lib/blog/transform"
+import { latestPostsQuery } from "@/lib/sanity/queries/blog"
+
+const completePost = {
+  _type: "blogPost",
+  _createdAt: "2026-08-12T00:00:00Z",
+  title: "Complete post",
+  slug: { current: "complete-post" },
+  url: "/blog/complete-post",
+  authors: [{ name: "Author", photo: "" }],
+  cover: "/cover.png",
+  category: {
+    title: "How to",
+    slug: { current: "how-to" },
+  },
+  isFeatured: false,
+  publishedAt: "2026-08-12T00:00:00Z",
+  caption: "Complete caption",
+  content: [],
+  seo: {
+    title: "Complete post",
+    description: "Complete caption",
+    socialImage: "",
+    noIndex: false,
+  },
+} as IPostData
+
+describe("blog data readiness", () => {
+  it("filters incomplete draft cards before ordering and slicing", () => {
+    const categoryFilterIndex = latestPostsQuery.indexOf(
+      "defined(category._ref)"
+    )
+    const orderIndex = latestPostsQuery.indexOf("| order")
+
+    assert.ok(categoryFilterIndex >= 0)
+    assert.ok(categoryFilterIndex < orderIndex)
+    assert.match(latestPostsQuery, /defined\(publishedAt\)/)
+  })
+
+  it("skips incomplete runtime data instead of throwing", () => {
+    const incompletePost = {
+      ...completePost,
+      category: null,
+      publishedAt: null,
+    } as unknown as IPostData
+
+    assert.equal(transformPost(incompletePost), null)
+    assert.deepEqual(
+      transformPosts([incompletePost, completePost]).map(
+        (post) => post.slug.current
+      ),
+      ["complete-post"]
+    )
+  })
+})

--- a/tests/sanity-preview.test.ts
+++ b/tests/sanity-preview.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import {
+  DraftsSchemaTypes,
+  PREVIEW_ROUTES,
+} from "@/lib/sanity/constants/drafts-schema-types"
+import { getPreviewPath } from "@/lib/sanity/preview-path"
+
+describe("Sanity preview paths", () => {
+  it("opens blog post drafts on their website route", () => {
+    assert.equal(PREVIEW_ROUTES[DraftsSchemaTypes.BLOG_POST], "/blog")
+    assert.equal(
+      getPreviewPath(
+        { slug: { current: "draft post" } },
+        DraftsSchemaTypes.BLOG_POST
+      ),
+      "/blog/draft%20post"
+    )
+  })
+
+  it("requires a slug before previewing a blog post draft", () => {
+    assert.match(
+      String(getPreviewPath({}, DraftsSchemaTypes.BLOG_POST)),
+      /needs a slug/
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- add a Sanity Studio preview view for draft blog posts
- generate validated preview paths from each post slug
- filter incomplete drafts from blog card queries and guard runtime transforms

## Why

Previewing a draft could crash when related-post queries returned incomplete drafts with missing category or publication data.

## Validation

- verified the draft preview flow in the browser
- added regression coverage for preview paths and incomplete draft data