### PR TITLE
feat(home): flag-driven getting-started hero A/B/C test

### DIFF
--- a/src/components/pages/home/copy-prompt-button.tsx
+++ b/src/components/pages/home/copy-prompt-button.tsx
@@ -13,6 +13,7 @@ interface ICopyPromptButtonProps
   copiedLabel?: string
   copiedMessage?: string
   label?: string
+  onCopy?: () => void
   resetInterval?: number
   showCopyIcon?: boolean
   value: string
@@ -22,6 +23,7 @@ function CopyPromptButton({
   copiedLabel = "Copied",
   copiedMessage = "Prompt copied to clipboard",
   label = "Copy prompt",
+  onCopy,
   resetInterval = 2500,
   showCopyIcon = true,
   value,
@@ -30,11 +32,16 @@ function CopyPromptButton({
   const { isCopied, handleCopy } = useCopyToClipboard(resetInterval)
   const statusId = useId()
 
+  const copy = () => {
+    handleCopy(value)
+    onCopy?.()
+  }
+
   return (
     <Button
       {...buttonProps}
       type="button"
-      onClick={() => handleCopy(value)}
+      onClick={copy}
       aria-label={isCopied ? copiedLabel || "Copied" : label}
       aria-describedby={statusId}
     >

--- a/src/components/pages/home/hero.tsx
+++ b/src/components/pages/home/hero.tsx
@@ -16,7 +16,15 @@ import slackIcon from "@/svgs/pages/connect/channels/slack.svg"
 import telegramIcon from "@/svgs/pages/connect/channels/telegram.svg"
 import whatsappIcon from "@/svgs/pages/connect/channels/whatsapp.svg"
 
+import {
+  WEBSITE_CLI_COMMAND_COPIED_EVENT,
+  WEBSITE_PROMPT_COPIED_EVENT,
+} from "@/lib/experiments"
+import { trackEvent } from "@/lib/mixpanel"
 import { cn } from "@/lib/utils"
+import { ROUTE } from "@/constants/routes"
+import { useGettingStartedFlow } from "@/hooks/use-getting-started-flow"
+import { Button } from "@/components/ui/button"
 import { CopyCommand } from "@/components/ui/copy-command"
 import Logos from "@/components/ui/logos"
 
@@ -28,6 +36,8 @@ import {
 } from "./channel-navigation"
 import CopyPromptButton from "./copy-prompt-button"
 import HeroGlobe from "./hero-globe"
+
+const SIGN_UP_HREF = String(ROUTE.dashboardV2AgentsSignUp)
 
 const DEFAULT_PROMPT =
   "Connect my AI agent to customers across their preferred channels with Novu."
@@ -209,6 +219,74 @@ function ChannelIcons() {
   )
 }
 
+// Getting-started A/B/C test: each arm commits the primary CTA to one flow.
+// The control (ui) renders on the server and first paint so the CTA area stays
+// stable; the assigned arm swaps in once the Mixpanel flag resolves. All arms
+// share the same block height to avoid layout shift on swap.
+function HeroGetStarted({
+  command,
+  prompt,
+}: {
+  command: string
+  prompt: string
+}) {
+  const flow = useGettingStartedFlow()
+
+  return (
+    <div className="mt-6 flex min-h-19 w-full flex-col gap-3 lg:mt-7">
+      <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:gap-5">
+        {flow === "ui" && (
+          <Button
+            asChild
+            variant="default"
+            size="none"
+            className="h-11 w-full px-5 text-base leading-none font-medium tracking-tight sm:w-auto"
+          >
+            <a href={SIGN_UP_HREF}>Get started free</a>
+          </Button>
+        )}
+
+        {flow === "cli" && (
+          <CopyCommand
+            command={command}
+            variant="highlighted"
+            copiedContent={<AnimatedCopyCheck />}
+            onCopy={() =>
+              trackEvent(WEBSITE_CLI_COMMAND_COPIED_EVENT, { command })
+            }
+          />
+        )}
+
+        {flow === "prompt" && (
+          <CopyPromptButton
+            className="h-11 w-full px-5 text-base leading-none font-medium tracking-tight normal-case sm:w-auto [&_svg]:size-3.5"
+            variant="default"
+            size="none"
+            resetInterval={2000}
+            value={prompt}
+            onCopy={() => trackEvent(WEBSITE_PROMPT_COPIED_EVENT, { prompt })}
+          />
+        )}
+      </div>
+
+      <div className="flex min-h-5 items-center">
+        {flow === "ui" ? (
+          <p className="text-sm tracking-tight text-[#a3a6b2]">
+            Free plan available. No credit card required.
+          </p>
+        ) : (
+          <a
+            className="text-sm font-medium tracking-tight text-[#a3a6b2] underline-offset-4 transition-colors hover:text-white hover:underline"
+            href={SIGN_UP_HREF}
+          >
+            Sign up instead
+          </a>
+        )}
+      </div>
+    </div>
+  )
+}
+
 function Hero({
   title,
   description,
@@ -235,20 +313,7 @@ function Hero({
             <p className="text-base leading-normal tracking-tight text-pretty text-[#a3a6b2] md:text-lg md:leading-normal">
               {description}
             </p>
-            <div className="mt-6 flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:gap-5 lg:mt-7">
-              <CopyCommand
-                command={command}
-                variant="highlighted"
-                copiedContent={<AnimatedCopyCheck />}
-              />
-              <CopyPromptButton
-                className="h-11 w-full px-5 text-base leading-none font-medium tracking-tight normal-case sm:w-39 [&_svg]:size-3.5"
-                variant="outline-transparent"
-                size="none"
-                resetInterval={2000}
-                value={prompt}
-              />
-            </div>
+            <HeroGetStarted command={command} prompt={prompt} />
           </div>
         </div>
 

--- a/src/components/ui/copy-command.tsx
+++ b/src/components/ui/copy-command.tsx
@@ -54,6 +54,7 @@ export interface CopyCommandProps
   controlClassName?: string
   copiedContent?: React.ReactNode
   copyButtonClassName?: string
+  onCopy?: () => void
 }
 
 function CopyCommand({
@@ -62,11 +63,17 @@ function CopyCommand({
   controlClassName,
   copiedContent,
   copyButtonClassName,
+  onCopy,
   variant,
   className,
   ...props
 }: CopyCommandProps) {
   const { isCopied, handleCopy } = useCopyToClipboard(2000)
+
+  const copy = () => {
+    handleCopy(command)
+    onCopy?.()
+  }
 
   return (
     <div
@@ -106,7 +113,7 @@ function CopyCommand({
             copyButtonClassName
           )}
           type="button"
-          onClick={() => handleCopy(command)}
+          onClick={copy}
           aria-label={isCopied ? "Copied" : "Copy to clipboard"}
         >
           {isCopied ? (

--- a/src/hooks/use-getting-started-flow.ts
+++ b/src/hooks/use-getting-started-flow.ts
@@ -1,0 +1,53 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+import {
+  GETTING_STARTED_FLOW_DEFAULT,
+  type GettingStartedFlow,
+  isGettingStartedFlow,
+  resolveGettingStartedFlow,
+} from "@/lib/experiments"
+
+/** QA override: append ?gsf=cli (or ui / prompt) to force an arm locally. */
+const QA_OVERRIDE_PARAM = "gsf"
+
+const readQaOverride = (): GettingStartedFlow | null => {
+  if (typeof window === "undefined") return null
+  const value = new URLSearchParams(window.location.search).get(
+    QA_OVERRIDE_PARAM
+  )
+  return isGettingStartedFlow(value) ? value : null
+}
+
+/**
+ * Returns the visitor's getting-started arm.
+ *
+ * Renders the control on the server and first paint so the CTA area is stable,
+ * then swaps to the assigned arm once the flag resolves. A ?gsf= query param
+ * forces an arm for QA without touching experiment assignment.
+ */
+export function useGettingStartedFlow(): GettingStartedFlow {
+  const [flow, setFlow] = useState<GettingStartedFlow>(
+    GETTING_STARTED_FLOW_DEFAULT
+  )
+
+  useEffect(() => {
+    const override = readQaOverride()
+    if (override) {
+      setFlow(override)
+      return
+    }
+
+    let active = true
+    resolveGettingStartedFlow().then((resolved) => {
+      if (active) setFlow(resolved)
+    })
+
+    return () => {
+      active = false
+    }
+  }, [])
+
+  return flow
+}

--- a/src/lib/experiments.ts
+++ b/src/lib/experiments.ts
@@ -1,0 +1,79 @@
+import mixpanel from "mixpanel-browser"
+
+import { initMixpanel } from "./mixpanel"
+
+/**
+ * Getting-started flow A/B/C test (novu.co home hero).
+ *
+ * Three arms committing the primary CTA to a single flow instead of showing
+ * every option at once. Assignment, splits (34/33/33) and metrics live on the
+ * Mixpanel experiment; the website only reads the flag and renders the arm.
+ *
+ * Flag key is the exact string configured in Mixpanel (do not rename).
+ */
+export const GETTING_STARTED_FLOW_FLAG_KEY =
+  "website-getting-started-flow-ui-vs-cli-vs-prompt-SJw6Uc"
+
+/** Super property stamped on every event so downstream metrics carry the arm. */
+export const GETTING_STARTED_FLOW_SUPER_PROPERTY = "getting_started_flow"
+
+export type GettingStartedFlow = "ui" | "cli" | "prompt"
+
+/** Control arm. Also the server / first-paint render before flags resolve. */
+export const GETTING_STARTED_FLOW_DEFAULT: GettingStartedFlow = "ui"
+
+/** Website-side copy events (the existing CLI/prompt events fire elsewhere). */
+export const WEBSITE_CLI_COMMAND_COPIED_EVENT = "Website CLI Command Copied"
+export const WEBSITE_PROMPT_COPIED_EVENT = "Website Prompt Copied"
+
+export const isGettingStartedFlow = (
+  value: unknown
+): value is GettingStartedFlow =>
+  value === "ui" || value === "cli" || value === "prompt"
+
+// The mixpanel-browser 2.71 type bundle does not yet expose the feature-flag
+// manager, so we describe just the method we call.
+interface MixpanelFlagManager {
+  get_variant_value: (
+    featureName: string,
+    fallbackValue: unknown
+  ) => Promise<unknown>
+}
+
+const getFlagManager = (): MixpanelFlagManager | null => {
+  const flags = (mixpanel as unknown as { flags?: MixpanelFlagManager }).flags
+  return flags ?? null
+}
+
+/**
+ * Resolve the visitor's getting-started arm from the Mixpanel feature flag.
+ *
+ * Reading the variant registers the exposure event that assigns the visitor to
+ * the experiment, then stamps the arm as a super property. Any failure (flags
+ * disabled, missing token, network) falls back to the control arm so the hero
+ * always renders.
+ */
+export const resolveGettingStartedFlow =
+  async (): Promise<GettingStartedFlow> => {
+    try {
+      await initMixpanel()
+
+      const flags = getFlagManager()
+      if (!flags) return GETTING_STARTED_FLOW_DEFAULT
+
+      const value = await flags.get_variant_value(
+        GETTING_STARTED_FLOW_FLAG_KEY,
+        GETTING_STARTED_FLOW_DEFAULT
+      )
+      const flow = isGettingStartedFlow(value)
+        ? value
+        : GETTING_STARTED_FLOW_DEFAULT
+
+      mixpanel.register({ [GETTING_STARTED_FLOW_SUPER_PROPERTY]: flow })
+
+      return flow
+    } catch (error) {
+      console.error("Failed to resolve getting-started flow:", error)
+      return GETTING_STARTED_FLOW_DEFAULT
+    }
+  }

--- a/src/lib/mixpanel.ts
+++ b/src/lib/mixpanel.ts
@@ -24,6 +24,9 @@ export const initMixpanel = (): Promise<void> => {
       mixpanel.init(MIXPANEL_TOKEN, {
         debug: process.env.NODE_ENV === "development",
         track_pageview: false,
+        // Enable feature flags so getting-started-flow variants can be
+        // evaluated client-side (see lib/experiments.ts). Auto-fetches on init.
+        flags: true,
       })
       isInitialized = true
       console.info("Mixpanel initialized successfully")


### PR DESCRIPTION
## What

Implements the **getting-started flow A/B/C test** on the home hero: each visitor sees one committed primary CTA instead of every option at once, driven by the Mixpanel feature flag.

Test plan: [`02-campaigns/2026-08-04-website-flow-ab-test-plan.md`](https://github.com/novuhq/website-new) (Novu-Marketing repo). Mixpanel experiment: [Website getting-started flow: UI vs CLI vs Prompt](https://mixpanel.com/project/2667883/view/3205091/app/experiments/9fe6798e-faf8-41d0-93ca-4ad2711c5c9d) (currently **draft**, flag **disabled**).

| Arm | Flag value | Primary CTA | Secondary |
|---|---|---|---|
| Control | `ui` | "Get started free" → agents sign-up | helper text |
| B | `cli` | `npx novu connect` copy command | "Sign up instead" |
| C | `prompt` | copyable coding-agent prompt | "Sign up instead" |

Flag key (exact, do not rename): `website-getting-started-flow-ui-vs-cli-vs-prompt-SJw6Uc`, splits 34/33/33.

## How

- **Enable Mixpanel feature flags** in `src/lib/mixpanel.ts` init (`flags: true`, autofetch on load).
- **`src/lib/experiments.ts`** (new): resolves the arm from the flag, registers `getting_started_flow` as a super property (so every downstream event carries the arm), and exports the flag key + event-name constants. Reading the variant fires the exposure event that assigns the visitor to the experiment.
- **`useGettingStartedFlow`** hook (new): renders the control (`ui`) on the server and first paint, then swaps to the assigned arm once the flag resolves. All arms share the same block height, so the swap does not shift layout.
- **Two website-side copy events** — `Website CLI Command Copied` and `Website Prompt Copied` — fired via a new optional `onCopy` callback on `CopyCommand` and `CopyPromptButton`. (The existing `Run Novu Connect Command` / `AI prompt copied` events fire in the terminal / post-signup dashboard, not on the site.)

## QA

Force any arm locally with a query param, no Mixpanel assignment involved:

- `/?gsf=ui` · `/?gsf=cli` · `/?gsf=prompt`

Confirm in Mixpanel Live View that reading the flag emits the exposure event and that `Website CLI Command Copied` / `Website Prompt Copied` arrive with the `getting_started_flow` property.

## Launch (after merge + QA)

1. Merge; verify each arm renders and both copy events fire.
2. Enable the flag in Mixpanel, then launch the experiment (draft → active).
3. Check SRM + exposure counts at 48h; read results at day 28 or on a sequential-testing call.

## Open decision for review

The plan defines the **control as a signup-primary CTA**, but the current hero shows the CLI command + prompt side by side (no signup). So this PR makes `ui` a signup button rather than "the current hero". If you'd rather the control mirror today's hero exactly, say so and I'll adjust the control arm (the flag/experiment already treats `ui` as control either way). Signup destination used: `ROUTE.dashboardV2AgentsSignUp`.

Base branch is `home-page-update` (where the home hero lives); retarget if Pixel Point works from a different integration branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
